### PR TITLE
[#33415] DocDB: Disable DriveIoStatsTest.CountsRangeSync on macOS

### DIFF
--- a/src/yb/util/drive_io_stats-test.cc
+++ b/src/yb/util/drive_io_stats-test.cc
@@ -260,7 +260,8 @@ TEST_F(DriveIoStatsTest, CloseWithoutSyncDoesNotLeakUnsyncedBytes) {
 }
 
 // sync_file_range is where SST write cost actually lands, so it gets its own counters.
-TEST_F(DriveIoStatsTest, CountsRangeSync) {
+// macOS has no sync_file_range, so Flush() falls back to fsync and there is nothing to count.
+TEST_F(DriveIoStatsTest, YB_DISABLE_TEST_ON_MACOS(CountsRangeSync)) {
   // Flush() returns before issuing sync_file_range when never_fsync is set, and YBTest sets it.
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_never_fsync) = false;
 


### PR DESCRIPTION
## Summary

`DriveIoStatsTest.CountsRangeSync` asserts that `Flush()` bumps the range-sync
counters. `PosixWritableFile::Flush` records them only inside its
`#if defined(__linux__)` branch — macOS has no `sync_file_range`, so `Flush()`
does a plain `fsync` and counts nothing.

Counting that `fsync` would make `range_sync_micros` mean writeback latency on
Linux and full-file durability latency on macOS, so disable the test with
`YB_DISABLE_TEST_ON_MACOS` and leave the metric alone.

Fixes #33415.

## Test plan

- [x] macOS arm64 release: `./yb_build.sh release --cxx-test drive_io_stats-test` — `CountsRangeSync` is reported disabled, the rest of the binary passes.
