### PR TITLE
[DOC-1446] Add DDL warning for major upgrade

### DIFF
--- a/docs/content/stable/manage/ysql-major-upgrade-local.md
+++ b/docs/content/stable/manage/ysql-major-upgrade-local.md
@@ -111,7 +111,7 @@ In addition, refer to the following:
 
 ### Enable mixed mode
 
-Because the upgrade is fully online, your cluster will temporarily consist of a mix of nodes running both PostgreSQL 11 and 15 (mixed mode). These processes need to be able to talk with each other and correctly process your SQL commands. Specifically, the PostgreSQL expressions that are used in the SQL statements get pushed down from the compute layer to the YugabyteDB storage layer. Because the expressions used by PostgreSQL have changed across the major version, you need to disable this optimization during the upgrade. (This will be addressed in v2025.1 (issue {{<issue 24730>}}).)
+Because the upgrade is fully online, your cluster will temporarily consist of a mix of nodes running both PostgreSQL 11 and 15 (mixed mode). These processes need to be able to talk with each other and correctly process your SQL commands.
 
 Set the `ysql_yb_major_version_upgrade_compatibility` flag to `11` on all YB-Master and YB-TServer processes. For example:
 

--- a/docs/content/stable/manage/ysql-major-upgrade-local.md
+++ b/docs/content/stable/manage/ysql-major-upgrade-local.md
@@ -264,6 +264,5 @@ Now that all the YB-Master and YB-TServer processes are on the same version, you
 
 ## Limitations
 
-- Expression pushdown is not available. {{<issue 24730>}}
-- Upgrading with extensions is not yet supported. {{<issue 24733>}}
+- Expression pushdown is partially available. {{<issue 24730>}}
 - Any backups that are taken in the monitoring phase can only be restored on a PG15 compatible universe (that is, backups cannot be restored if rollback is performed).

--- a/docs/content/stable/manage/ysql-major-upgrade-yugabyted.md
+++ b/docs/content/stable/manage/ysql-major-upgrade-yugabyted.md
@@ -240,6 +240,5 @@ yugabyted does not currently support rollback.
 
 ## Limitations
 
-- Expression pushdown is not available. {{<issue 24730>}}
-- Upgrading with extensions is not yet supported. {{<issue 24733>}}
+- Expression pushdown is partially available. {{<issue 24730>}}
 - Any backups that are taken in the monitoring phase can only be restored on a PG15 compatible universe (that is, backups cannot be restored if rollback is performed).

