### PR TITLE
[#33438] Build: Write resolved YB_THIRDPARTY_DIR back to the CMake cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,10 @@ if("${YB_THIRDPARTY_DIR}" STREQUAL "")
 endif()
 # Remove trailing slash from YB_THIRDPARTY_DIR if it exists.
 string(REGEX REPLACE "/+$" "" YB_THIRDPARTY_DIR "${YB_THIRDPARTY_DIR}")
+# Write the resolved path back to the cache: the fallback above only sets a normal variable,
+# and tools such as build_postgres.py read YB_THIRDPARTY_DIR from CMakeCache.txt.
+set(YB_THIRDPARTY_DIR "${YB_THIRDPARTY_DIR}" CACHE INTERNAL
+    "Top-level directory of yugabyte-db-thirdparty checkout or pre-built location" FORCE)
 message("YB_THIRDPARTY_DIR: ${YB_THIRDPARTY_DIR}")
 
 set(YB_BUILD_ROOT "${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
## Summary

`CMakeLists.txt` sets the `YB_THIRDPARTY_DIR` cache entry from `$ENV{YB_THIRDPARTY_DIR}`, and `CACHE INTERNAL` implies `FORCE`, so a configure run without the env var caches an empty string — and blanks a previously-correct cache entry on reconfigure. The fallback that reads `thirdparty_path.txt` (or defaults to `${YB_SRC_ROOT}/thirdparty`) only set a normal variable, which shadows the cache entry, so `CMakeCache.txt` kept the empty value.

`build_postgres.py` reads `YB_THIRDPARTY_DIR` from `CMakeCache.txt` and exports it to the third-party-extensions make, so `pg_duckdb` computed `FULL_DUCKDB_LIB` with an empty prefix and failed with `prebuilt DuckDB bundle not found` even though the bundle exists. This hits anyone whose configure runs without the env var — e.g. running `cmake` directly or through an IDE instead of `yb_build.sh`.

Fix: after the fallback resolves the path and the trailing slash is stripped, write the value back to the cache with `set(... CACHE INTERNAL ... FORCE)`, so the cache always holds the resolved path.

## Test plan

- [x] Reproduced the configure logic in a minimal CMake project with `YB_THIRDPARTY_DIR` unset in the environment and a `thirdparty_path.txt` (with trailing slash) in the binary dir: before the fix `CMakeCache.txt` held `YB_THIRDPARTY_DIR:INTERNAL=` (empty); with the fix it holds the resolved, slash-stripped path.
