### PR TITLE
[#33017] DocDB: Polish yb-admin SetUsage() header, footer, and gflags leak

### DIFF
--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -2213,6 +2213,17 @@ TEST_F(AdminCliTest, PrintArgumentExpressions) {
   status = CallAdmin("list_change_data_streams", "extra_arg_1", "extra_arg_2");
   ASSERT_NOK(status);
   ASSERT_NE(status.ToString().find(namespace_expression), std::string::npos);
+
+  // create_snapshot's usage_arguments_ repeats a placeholder ("<table> [<table>]..."); with
+  // bracketed tokens now matching, its definition must still be printed only once.
+  status = CallAdmin("create_snapshot");
+  ASSERT_NOK(status);
+  const auto create_snapshot_output = status.ToString();
+  const auto first_table_definition = create_snapshot_output.find(table_expression);
+  ASSERT_NE(first_table_definition, std::string::npos);
+  ASSERT_EQ(
+      create_snapshot_output.find(table_expression, first_table_definition + 1),
+      std::string::npos);
 }
 
 TEST_F(AdminCliTest, TestCompactionStatusBeforeCompaction) {

--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -277,9 +277,10 @@ TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
   ASSERT_STR_CONTAINS(output, kFullUsageMarker);
   // The <namespace>/<table>/<index> placeholder definitions are no longer dumped in a global
   // footer here -- only a minority of operations use them, and RunCommand() already surfaces the
-  // relevant definition alongside a specific command's usage on a bad-arguments error instead
-  // (see PrintArgumentExpressions below).
-  ASSERT_STR_NOT_CONTAINS(output, "Argument definitions:");
+  // relevant definitions alongside a specific command's usage on a bad-arguments error instead
+  // (see PrintArgumentExpressions below). The string is <namespace>'s expansion, which the footer
+  // printed and no operation line contains.
+  ASSERT_STR_NOT_CONTAINS(output, "[(ycql|ysql).]<namespace_name>");
   ASSERT_STR_NOT_CONTAINS(output, "Flags from");
   ASSERT_STR_NOT_CONTAINS(output, "yb-admin_cli.cc:");
   // google::ProgramUsage() emits this when SetUsageMessage() has not been called. Any path that
@@ -2216,9 +2217,12 @@ TEST_F(AdminCliTest, PrintArgumentExpressions) {
   const auto index_expression = "<index>\n  <namespace> <index_name> | tableid.<index_id>";
 
   BuildAndStart();
+  // The <table> and <index> definitions reference <namespace>, so <namespace>'s definition must
+  // accompany them even when the command's arguments never name <namespace> directly.
   auto status = CallAdmin("delete_table");
   ASSERT_NOK(status);
   ASSERT_NE(status.ToString().find(table_expression), std::string::npos);
+  ASSERT_NE(status.ToString().find(namespace_expression), std::string::npos);
 
   status = CallAdmin("delete_namespace");
   ASSERT_NOK(status);
@@ -2227,6 +2231,7 @@ TEST_F(AdminCliTest, PrintArgumentExpressions) {
   status = CallAdmin("delete_index");
   ASSERT_NOK(status);
   ASSERT_NE(status.ToString().find(index_expression), std::string::npos);
+  ASSERT_NE(status.ToString().find(namespace_expression), std::string::npos);
 
   status = CallAdmin("add_universe_key_to_all_masters");
   ASSERT_NOK(status);

--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -282,6 +282,11 @@ TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
   ASSERT_STR_NOT_CONTAINS(output, "Argument definitions:");
   ASSERT_STR_NOT_CONTAINS(output, "Flags from");
   ASSERT_STR_NOT_CONTAINS(output, "yb-admin_cli.cc:");
+  // google::ProgramUsage() emits this when SetUsageMessage() has not been called. Any path that
+  // prints usage before SetUsage() runs shows it as the entire message -- see the
+  // --init_master_addrs test below.
+  ASSERT_STR_NOT_CONTAINS(output, "SetUsageMessage");
+  ASSERT_STR_NOT_CONTAINS(error, "SetUsageMessage");
 
   // The Operations: list must number only the entries it actually prints. It used to number by
   // each command's index in the full (including hidden) command table, so a hidden command's slot
@@ -296,6 +301,34 @@ TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
   for (size_t idx = 0; idx < operation_numbers.size(); ++idx) {
     ASSERT_EQ(operation_numbers[idx], static_cast<int>(idx) + 1)
         << "gap or duplicate in operation numbering at position " << idx;
+  }
+}
+
+// A malformed --init_master_addrs must be reported on its own terms. The flag is read in Run()
+// before SetUsage() has been called, so returning InvalidArgument here makes main() print an unset
+// google::ProgramUsage() -- the user's entire error message becomes "Warning: SetUsageMessage()
+// never called". A value that splits to nothing ("," -- ParseStrings uses SkipEmpty) parses as OK
+// with zero addresses, and indexing the empty vector crashes with SIGSEGV (#33435).
+TEST_F(AdminCliTest, MalformedInitMasterAddrs) {
+  const auto exe_path = GetAdminToolPath();
+  std::string output;
+  std::string error;
+
+  for (const auto& bad_value : {"host:99999", "host:abc", ",", ",,"}) {
+    output.clear();
+    error.clear();
+    ASSERT_NOK(Subprocess::Call(
+        ToStringVector(exe_path, "--init_master_addrs", bad_value, "list_tables"), &output,
+        &error))
+        << "--init_master_addrs=" << bad_value << " unexpectedly succeeded";
+    // Naming the flag proves we took the targeted path: a crash prints no such line, and the
+    // pre-SetUsage InvalidArgument path printed only the gflags warning.
+    ASSERT_STR_CONTAINS(error, "Invalid --init_master_addrs");
+    ASSERT_STR_NOT_CONTAINS(error, "SetUsageMessage");
+    ASSERT_STR_NOT_CONTAINS(output, "SetUsageMessage");
+    // A bad flag value is not a usage error, so neither stream gets the operation catalog.
+    ASSERT_STR_NOT_CONTAINS(output, "Operations:");
+    ASSERT_STR_NOT_CONTAINS(error, "Operations:");
   }
 }
 

--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -212,12 +212,12 @@ class AdminCliTest : public AdminTestBase {
 // cluster (the operation is checked before yb-admin connects to the master): prefix matches,
 // fuzzy (edit-distance) matches, and that an invalid operation no longer dumps the full command
 // list (the original complaint in the issue) while running with no operation still prints the
-// full usage as help.
+// full usage as help, structured into sections and without the raw gflags dump.
 TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
   const auto exe_path = GetAdminToolPath();
   constexpr auto kUnusedMasterAddress = "127.0.0.1:0";
   // This marker only appears in the full usage/command listing (which is printed to stdout).
-  constexpr auto kFullUsageMarker = "<operation> must be one of";
+  constexpr auto kFullUsageMarker = "Operations:";
   std::string output;
   std::string error;
 
@@ -265,10 +265,38 @@ TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
       nullptr, &error));
   ASSERT_STR_NOT_CONTAINS(error, "Did you mean one of these?");
 
-  // Running with no operation at all should still print the full usage as help on stdout.
+  // Running with no operation at all should still print the full usage as help on stdout,
+  // structured with clear sections, and without leaking the raw gflags dump (source path, flag
+  // types/defaults) that google::ShowUsageWithFlagsRestrict used to append.
   ASSERT_NOK(Subprocess::Call(
       ToStringVector(exe_path, "--master_addresses", kUnusedMasterAddress), &output, &error));
+  ASSERT_STR_CONTAINS(output, "Usage:");
+  ASSERT_STR_CONTAINS(output, "Common global flags:");
+  ASSERT_STR_CONTAINS(output, "Tip:");
+  ASSERT_STR_CONTAINS(output, "Example:");
   ASSERT_STR_CONTAINS(output, kFullUsageMarker);
+  // The <namespace>/<table>/<index> placeholder definitions are no longer dumped in a global
+  // footer here -- only a minority of operations use them, and RunCommand() already surfaces the
+  // relevant definition alongside a specific command's usage on a bad-arguments error instead
+  // (see PrintArgumentExpressions below).
+  ASSERT_STR_NOT_CONTAINS(output, "Argument definitions:");
+  ASSERT_STR_NOT_CONTAINS(output, "Flags from");
+  ASSERT_STR_NOT_CONTAINS(output, "yb-admin_cli.cc:");
+
+  // The Operations: list must number only the entries it actually prints. It used to number by
+  // each command's index in the full (including hidden) command table, so a hidden command's slot
+  // left a gap in the visible numbering, e.g. "85. ..." followed directly by "87. ...".
+  std::vector<int> operation_numbers;
+  std::regex operation_number_re(R"(\n\s*(\d+)\. \S)");
+  for (std::sregex_iterator it(output.begin(), output.end(), operation_number_re), end; it != end;
+       ++it) {
+    operation_numbers.push_back(std::stoi((*it)[1].str()));
+  }
+  ASSERT_FALSE(operation_numbers.empty());
+  for (size_t idx = 0; idx < operation_numbers.size(); ++idx) {
+    ASSERT_EQ(operation_numbers[idx], static_cast<int>(idx) + 1)
+        << "gap or duplicate in operation numbering at position " << idx;
+  }
 }
 
 // Test yb-admin config change while running a workload.
@@ -2149,9 +2177,10 @@ TEST_F(AdminCliTest, TestListNamespaces) {
 }
 
 TEST_F(AdminCliTest, PrintArgumentExpressions) {
-  const auto namespace_expression = "<namespace>:\n [(ycql|ysql).]<namespace_name> (default ycql.)";
-  const auto table_expression = "<table>:\n <namespace> <table_name> | tableid.<table_id>";
-  const auto index_expression = "<index>:\n  <namespace> <index_name> | tableid.<index_id>";
+  const auto namespace_expression =
+      "<namespace>\n  [(ycql|ysql).]<namespace_name> (default: ycql.)";
+  const auto table_expression = "<table>\n  <namespace> <table_name> | tableid.<table_id>";
+  const auto index_expression = "<index>\n  <namespace> <index_name> | tableid.<index_id>";
 
   BuildAndStart();
   auto status = CallAdmin("delete_table");
@@ -2171,6 +2200,19 @@ TEST_F(AdminCliTest, PrintArgumentExpressions) {
   ASSERT_EQ(status.ToString().find(namespace_expression), std::string::npos);
   ASSERT_EQ(status.ToString().find(table_expression), std::string::npos);
   ASSERT_EQ(status.ToString().find(index_expression), std::string::npos);
+
+  // import_snapshot's usage_arguments_ is "<file_name> [<namespace> <table_name>
+  // [<table_name>]...]" -- <namespace> only ever appears bracketed. Called with no arguments at
+  // all, it fails argument-count validation before touching the placeholder, so this only
+  // exercises the bracket-stripping fix, not a namespace-specific error.
+  status = CallAdmin("import_snapshot");
+  ASSERT_NOK(status);
+  ASSERT_NE(status.ToString().find(namespace_expression), std::string::npos);
+
+  // list_change_data_streams' usage_arguments_ is "[<namespace>]" -- also always bracketed.
+  status = CallAdmin("list_change_data_streams", "extra_arg_1", "extra_arg_2");
+  ASSERT_NOK(status);
+  ASSERT_NE(status.ToString().find(namespace_expression), std::string::npos);
 }
 
 TEST_F(AdminCliTest, TestCompactionStatusBeforeCompaction) {

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -113,9 +113,11 @@ constexpr int32 kDefaultRpcPort = 9100;
 const string kMinus = "minus";
 
 const std::string namespace_expression =
-    "<namespace>:\n [(ycql|ysql).]<namespace_name> (default ycql.)";
-const std::string table_expression = "<table>:\n <namespace> <table_name> | tableid.<table_id>";
-const std::string index_expression = "<index>:\n  <namespace> <index_name> | tableid.<index_id>";
+    "<namespace>\n  [(ycql|ysql).]<namespace_name> (default: ycql.)";
+const std::string table_expression =
+    "<table>\n  <namespace> <table_name> | tableid.<table_id>";
+const std::string index_expression =
+    "<index>\n  <namespace> <index_name> | tableid.<index_id>";
 
 Status GetUniverseConfig(ClusterAdminClient* client, const ClusterAdminCli::CLIArguments&) {
   RETURN_NOT_OK_PREPEND(client->GetUniverseConfig(), "Unable to get universe config");
@@ -430,11 +432,21 @@ std::string ClusterAdminCli::GetArgumentExpressions(const std::string& usage_arg
   std::stringstream ss(usage_arguments);
   std::string next_argument;
   while (ss >> next_argument) {
-    if (next_argument == "<namespace>" || next_argument == "<source_namespace>") {
+    // usage_arguments_ marks optional arguments with surrounding '[' ']' and repeated ones with
+    // a trailing "...", e.g. "[<namespace> <table_name> [<table_name>]...]". Strip those
+    // decorations before comparing, otherwise a placeholder inside brackets never matches and its
+    // definition is silently omitted.
+    const auto begin = next_argument.find_first_not_of('[');
+    const auto end = next_argument.find_last_not_of("].");
+    const std::string token = (begin == std::string::npos || end == std::string::npos ||
+                                begin > end)
+                                   ? std::string()
+                                   : next_argument.substr(begin, end - begin + 1);
+    if (token == "<namespace>" || token == "<source_namespace>") {
       expressions += namespace_expression + '\n';
-    } else if (next_argument == "<table>") {
+    } else if (token == "<table>") {
       expressions += table_expression + '\n';
-    } else if (next_argument == "<index>") {
+    } else if (token == "<index>") {
       expressions += index_expression + '\n';
     }
   }
@@ -595,32 +607,42 @@ void ClusterAdminCli::Register(
 void ClusterAdminCli::SetUsage(const string& prog_name) {
   ostringstream str;
 
-  str << prog_name << " [--master_addresses server1:port,server2:port,server3:port,...] "
-      << " [--timeout_ms <millisec>] [--certs_dir_name <dir_name>]" << endl
-      << "  [--flagfile <path/to/master/conf/server.conf>]" << endl
-      << "  <operation>" << endl
+  str << "Usage:" << endl
+      << "  " << prog_name << " [global flags] <operation> [args]" << endl
       << endl
-      << "Tip: Use --flagfile with the master's server.conf to automatically pick up" << endl
-      << "master_addresses and certs_dir, avoiding manual flag entry." << endl
-      << "Example: " << prog_name
-      << " --flagfile master/conf/server.conf list_all_masters" << endl
+      << "Common global flags:" << endl
+      << "  --master_addresses host:port[,host:port,...]  (default: localhost:7100)" << endl
+      << "  --init_master_addrs host:port                 (alternative to --master_addresses)"
       << endl
-      << "<operation> must be one of:" << endl;
+      << "  --timeout_ms <millisec>                       (default: 60000)" << endl
+      << "  --certs_dir_name <dir>" << endl
+      << "  --flagfile <path>" << endl
+      << endl
+      << "Tip:" << endl
+      << "  Use --flagfile with the master's server.conf to automatically pick up" << endl
+      << "  master_addresses and certs_dir, avoiding manual flag entry." << endl
+      << endl
+      << "Example:" << endl
+      << "  " << prog_name << " --flagfile /path/to/master/conf/server.conf list_all_masters"
+      << endl
+      << endl
+      << "Operations:" << endl;
 
-  for (size_t i = 0; i < commands_.size(); ++i) {
-    const auto& command = commands_[i];
+  // Number only the operations actually printed, so a hidden command's slot in commands_ doesn't
+  // leave a gap in the visible list (e.g. "85. ..." followed by "87. ..." with no "86.").
+  size_t visible_number = 0;
+  for (const auto& command : commands_) {
     if (command.hidden_) {
       continue;
     }
-    str << ' ' << i + 1 << ". " << command.name_ << (command.usage_arguments_.empty() ? "" : " ")
-        << command.usage_arguments_ << endl;
+    str << "  " << ++visible_number << ". " << command.name_
+        << (command.usage_arguments_.empty() ? "" : " ") << command.usage_arguments_ << endl;
   }
 
-  str << endl;
-  str << namespace_expression << endl;
-  str << table_expression << endl;
-  str << index_expression << endl;
-
+  // Argument placeholders like <namespace>/<table>/<index> are defined per-command instead of
+  // in a global footer here: only a minority of operations use them (see GetArgumentExpressions),
+  // and RunCommand() already prints the relevant definition alongside a specific command's usage
+  // when that command's arguments are invalid.
   google::SetUsageMessage(str.str());
 }
 
@@ -3313,7 +3335,11 @@ int main(int argc, char** argv) {
   }
 
   if (s.IsInvalidArgument()) {
-    google::ShowUsageWithFlagsRestrict(argv[0], __FILE__);
+    // Print the usage message set up by ClusterAdminCli::SetUsage directly, rather than
+    // google::ShowUsageWithFlagsRestrict(argv[0], __FILE__), which additionally dumps every gflag
+    // defined in this file with its build-relative source path, type, and default -- noise that
+    // buries the operation catalog the usage message already lists in full.
+    std::cout << google::ProgramUsage();
   }
 
   return 1;

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -428,7 +428,6 @@ size_t EditDistance(const string& lhs, const string& rhs) {
 }  // namespace
 
 std::string ClusterAdminCli::GetArgumentExpressions(const std::string& usage_arguments) {
-  std::string expressions;
   bool has_namespace = false;
   bool has_table = false;
   bool has_index = false;
@@ -438,24 +437,33 @@ std::string ClusterAdminCli::GetArgumentExpressions(const std::string& usage_arg
     // usage_arguments_ marks optional arguments with surrounding '[' ']' and repeated ones with
     // a trailing "...", e.g. "[<namespace> <table_name> [<table_name>]...]". Strip those
     // decorations before comparing, otherwise a placeholder inside brackets never matches and its
-    // definition is silently omitted. Stripping also makes a repeated placeholder match more than
-    // once (create_snapshot's "<table> [<table>]..."), so emit each definition at most once.
+    // definition is silently omitted.
     const auto begin = next_argument.find_first_not_of('[');
     const auto end = next_argument.find_last_not_of("].");
     const std::string token = (begin == std::string::npos || end == std::string::npos ||
                                 begin > end)
                                    ? std::string()
                                    : next_argument.substr(begin, end - begin + 1);
-    if (!has_namespace && (token == "<namespace>" || token == "<source_namespace>")) {
+    if (token == "<namespace>" || token == "<source_namespace>") {
       has_namespace = true;
-      expressions += namespace_expression + '\n';
-    } else if (!has_table && token == "<table>") {
+    } else if (token == "<table>") {
       has_table = true;
-      expressions += table_expression + '\n';
-    } else if (!has_index && token == "<index>") {
+    } else if (token == "<index>") {
       has_index = true;
-      expressions += index_expression + '\n';
     }
+  }
+  // The <table> and <index> definitions themselves reference <namespace>, so it must be defined
+  // whenever they are. Each placeholder is emitted once, referencing definitions first.
+  has_namespace |= has_table || has_index;
+  std::string expressions;
+  if (has_table) {
+    expressions += table_expression + '\n';
+  }
+  if (has_index) {
+    expressions += index_expression + '\n';
+  }
+  if (has_namespace) {
+    expressions += namespace_expression + '\n';
   }
   return expressions.empty() ? "" : "Definitions: " + expressions;
 }
@@ -658,9 +666,10 @@ void ClusterAdminCli::SetUsage(const string& prog_name) {
   }
 
   // Argument placeholders like <namespace>/<table>/<index> are defined per-command instead of
-  // in a global footer here: only a minority of operations use them (see GetArgumentExpressions),
-  // and RunCommand() already prints the relevant definition alongside a specific command's usage
-  // when that command's arguments are invalid.
+  // in a global footer here: only a minority of operations use them, and RunCommand() prints the
+  // relevant definitions alongside a specific command's usage when that command's arguments are
+  // invalid. GetArgumentExpressions() keeps that output self-contained by also defining
+  // <namespace> whenever a <table>/<index> definition references it.
   google::SetUsageMessage(str.str());
 }
 

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -429,24 +429,31 @@ size_t EditDistance(const string& lhs, const string& rhs) {
 
 std::string ClusterAdminCli::GetArgumentExpressions(const std::string& usage_arguments) {
   std::string expressions;
+  bool has_namespace = false;
+  bool has_table = false;
+  bool has_index = false;
   std::stringstream ss(usage_arguments);
   std::string next_argument;
   while (ss >> next_argument) {
     // usage_arguments_ marks optional arguments with surrounding '[' ']' and repeated ones with
     // a trailing "...", e.g. "[<namespace> <table_name> [<table_name>]...]". Strip those
     // decorations before comparing, otherwise a placeholder inside brackets never matches and its
-    // definition is silently omitted.
+    // definition is silently omitted. Stripping also makes a repeated placeholder match more than
+    // once (create_snapshot's "<table> [<table>]..."), so emit each definition at most once.
     const auto begin = next_argument.find_first_not_of('[');
     const auto end = next_argument.find_last_not_of("].");
     const std::string token = (begin == std::string::npos || end == std::string::npos ||
                                 begin > end)
                                    ? std::string()
                                    : next_argument.substr(begin, end - begin + 1);
-    if (token == "<namespace>" || token == "<source_namespace>") {
+    if (!has_namespace && (token == "<namespace>" || token == "<source_namespace>")) {
+      has_namespace = true;
       expressions += namespace_expression + '\n';
-    } else if (token == "<table>") {
+    } else if (!has_table && token == "<table>") {
+      has_table = true;
       expressions += table_expression + '\n';
-    } else if (token == "<index>") {
+    } else if (!has_index && token == "<index>") {
+      has_index = true;
       expressions += index_expression + '\n';
     }
   }

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -545,8 +545,19 @@ Status ClusterAdminCli::Run(int argc, char** argv) {
   const string addrs = FLAGS_master_addresses;
   if (!FLAGS_init_master_addrs.empty()) {
     std::vector<HostPort> init_master_addrs;
-    RETURN_NOT_OK(HostPort::ParseStrings(
-        FLAGS_init_master_addrs, master::kMasterDefaultPort, &init_master_addrs));
+    const auto parse_status = HostPort::ParseStrings(
+        FLAGS_init_master_addrs, master::kMasterDefaultPort, &init_master_addrs);
+    // Neither failure may return InvalidArgument: SetUsage() has not run yet, so main()'s
+    // InvalidArgument branch would print an unset google::ProgramUsage() -- "Warning:
+    // SetUsageMessage() never called" as the entire error message. ParseStrings() also splits with
+    // SkipEmpty(), so a value of "," parses to zero addresses and returns OK; indexing that is out
+    // of bounds (#33435).
+    if (!parse_status.ok() || init_master_addrs.empty()) {
+      cerr << "Invalid --init_master_addrs '" << FLAGS_init_master_addrs << "': "
+           << (parse_status.ok() ? "no addresses found" : parse_status.message().ToBuffer())
+           << endl;
+      return STATUS(RuntimeError, "Invalid --init_master_addrs");
+    }
     client_.reset(new ClusterAdminClient(
         init_master_addrs[0], MonoDelta::FromMilliseconds(FLAGS_timeout_ms)));
   } else {


### PR DESCRIPTION
## Summary

Restructure `ClusterAdminCli::SetUsage()` into clear `Usage` / `Common global flags` / `Tip` / `Example` / `Operations` sections instead of one run-on paragraph, and stop leaking gflags internals into the invalid-argument usage path. (The gflags `--help*` surfaces themselves are Phase 1b-b, #33431 / #33442, stacked on this PR.)

- `main()` no longer calls `google::ShowUsageWithFlagsRestrict(argv[0], __FILE__)` on an invalid argument, which additionally dumped every gflag in this file with its build-relative source path, C++ type, and default -- noise that buried the operation catalog the usage message already lists. It now prints `google::ProgramUsage()` instead: same stdout stream, same full operation catalog, no dump.
- Add `--init_master_addrs` to the new `Common global flags` section (a real global flag with no home in either #33017 or #32640's plan).
- Report a malformed `--init_master_addrs` on its own terms (#33431 §1.3's interim fix, placed in 1b-a by the design doc). The flag is parsed before `SetUsage()` runs, so its `InvalidArgument` made `main()` print an unset `google::ProgramUsage()` -- the entire error message was `Warning: SetUsageMessage() never called`. Now: a stderr line naming the flag and the parse error, and a `RuntimeError` return. Folds in the guard for #33435 (a value of `,` parsed to zero addresses and indexing the empty vector crashed with SIGSEGV), which shares the same two lines.
- Drop the global footer that unconditionally printed the `<namespace>`/`<table>`/`<index>` definitions after the full operation catalog, even though only a minority of the 134 registered operations use one of these placeholders. `RunCommand()` prints the relevant definitions alongside a specific command's usage when that command's arguments are invalid -- a narrower, better-targeted mechanism.
- Make those per-command definitions self-contained: the `<table>` and `<index>` definitions are themselves written in terms of `<namespace>`, but `GetArgumentExpressions()` only emitted the `<namespace>` definition when the command's own arguments named it -- so `delete_table` with bad arguments printed a definition referencing an undefined `<namespace>`. Emit the `<namespace>` definition transitively whenever the `<table>`/`<index>` definition is emitted (the function is byte-identical to the Phase 1b-b branch, so the post-merge rebase resolves trivially).
- Fix `GetArgumentExpressions()` bracket matching: it matched placeholders by exact whitespace-split token equality, so a placeholder wrapped in optional-argument brackets (`import_snapshot`'s `[<namespace> <table_name> [<table_name>]...]`, `list_change_data_streams`' `[<namespace>]`) never matched and its definition was silently omitted. Strip the leading `[` and trailing `]`/`.` decorations before comparing. Stripping also makes a repeated placeholder match more than once (`create_snapshot`'s `<table> [<table>]...`), so each definition is now emitted at most once.
- Fix a numbering gap in the printed `Operations:` list: it numbered by each command's index in the full (including hidden) command table, so a hidden command's slot left a permanent gap in the visible numbering (e.g. "85. ..." followed directly by "87. ...", no "86."). Number only the operations actually printed instead.

No command names, argument syntax, or auto-execution behavior changed.

## Test Plan

- `yb-admin-test.cc`, `InvalidOperationSuggestsClosestCommands`: updated for the new header sections and the absence of `Flags from`, the source-path leak, the gflags unset-usage warning, and the footer -- the footer check asserts on `[(ycql|ysql).]<namespace_name>` (the `<namespace>` expansion the footer printed, which no operation line contains), so it fails on master; added a check that every printed operation number is sequential (1, 2, 3, ...) with no gaps or duplicates, covering the numbering fix generically.
- `yb-admin-test.cc`, new `MalformedInitMasterAddrs`: `host:99999` / `host:abc` / `,` / `,,` must all fail with a stderr line naming the flag, no gflags unset-usage warning, and no operation catalog on either stream.
- `yb-admin-test.cc`, `PrintArgumentExpressions`: added `import_snapshot` and `list_change_data_streams` cases covering the bracket-matching fix; a `create_snapshot` case asserting the repeated `<table>` placeholder prints its definition exactly once; and `delete_table`/`delete_index` assertions that the `<namespace>` definition accompanies the `<table>`/`<index>` definitions that reference it.
- Manually verified against a locally built `bin/yb-admin`: `import_snapshot` with bad arguments now shows its `<namespace>` definition where it previously showed nothing; no-op usage ends cleanly after the operation list with no footer; the operation list is numbered 1..133 with no gap around the hidden `unsafe_release_object_locks_global` slot.

<details>
<summary>Design doc: <code>yb-admin</code> <code>SetUsage()</code> Output Polish</summary>

https://docs.google.com/document/d/1eeSkB5t2piDJ8-nYpenUr4CdMZ9ceyu67spEh6S55oo/edit

Covers the full rationale (including gcloud/AWS CLI precedent for dropping the global argument-definitions footer), before/after usage-text mockups, and the reviewer sign-off this PR implements.

</details>
