### PR TITLE
[#33399] DocDB: Set stop marks in ThreadSubPoolBase::Shutdown instead of adding them

### DIFF
--- a/src/yb/util/thread_pool.cc
+++ b/src/yb/util/thread_pool.cc
@@ -698,7 +698,7 @@ void YBThreadPool::SetCgroup(Cgroup* cgroup) {
 // ------------------------------------------------------------------------------------------------
 
 void ThreadSubPoolBase::Shutdown() {
-  auto active_enqueues = active_enqueues_.fetch_add(kStopMark, std::memory_order_acq_rel);
+  auto active_enqueues = active_enqueues_.fetch_or(kStopMark, std::memory_order_acq_rel);
   if (active_enqueues >= kStopMark) {
     while (!(active_enqueues & kStoppedMark)) {
       std::this_thread::sleep_for(1ms);
@@ -716,7 +716,7 @@ void ThreadSubPoolBase::Shutdown() {
     std::this_thread::sleep_for(1ms);
   }
   AbortTasks();
-  active_enqueues_.fetch_add(kStoppedMark, std::memory_order_acq_rel);
+  active_enqueues_.fetch_or(kStoppedMark, std::memory_order_acq_rel);
 }
 
 void ThreadSubPoolBase::AbortTasks() {

--- a/src/yb/util/threadpool-test.cc
+++ b/src/yb/util/threadpool-test.cc
@@ -730,6 +730,23 @@ TEST_F(TestThreadPool, TestTokenConcurrency) {
                           kSubmitThreads, total_num_tokens_submitted.load());
 }
 
+// Repeated Shutdown() on a token of either execution mode stays idempotent, and the token keeps
+// rejecting submissions after every call.
+TEST_F(TestThreadPool, TestRepeatedTokenShutdown) {
+  const int kNumShutdowns = 40000;
+
+  std::unique_ptr<ThreadPool> thread_pool;
+  ASSERT_OK(ThreadPoolBuilder("test").Build(&thread_pool));
+
+  for (auto mode : {ThreadPool::ExecutionMode::SERIAL, ThreadPool::ExecutionMode::CONCURRENT}) {
+    auto token = thread_pool->NewToken(mode);
+    for (int i = 0; i < kNumShutdowns; i++) {
+      token->Shutdown();
+      ASSERT_TRUE(token->SubmitFunc([]() {}).IsShutdownInProgress());
+    }
+  }
+}
+
 TEST_F(TestThreadPool, TestTaskRunnerStopWait) {
   TaskRunner runner;
   ASSERT_OK(runner.Init(/* concurrency = */1));


### PR DESCRIPTION
## Summary

`ThreadSubPoolBase::Shutdown()` wrote both of its flags into `active_enqueues_` with `fetch_add`, so
redundant calls on the same token accumulated through the 15-bit stop field at bits 48-62. On call
32769 the carry reached `kStoppedMark` at bit 63 and rolled out of the word, leaving
`active_enqueues_` at zero: the caller then took the shutdown-owner path a second time, so
`AbortTasks()` ran again — dereferencing an already-released `task_` in `Strand::AbortTasks` — and
`Closing()` reported false, letting a shut-down token accept submissions again.

Use `fetch_or` for both marks, so bit 48 and bit 63 are set once and never carry. Repeated
`Shutdown()` is a documented, normal path — the token destructor calls it a second time — so this
makes the function match the contract in its own header comment.

See #33399 for the bit-level walkthrough and the crash trace.

Adds `TestThreadPool.TestRepeatedTokenShutdown`, which calls `Shutdown()` 40000 times on a token of
each execution mode and checks after every call that the token still rejects submissions. Without
the fix the CONCURRENT case trips the assertion and the SERIAL case segfaults; the test runs in
about 5 ms.

This also fixes the intermittent `TestThreadPool.TestTokenConcurrency` crash that led to the bug.

## Test plan

- [x] `util_threadpool-test --gtest_filter=TestThreadPool.TestRepeatedTokenShutdown` — fails without
      the fix (assertion in the CONCURRENT case), passes with it
- [x] `util_threadpool-test --gtest_filter=TestThreadPool.TestTokenConcurrency` with the cycle-thread
      sleep temporarily raised to 1000 µs: 29 of 50 iterations failed without the fix, 50 of 50
      passed with it
- [x] Full `util_threadpool-test` binary