--- a/docs/content/stable/yugabyte-platform/manage-deployments/upgrade-software-install.md
+++ b/docs/content/stable/yugabyte-platform/manage-deployments/upgrade-software-install.md
@@ -100,7 +100,22 @@ If you have problems, you can [roll back](#roll-back-an-upgrade) during this tim
 
 For upgrades that require finalizing, you can monitor for as long as you need, up to a _maximum recommended limit of two days_ to avoid operator errors that can arise from having to maintain two versions.
 
-A subset of features that require format changes will not be available until the upgrade is finalized. Also, you cannot perform another upgrade until you have finalized the current one.
+A subset of features that require format changes will not be available until the upgrade is finalized. 
+
+{{< warning title="DDLs remain blocked until the upgrade is finalized" >}}
+If you are performing a [YSQL major upgrade](../ysql-major-upgrade-yba/), DDL statements and other catalog
+modifications continue to be blocked during the monitoring phase, including for validation or test queries. A blocked
+DDL returns the following:
+
+```output
+ERROR: YSQL DDLs, and catalog modifications are not allowed during a major YSQL upgrade
+```
+
+This is expected. DDL support resumes once you finalize or roll back the upgrade. Refer to
+[Limitations](../ysql-major-upgrade-yba/#limitations) for the full list of operations unavailable until then.
+{{< /warning >}}
+
+You cannot perform another upgrade until you have finalized the current one.
 
 If you are satisfied with the upgrade:
 

--- a/docs/content/stable/yugabyte-platform/manage-deployments/upgrade-software-install.md
+++ b/docs/content/stable/yugabyte-platform/manage-deployments/upgrade-software-install.md
@@ -103,16 +103,13 @@ For upgrades that require finalizing, you can monitor for as long as you need, u
 A subset of features that require format changes will not be available until the upgrade is finalized. 
 
 {{< warning title="DDLs remain blocked until the upgrade is finalized" >}}
-If you are performing a [YSQL major upgrade](../ysql-major-upgrade-yba/), DDL statements and other catalog
-modifications continue to be blocked during the monitoring phase, including for validation or test queries. A blocked
-DDL returns the following:
+If you are performing a [YSQL major upgrade](../ysql-major-upgrade-yba/), DDL statements and other catalog modifications continue to be blocked during the monitoring phase, including for validation or test queries. A blocked DDL returns the following:
 
 ```output
 ERROR: YSQL DDLs, and catalog modifications are not allowed during a major YSQL upgrade
 ```
 
-This is expected. DDL support resumes once you finalize or roll back the upgrade. Refer to
-[Limitations](../ysql-major-upgrade-yba/#limitations) for the full list of operations unavailable until then.
+This is expected. DDL support resumes after you finalize or roll back the upgrade. Refer to [Limitations](../ysql-major-upgrade-yba/#limitations) for the full list of operations unavailable until then.
 {{< /warning >}}
 
 You cannot perform another upgrade until you have finalized the current one.

--- a/docs/content/stable/yugabyte-platform/manage-deployments/ysql-major-upgrade-yba.md
+++ b/docs/content/stable/yugabyte-platform/manage-deployments/ysql-major-upgrade-yba.md
@@ -18,7 +18,7 @@ The upgrade is fully online. While the upgrade is in progress, you have full and
 
 ## Before you begin
 
-- All DDL statements, except ones related to [Temporary table](../../../api/ysql/the-sql-language/creating-and-using-temporary-schema-objects/temporary-tables-views-sequences-and-indexes/) and [Refresh Materialized View](../../../api/ysql/the-sql-language/statements/ddl_refresh_matview/) are blocked for the duration of the upgrade. Consider executing all DDLs before the upgrade, and pause any jobs that might run DDLs. DMLs are allowed.
+- All DDL statements, except ones related to [Temporary table](../../../api/ysql/the-sql-language/creating-and-using-temporary-schema-objects/temporary-tables-views-sequences-and-indexes/) and [Refresh Materialized View](../../../api/ysql/the-sql-language/statements/ddl_refresh_matview/) are blocked for the duration of the upgrade (including during monitoring). Consider executing all DDLs before the upgrade, and pause any jobs that might run DDLs. DMLs are allowed.
 - Upgrade client drivers.
 
     Upgrade all application client drivers to the new version. The client drivers are backwards compatible, and work with both the old and new versions of the database.
@@ -49,6 +49,14 @@ After a successful upgrade precheck, you can proceed with the usual database upg
 {{<tip title="Backup">}}
 Back up your cluster at this time. Refer to [Backup](../../../reference/configuration/yugabyted/#backup).
 {{</tip>}}
+
+## Monitor phase
+
+After all the YB-Master and YB-TServer processes are upgraded, monitor the cluster to ensure it is healthy. Make sure workloads are running as expected and there are no errors in the logs.
+
+You can remain in this phase for as long as you need, up to a maximum recommended limit of two days.
+
+DDLs are not allowed even in this phase. New features that require format changes will not be available until the upgrade is finalized.
 
 ## Limitations
 

--- a/docs/content/v2025.1/manage/ysql-major-upgrade-local.md
+++ b/docs/content/v2025.1/manage/ysql-major-upgrade-local.md
@@ -111,7 +111,7 @@ In addition, refer to the following:
 
 ### Enable mixed mode
 
-Because the upgrade is fully online, your cluster will temporarily consist of a mix of nodes running both PostgreSQL 11 and 15 (mixed mode). These processes need to be able to talk with each other and correctly process your SQL commands. Specifically, the PostgreSQL expressions that are used in the SQL statements get pushed down from the compute layer to the YugabyteDB storage layer. Because the expressions used by PostgreSQL have changed across the major version, you need to disable this optimization during the upgrade. (This will be addressed in v2025.1 (issue {{<issue 24730>}}).)
+Because the upgrade is fully online, your cluster will temporarily consist of a mix of nodes running both PostgreSQL 11 and 15 (mixed mode). These processes need to be able to talk with each other and correctly process your SQL commands.
 
 Set the `ysql_yb_major_version_upgrade_compatibility` flag to `11` on all YB-Master and YB-TServer processes. For example:
 
@@ -264,6 +264,5 @@ Now that all the YB-Master and YB-TServer processes are on the same version, you
 
 ## Limitations
 
-- Expression pushdown is not available. {{<issue 24730>}}
-- Upgrading with extensions is not yet supported. {{<issue 24733>}}
+- Expression pushdown is partially available. {{<issue 24730>}}
 - Any backups that are taken in the monitoring phase can only be restored on a PG15 compatible universe (that is, backups cannot be restored if rollback is performed).

--- a/docs/content/v2025.1/manage/ysql-major-upgrade-yugabyted.md
+++ b/docs/content/v2025.1/manage/ysql-major-upgrade-yugabyted.md
@@ -240,6 +240,5 @@ yugabyted does not currently support rollback.
 
 ## Limitations
 
-- Expression pushdown is not available. {{<issue 24730>}}
-- Upgrading with extensions is not yet supported. {{<issue 24733>}}
+- Expression pushdown is partially available. {{<issue 24730>}}
 - Any backups that are taken in the monitoring phase can only be restored on a PG15 compatible universe (that is, backups cannot be restored if rollback is performed).

--- a/docs/content/v2025.1/yugabyte-platform/manage-deployments/upgrade-software-install.md
+++ b/docs/content/v2025.1/yugabyte-platform/manage-deployments/upgrade-software-install.md
@@ -98,7 +98,19 @@ If you have problems, you can [roll back](#roll-back-an-upgrade) during this tim
 
 For upgrades that require finalizing, you can monitor for as long as you need, up to a _maximum recommended limit of two days_ to avoid operator errors that can arise from having to maintain two versions.
 
-A subset of features that require format changes will not be available until the upgrade is finalized. Also, you cannot perform another upgrade until you have finalized the current one.
+A subset of features that require format changes will not be available until the upgrade is finalized. 
+
+{{< warning title="DDLs remain blocked until the upgrade is finalized" >}}
+If you are performing a [YSQL major upgrade](../ysql-major-upgrade-yba/), DDL statements and other catalog modifications continue to be blocked during the monitoring phase, including for validation or test queries. A blocked DDL returns the following:
+
+```output
+ERROR: YSQL DDLs, and catalog modifications are not allowed during a major YSQL upgrade
+```
+
+This is expected. DDL support resumes after you finalize or roll back the upgrade. Refer to [Limitations](../ysql-major-upgrade-yba/#limitations) for the full list of operations unavailable until then.
+{{< /warning >}}
+
+You cannot perform another upgrade until you have finalized the current one.
 
 If you are satisfied with the upgrade:
 

--- a/docs/content/v2025.1/yugabyte-platform/manage-deployments/ysql-major-upgrade-yba.md
+++ b/docs/content/v2025.1/yugabyte-platform/manage-deployments/ysql-major-upgrade-yba.md
@@ -18,7 +18,7 @@ The upgrade is fully online. While the upgrade is in progress, you have full and
 
 ## Before you begin
 
-- All DDL statements, except ones related to [Temporary table](../../../api/ysql/the-sql-language/creating-and-using-temporary-schema-objects/temporary-tables-views-sequences-and-indexes/) and [Refresh Materialized View](../../../api/ysql/the-sql-language/statements/ddl_refresh_matview/) are blocked for the duration of the upgrade. Consider executing all DDLs before the upgrade, and pause any jobs that might run DDLs. DMLs are allowed.
+- All DDL statements, except ones related to [Temporary table](../../../api/ysql/the-sql-language/creating-and-using-temporary-schema-objects/temporary-tables-views-sequences-and-indexes/) and [Refresh Materialized View](../../../api/ysql/the-sql-language/statements/ddl_refresh_matview/) are blocked for the duration of the upgrade (including during monitoring). Consider executing all DDLs before the upgrade, and pause any jobs that might run DDLs. DMLs are allowed.
 - Upgrade client drivers.
 
     Upgrade all application client drivers to the new version. The client drivers are backwards compatible, and work with both the old and new versions of the database.
@@ -49,6 +49,14 @@ After a successful upgrade precheck, you can proceed with the usual database upg
 {{<tip title="Backup">}}
 Back up your cluster at this time. Refer to [Backup](../../../reference/configuration/yugabyted/#backup).
 {{</tip>}}
+
+## Monitor phase
+
+After all the YB-Master and YB-TServer processes are upgraded, monitor the cluster to ensure it is healthy. Make sure workloads are running as expected and there are no errors in the logs.
+
+You can remain in this phase for as long as you need, up to a maximum recommended limit of two days.
+
+DDLs are not allowed even in this phase. New features that require format changes will not be available until the upgrade is finalized.
 
 ## Limitations
 

--- a/docs/content/v2025.2/manage/ysql-major-upgrade-local.md
+++ b/docs/content/v2025.2/manage/ysql-major-upgrade-local.md
@@ -111,7 +111,7 @@ In addition, refer to the following:
 
 ### Enable mixed mode
 
-Because the upgrade is fully online, your cluster will temporarily consist of a mix of nodes running both PostgreSQL 11 and 15 (mixed mode). These processes need to be able to talk with each other and correctly process your SQL commands. Specifically, the PostgreSQL expressions that are used in the SQL statements get pushed down from the compute layer to the YugabyteDB storage layer. Because the expressions used by PostgreSQL have changed across the major version, you need to disable this optimization during the upgrade. (This will be addressed in v2025.1 (issue {{<issue 24730>}}).)
+Because the upgrade is fully online, your cluster will temporarily consist of a mix of nodes running both PostgreSQL 11 and 15 (mixed mode). These processes need to be able to talk with each other and correctly process your SQL commands.
 
 Set the `ysql_yb_major_version_upgrade_compatibility` flag to `11` on all YB-Master and YB-TServer processes. For example:
 
@@ -264,6 +264,5 @@ Now that all the YB-Master and YB-TServer processes are on the same version, you
 
 ## Limitations
 
-- Expression pushdown is not available. {{<issue 24730>}}
-- Upgrading with extensions is not yet supported. {{<issue 24733>}}
+- Expression pushdown is partially available. {{<issue 24730>}}
 - Any backups that are taken in the monitoring phase can only be restored on a PG15 compatible universe (that is, backups cannot be restored if rollback is performed).

--- a/docs/content/v2025.2/manage/ysql-major-upgrade-yugabyted.md
+++ b/docs/content/v2025.2/manage/ysql-major-upgrade-yugabyted.md
@@ -240,6 +240,5 @@ yugabyted does not currently support rollback.
 
 ## Limitations
 
-- Expression pushdown is not available. {{<issue 24730>}}
-- Upgrading with extensions is not yet supported. {{<issue 24733>}}
+- Expression pushdown is partially available. {{<issue 24730>}}
 - Any backups that are taken in the monitoring phase can only be restored on a PG15 compatible universe (that is, backups cannot be restored if rollback is performed).

--- a/docs/content/v2025.2/yugabyte-platform/manage-deployments/upgrade-software-install.md
+++ b/docs/content/v2025.2/yugabyte-platform/manage-deployments/upgrade-software-install.md
@@ -98,7 +98,19 @@ If you have problems, you can [roll back](#roll-back-an-upgrade) during this tim
 
 For upgrades that require finalizing, you can monitor for as long as you need, up to a _maximum recommended limit of two days_ to avoid operator errors that can arise from having to maintain two versions.
 
-A subset of features that require format changes will not be available until the upgrade is finalized. Also, you cannot perform another upgrade until you have finalized the current one.
+A subset of features that require format changes will not be available until the upgrade is finalized. 
+
+{{< warning title="DDLs remain blocked until the upgrade is finalized" >}}
+If you are performing a [YSQL major upgrade](../ysql-major-upgrade-yba/), DDL statements and other catalog modifications continue to be blocked during the monitoring phase, including for validation or test queries. A blocked DDL returns the following:
+
+```output
+ERROR: YSQL DDLs, and catalog modifications are not allowed during a major YSQL upgrade
+```
+
+This is expected. DDL support resumes after you finalize or roll back the upgrade. Refer to [Limitations](../ysql-major-upgrade-yba/#limitations) for the full list of operations unavailable until then.
+{{< /warning >}}
+
+You cannot perform another upgrade until you have finalized the current one.
 
 If you are satisfied with the upgrade:
 

--- a/docs/content/v2025.2/yugabyte-platform/manage-deployments/ysql-major-upgrade-yba.md
+++ b/docs/content/v2025.2/yugabyte-platform/manage-deployments/ysql-major-upgrade-yba.md
@@ -18,7 +18,7 @@ The upgrade is fully online. While the upgrade is in progress, you have full and
 
 ## Before you begin
 
-- All DDL statements, except ones related to [Temporary table](../../../api/ysql/the-sql-language/creating-and-using-temporary-schema-objects/temporary-tables-views-sequences-and-indexes/) and [Refresh Materialized View](../../../api/ysql/the-sql-language/statements/ddl_refresh_matview/) are blocked for the duration of the upgrade. Consider executing all DDLs before the upgrade, and pause any jobs that might run DDLs. DMLs are allowed.
+- All DDL statements, except ones related to [Temporary table](../../../api/ysql/the-sql-language/creating-and-using-temporary-schema-objects/temporary-tables-views-sequences-and-indexes/) and [Refresh Materialized View](../../../api/ysql/the-sql-language/statements/ddl_refresh_matview/) are blocked for the duration of the upgrade (including during monitoring). Consider executing all DDLs before the upgrade, and pause any jobs that might run DDLs. DMLs are allowed.
 - Upgrade client drivers.
 
     Upgrade all application client drivers to the new version. The client drivers are backwards compatible, and work with both the old and new versions of the database.
@@ -49,6 +49,14 @@ After a successful upgrade precheck, you can proceed with the usual database upg
 {{<tip title="Backup">}}
 Back up your cluster at this time. Refer to [Backup](../../../reference/configuration/yugabyted/#backup).
 {{</tip>}}
+
+## Monitor phase
+
+After all the YB-Master and YB-TServer processes are upgraded, monitor the cluster to ensure it is healthy. Make sure workloads are running as expected and there are no errors in the logs.
+
+You can remain in this phase for as long as you need, up to a maximum recommended limit of two days.
+
+DDLs are not allowed even in this phase. New features that require format changes will not be available until the upgrade is finalized.
 
 ## Limitations
 


### PR DESCRIPTION
- Call out DDL-block limitation explicitly in the YBA "Monitor the universe" step for YSQL major upgrades.
- Update limitations for YSQL major updgrades

@netlify /stable/yugabyte-platform/manage-deployments/upgrade-software-install/