### PR TITLE
[#33431] DocDB: yb-admin help UX Phase 1b-b: short overview, help operation, repaired --help surfaces

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -3124,9 +3124,12 @@ class ControlScript(object):
         status_details = [(Output.make_yellow("Admin operation"),
                            "Find the response below."),]
         Output.print_out(self.get_status_string_common(status_details))
-        if 0 == ret_code:
+        # yb-admin writes usage and help text to stdout even when it exits non-zero, so show
+        # stdout unconditionally; discarding it on failure rendered usage errors as an empty red
+        # block (#33433).
+        if out:
           Output.print_out(out)
-        else:
+        if 0 != ret_code:
           Output.log(err)
           Output.print_out(Output.make_red(err))
 

--- a/docs/content/stable/admin/yb-admin.md
+++ b/docs/content/stable/admin/yb-admin.md
@@ -65,6 +65,8 @@ To list all operations, run `yb-admin help` from the YugabyteDB home directory.
 ./bin/yb-admin help
 ```
 
+The `help` operation is available in v2026.2 and later. In earlier versions, run `./bin/yb-admin --help`.
+
 To display the usage of a single operation, pass its name to `help`:
 
 ```sh

--- a/docs/content/stable/admin/yb-admin.md
+++ b/docs/content/stable/admin/yb-admin.md
@@ -59,10 +59,22 @@ yb-admin \
 
 ### Online help
 
-To display the online help, run `yb-admin --help` from the YugabyteDB home directory.
+To list all operations, run `yb-admin help` from the YugabyteDB home directory.
 
 ```sh
-./bin/yb-admin --help
+./bin/yb-admin help
+```
+
+To display the usage of a single operation, pass its name to `help`:
+
+```sh
+./bin/yb-admin help delete_table
+```
+
+You can also pass any text to list the operations whose name contains it. For example, to list all snapshot operations:
+
+```sh
+./bin/yb-admin help snapshot
 ```
 
 ## Commands

--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -32,7 +32,9 @@
 // Tests for the yb-admin command-line tool.
 
 #include <algorithm>
+#include <fstream>
 #include <regex>
+#include <sstream>
 #include <thread>
 
 #include <boost/algorithm/string.hpp>
@@ -66,6 +68,7 @@
 #include "yb/util/backoff_waiter.h"
 #include "yb/util/date_time.h"
 #include "yb/util/format.h"
+#include "yb/util/monotime.h"
 #include "yb/util/json_document.h"
 #include "yb/util/net/net_util.h"
 #include "yb/util/scope_exit.h"
@@ -211,13 +214,13 @@ class AdminCliTest : public AdminTestBase {
 // Verify the "did you mean" help for a misspelled operation, none of which needs a running
 // cluster (the operation is checked before yb-admin connects to the master): prefix matches,
 // fuzzy (edit-distance) matches, and that an invalid operation no longer dumps the full command
-// list (the original complaint in the issue) while running with no operation still prints the
-// full usage as help, structured into sections and without the raw gflags dump.
+// list (the original complaint in the issue) while running with no operation prints the short
+// overview, without the raw gflags dump.
 TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
   const auto exe_path = GetAdminToolPath();
   constexpr auto kUnusedMasterAddress = "127.0.0.1:0";
-  // This marker only appears in the full usage/command listing (which is printed to stdout).
-  constexpr auto kFullUsageMarker = "Operations:";
+  // This marker only appears in the operation listing (`yb-admin help`, printed to stdout).
+  constexpr auto kOperationListMarker = "Operations (";
   std::string output;
   std::string error;
 
@@ -230,16 +233,16 @@ TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
   ASSERT_STR_CONTAINS(error, "list_snapshot_schedules");
 
   // Prefix match: a prefix of several commands lists every candidate and a hint, and must not dump
-  // the full command list on either stream.
+  // the operation list on either stream.
   ASSERT_NOK(Subprocess::Call(
       ToStringVector(exe_path, "--master_addresses", kUnusedMasterAddress, "list_table"), &output,
       &error));
   ASSERT_STR_CONTAINS(error, "Did you mean one of these?");
   ASSERT_STR_CONTAINS(error, "list_tables");
   ASSERT_STR_CONTAINS(error, "list_tablets");
-  ASSERT_STR_CONTAINS(error, "to see all available operations");
-  ASSERT_STR_NOT_CONTAINS(output, kFullUsageMarker);
-  ASSERT_STR_NOT_CONTAINS(error, kFullUsageMarker);
+  ASSERT_STR_CONTAINS(error, "help' to list all operations");
+  ASSERT_STR_NOT_CONTAINS(output, kOperationListMarker);
+  ASSERT_STR_NOT_CONTAINS(error, kOperationListMarker);
 
   // Fuzzy match: a transposition ("tabels" instead of "tables") is not a prefix but is close.
   ASSERT_NOK(Subprocess::Call(
@@ -265,20 +268,20 @@ TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
       nullptr, &error));
   ASSERT_STR_NOT_CONTAINS(error, "Did you mean one of these?");
 
-  // Running with no operation at all should still print the full usage as help on stdout,
-  // structured with clear sections, and without leaking the raw gflags dump (source path, flag
-  // types/defaults) that google::ShowUsageWithFlagsRestrict used to append.
+  // Running with no operation prints the short overview on stdout (still exit 1: an incorrect
+  // invocation), not the operation list, and without leaking the raw gflags dump (source path,
+  // flag types/defaults) that google::ShowUsageWithFlagsRestrict used to append.
   ASSERT_NOK(Subprocess::Call(
       ToStringVector(exe_path, "--master_addresses", kUnusedMasterAddress), &output, &error));
   ASSERT_STR_CONTAINS(output, "Usage:");
+  ASSERT_STR_CONTAINS(output, "Get help:");
   ASSERT_STR_CONTAINS(output, "Common global flags:");
-  ASSERT_STR_CONTAINS(output, "Tip:");
   ASSERT_STR_CONTAINS(output, "Example:");
-  ASSERT_STR_CONTAINS(output, kFullUsageMarker);
-  // The <namespace>/<table>/<index> placeholder definitions are no longer dumped in a global
-  // footer here -- only a minority of operations use them, and RunCommand() already surfaces the
-  // relevant definition alongside a specific command's usage on a bad-arguments error instead
-  // (see PrintArgumentExpressions below).
+  ASSERT_STR_NOT_CONTAINS(output, kOperationListMarker);
+  // The <namespace>/<table>/<index> placeholder definitions are not dumped in a global footer --
+  // only a minority of operations use them, and RunCommand() already surfaces the relevant
+  // definition alongside a specific command's usage on a bad-arguments error instead (see
+  // PrintArgumentExpressions below).
   ASSERT_STR_NOT_CONTAINS(output, "Argument definitions:");
   ASSERT_STR_NOT_CONTAINS(output, "Flags from");
   ASSERT_STR_NOT_CONTAINS(output, "yb-admin_cli.cc:");
@@ -288,22 +291,9 @@ TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
   ASSERT_STR_NOT_CONTAINS(output, "SetUsageMessage");
   ASSERT_STR_NOT_CONTAINS(error, "SetUsageMessage");
 
-  // The Operations: list must number only the entries it actually prints. It used to number by
-  // each command's index in the full (including hidden) command table, so a hidden command's slot
-  // left a gap in the visible numbering, e.g. "85. ..." followed directly by "87. ...".
-  std::vector<int> operation_numbers;
-  std::regex operation_number_re(R"(\n\s*(\d+)\. \S)");
-  for (std::sregex_iterator it(output.begin(), output.end(), operation_number_re), end; it != end;
-       ++it) {
-    operation_numbers.push_back(std::stoi((*it)[1].str()));
-  }
-  // A floor, not just non-empty: the whole point of this test is that the visible list is
-  // numbered 1..N with no gap, and ASSERT_FALSE(empty()) would pass a build that printed one line.
-  ASSERT_GE(operation_numbers.size(), 100);
-  for (size_t idx = 0; idx < operation_numbers.size(); ++idx) {
-    ASSERT_EQ(operation_numbers[idx], static_cast<int>(idx) + 1)
-        << "gap or duplicate in operation numbering at position " << idx;
-  }
+  // The overview stays short. It is 22 lines today; the margin is for Phase 2, and the ceiling is
+  // what stops it regrowing into the 151-line wall the help restructure removed.
+  ASSERT_LE(std::count(output.begin(), output.end(), '\n'), 25);
 }
 
 // A malformed --init_master_addrs must be reported on its own terms. The flag is read in Run()
@@ -329,9 +319,247 @@ TEST_F(AdminCliTest, MalformedInitMasterAddrs) {
     ASSERT_STR_NOT_CONTAINS(error, "SetUsageMessage");
     ASSERT_STR_NOT_CONTAINS(output, "SetUsageMessage");
     // A bad flag value is not a usage error, so neither stream gets the operation catalog.
-    ASSERT_STR_NOT_CONTAINS(output, "Operations:");
-    ASSERT_STR_NOT_CONTAINS(error, "Operations:");
+    ASSERT_STR_NOT_CONTAINS(output, "Operations (");
+    ASSERT_STR_NOT_CONTAINS(error, "Operations (");
   }
+}
+
+namespace {
+
+std::vector<std::string> SplitLines(const std::string& text) {
+  std::vector<std::string> lines;
+  std::istringstream stream(text);
+  std::string line;
+  while (std::getline(stream, line)) {
+    lines.push_back(line);
+  }
+  return lines;
+}
+
+}  // namespace
+
+// --help and its spellings are intercepted before the flag parse and print the short overview,
+// exit 0. None of these invocations needs a running cluster; that is part of the contract (help
+// must answer on a broken cluster).
+TEST_F(AdminCliTest, HelpFlagsPrintOverview) {
+  const auto exe_path = GetAdminToolPath();
+  std::string output;
+  std::string error;
+
+  for (const auto* help_flag : {"--help", "-help", "--h", "-h", "--help=true"}) {
+    output.clear();
+    error.clear();
+    SCOPED_TRACE(help_flag);
+    ASSERT_OK(Subprocess::Call(ToStringVector(exe_path, help_flag), &output, &error));
+    ASSERT_STR_CONTAINS(output, "administer a YugabyteDB cluster");
+    ASSERT_STR_CONTAINS(output, "Get help:");
+    ASSERT_STR_CONTAINS(output, "Common global flags:");
+    ASSERT_STR_NOT_CONTAINS(output, "Flags from");
+    ASSERT_STR_NOT_CONTAINS(output, "SetUsageMessage");
+    ASSERT_STR_NOT_CONTAINS(error, "SetUsageMessage");
+    // The overview stays at most 25 lines (22 today; the margin is for Phase 2) -- the ceiling
+    // that stops it regrowing into the 151-line wall the restructure removed.
+    ASSERT_LE(std::count(output.begin(), output.end(), '\n'), 25) << help_flag;
+  }
+
+  // The =<bool> form is parsed, not merely matched: --help=false is not a help request and takes
+  // the bare-invocation path -- overview on stdout, exit 1.
+  ASSERT_NOK(Subprocess::Call(ToStringVector(exe_path, "--help=false"), &output, &error));
+  ASSERT_STR_CONTAINS(output, "Get help:");
+
+  // gflags accepts the two-token form "--flag value" for non-boolean flags, so here --help is the
+  // *value* of --master_addresses, not a request: no operation follows, so this is the
+  // bare-invocation path (exit 1), never help-and-exit-0.
+  ASSERT_NOK(Subprocess::Call(
+      ToStringVector(exe_path, "--master_addresses", "--help"), &output, &error));
+
+  // --helpshort is repaired (it used to print "No modules matched: use -help"): the overview plus
+  // the flags yb-admin itself defines, formatted without gflags' build-relative
+  // "Flags from ../../src/..." path headers.
+  ASSERT_OK(Subprocess::Call(ToStringVector(exe_path, "--helpshort"), &output, &error));
+  ASSERT_STR_CONTAINS(output, "Get help:");
+  ASSERT_STR_CONTAINS(output, "own flags:");
+  ASSERT_STR_CONTAINS(output, "--timeout_ms");
+  ASSERT_STR_CONTAINS(output, "--certs_dir_name");
+  ASSERT_STR_NOT_CONTAINS(output, "No modules matched");
+  ASSERT_STR_NOT_CONTAINS(output, "Flags from");
+
+  // --helpfull legitimately remains the all-flags dump -- the guard proving the repair of the
+  // other surfaces did not break the one that is supposed to dump flags. It now carries the real
+  // overview as its header instead of the SetUsageMessage warning.
+  ASSERT_NOK(Subprocess::Call(ToStringVector(exe_path, "--helpfull"), &output, &error));
+  ASSERT_STR_CONTAINS(output, "Flags from");
+  ASSERT_STR_CONTAINS(output, "administer a YugabyteDB cluster");
+  ASSERT_STR_NOT_CONTAINS(output, "SetUsageMessage");
+  ASSERT_STR_NOT_CONTAINS(error, "SetUsageMessage");
+}
+
+// `yb-admin help` prints every non-hidden operation: alphabetical, numbered 1..N with no gap or
+// duplicate, each entry on one terminal line.
+TEST_F(AdminCliTest, HelpListsAllOperations) {
+  const auto exe_path = GetAdminToolPath();
+  std::string output;
+  std::string error;
+  ASSERT_OK(Subprocess::Call(ToStringVector(exe_path, "help"), &output, &error));
+  ASSERT_STR_CONTAINS(output, "Operations (");
+  ASSERT_STR_CONTAINS(output, "help <operation>' for the usage of one operation");
+  ASSERT_STR_NOT_CONTAINS(output, "Flags from");
+  ASSERT_STR_NOT_CONTAINS(output, "SetUsageMessage");
+  ASSERT_STR_NOT_CONTAINS(error, "SetUsageMessage");
+
+  std::vector<int> numbers;
+  std::vector<std::string> names;
+  std::regex entry_re(R"(\n\s*(\d+)\. (\S+))");
+  for (std::sregex_iterator it(output.begin(), output.end(), entry_re), end; it != end; ++it) {
+    numbers.push_back(std::stoi((*it)[1].str()));
+    names.push_back((*it)[2].str());
+  }
+  // A floor, not just non-empty: ASSERT_FALSE(empty()) would pass a build that printed one line.
+  ASSERT_GE(numbers.size(), 100);
+  for (size_t idx = 0; idx < numbers.size(); ++idx) {
+    ASSERT_EQ(numbers[idx], static_cast<int>(idx) + 1)
+        << "gap or duplicate in operation numbering at position " << idx;
+  }
+  ASSERT_TRUE(std::is_sorted(names.begin(), names.end())) << "operation list is not alphabetical";
+  // help itself is a registered operation, so it appears in its own list; hidden operations do
+  // not.
+  ASSERT_TRUE(std::find(names.begin(), names.end(), "help") != names.end());
+  ASSERT_TRUE(
+      std::find(names.begin(), names.end(), "unsafe_release_object_locks_global") == names.end());
+
+  // Usage strings are trimmed at registration, so a stray space in one (list_snapshots' args led
+  // with one) cannot render a double separator.
+  ASSERT_STR_CONTAINS(output, "list_snapshots [");
+  ASSERT_STR_NOT_CONTAINS(output, "list_snapshots  ");
+
+  // Entries are capped to one terminal line; the full syntax is one "help <operation>" away.
+  for (const auto& line : SplitLines(output)) {
+    ASSERT_LE(line.size(), 100) << line;
+  }
+  ASSERT_TRUE(std::regex_search(
+      output, std::regex(R"(alter_universe_replication [^\n]*\.\.\.)")))
+      << "the longest usage string is expected to be truncated with '...'";
+  ASSERT_OK(Subprocess::Call(
+      ToStringVector(exe_path, "help", "alter_universe_replication"), &output, &error));
+  const auto usage_line = SplitLines(output).front();
+  ASSERT_STR_CONTAINS(usage_line, "Usage: yb-admin alter_universe_replication");
+  ASSERT_GT(usage_line.size(), 100) << "help <operation> must show the untruncated syntax";
+}
+
+// `yb-admin help <arg>` dispatch: exact operation, case-insensitive substring filter, and typo
+// suggestions, in that order.
+TEST_F(AdminCliTest, HelpOperationDispatch) {
+  const auto exe_path = GetAdminToolPath();
+  std::string output;
+  std::string error;
+
+  // Substring filter, not prefix: operation names are verb-first, so a topic word like
+  // "snapshot" sits mid-name and a prefix filter would find none of these.
+  ASSERT_OK(Subprocess::Call(ToStringVector(exe_path, "help", "snapshot"), &output, &error));
+  ASSERT_STR_CONTAINS(output, "Operations matching 'snapshot' (");
+  // Filtered entries carry an ASCII "*" marker, not a number: the numbers index the full list.
+  ASSERT_STR_CONTAINS(output, "\n  * abort_snapshot_restore");
+  ASSERT_STR_CONTAINS(output, "create_snapshot");
+  ASSERT_STR_CONTAINS(output, "restore_snapshot_schedule");
+  ASSERT_FALSE(std::regex_search(output, std::regex(R"(\n\s*\d+\. )")));
+
+  // An exact name prints that operation's usage, hidden operations included: the list omits
+  // them, but an engineer who already knows the name can read the syntax.
+  ASSERT_OK(Subprocess::Call(
+      ToStringVector(exe_path, "help", "unsafe_release_object_locks_global"), &output, &error));
+  ASSERT_STR_CONTAINS(output, "Usage: yb-admin unsafe_release_object_locks_global");
+
+  // Numbers are display-only: "help 42" is an unknown operation, not operation #42.
+  ASSERT_NOK(Subprocess::Call(ToStringVector(exe_path, "help", "42"), &output, &error));
+  ASSERT_STR_CONTAINS(error, "Invalid operation: 42");
+
+  // An argument matching nothing degrades to the typo suggestions, on stderr, without an
+  // "Error running help:" line burying them.
+  output.clear();
+  error.clear();
+  ASSERT_NOK(Subprocess::Call(ToStringVector(exe_path, "help", "delete_tabel"), &output, &error));
+  ASSERT_STR_CONTAINS(error, "Invalid operation: delete_tabel");
+  ASSERT_STR_CONTAINS(error, "delete_table");
+  ASSERT_STR_CONTAINS(error, "help' to list all operations");
+  ASSERT_STR_NOT_CONTAINS(error, "Error running help");
+  ASSERT_TRUE(output.empty()) << output;
+
+  // Far-off garbage gets no suggestions.
+  ASSERT_NOK(Subprocess::Call(
+      ToStringVector(exe_path, "help", "zzzzzzzzzzzzzzzzzz"), nullptr, &error));
+  ASSERT_STR_NOT_CONTAINS(error, "Did you mean one of these?");
+
+  // help is a registered operation, so a typo of help itself is suggested like any other.
+  error.clear();
+  ASSERT_NOK(Subprocess::Call(ToStringVector(exe_path, "hepl"), nullptr, &error));
+  ASSERT_STR_CONTAINS(error, "Did you mean one of these?");
+  ASSERT_TRUE(std::regex_search(error, std::regex(R"(\n  help\n)"))) << error;
+
+  // Extra arguments are a standard usage error, formatted by RunCommand() like any other
+  // operation's: help's own usage line on stderr, no overview.
+  output.clear();
+  error.clear();
+  ASSERT_NOK(Subprocess::Call(
+      ToStringVector(exe_path, "help", "extra1", "extra2"), &output, &error));
+  ASSERT_STR_CONTAINS(error, "Usage: yb-admin help [<operation>]");
+  ASSERT_STR_NOT_CONTAINS(output, "Get help:");
+}
+
+// help never constructs a client and is intercepted before the flag parse, so it answers with
+// unreachable masters, unparsable connection flags, and flags ahead of the operation.
+TEST_F(AdminCliTest, HelpNeedsNoCluster) {
+  const auto exe_path = GetAdminToolPath();
+  std::string output;
+  std::string error;
+
+  // A well-formed address on a closed port must answer immediately, not hang out the full
+  // --timeout_ms (60s by default) -- the failure mode of running help through a client.
+  const auto start = MonoTime::Now();
+  ASSERT_OK(Subprocess::Call(
+      ToStringVector(exe_path, "help", "--master_addresses", "127.0.0.1:1"), &output, &error));
+  ASSERT_STR_CONTAINS(output, "Operations (");
+  ASSERT_LT((MonoTime::Now() - start).ToSeconds(), 30);
+
+  // Connection flags are validated only by operations that need a client.
+  ASSERT_OK(Subprocess::Call(
+      ToStringVector(exe_path, "help", "--init_master_addrs=host:badport"), &output, &error));
+  ASSERT_STR_CONTAINS(output, "Operations (");
+
+  // The help-flag scan reads every raw argv token, not just argv[1]: real commands lead with
+  // flags, and the operation to show help for sits after them.
+  const auto flagfile_path = tmp_dir_ / "flagfile.conf";
+  std::ofstream flagfile(flagfile_path);
+  flagfile << "--master_addresses=127.0.0.1:1\n";
+  flagfile.close();
+  ASSERT_OK(Subprocess::Call(
+      ToStringVector(exe_path, "--flagfile", flagfile_path, "delete_table", "--help"), &output,
+      &error));
+  ASSERT_STR_CONTAINS(output, "Usage: yb-admin delete_table <table>");
+}
+
+// `help <operation>`, `<operation> --help`, and RunCommand()'s bad-argument error all print one
+// shared block -- the anti-drift property the shared printer exists for, prog_name spelling
+// included.
+TEST_F(AdminCliTest, HelpMatchesBadArgumentUsage) {
+  const auto exe_path = GetAdminToolPath();
+  std::string help_output;
+  ASSERT_OK(Subprocess::Call(
+      ToStringVector(exe_path, "help", "delete_table"), &help_output, /* stderr_str */ nullptr));
+  ASSERT_STR_CONTAINS(help_output, "Usage: yb-admin delete_table <table>");
+  ASSERT_STR_CONTAINS(help_output, "Definitions: <table>");
+  // <table>'s definition references <namespace>, so <namespace> is defined transitively.
+  ASSERT_STR_CONTAINS(help_output, "[(ycql|ysql).]<namespace_name>");
+
+  std::string flag_output;
+  ASSERT_OK(Subprocess::Call(
+      ToStringVector(exe_path, "delete_table", "--help"), &flag_output, nullptr));
+  ASSERT_EQ(help_output, flag_output);
+
+  BuildAndStart();
+  const auto status = CallAdmin("delete_table");
+  ASSERT_NOK(status);
+  boost::trim_right(help_output);
+  ASSERT_STR_CONTAINS(status.ToString(), help_output);
 }
 
 // Test yb-admin config change while running a workload.
@@ -2218,9 +2446,13 @@ TEST_F(AdminCliTest, PrintArgumentExpressions) {
   const auto index_expression = "<index>\n  <namespace> <index_name> | tableid.<index_id>";
 
   BuildAndStart();
+  // <table> and <index> definitions reference <namespace>, so the namespace definition is
+  // included transitively; the referencing definition prints first.
   auto status = CallAdmin("delete_table");
   ASSERT_NOK(status);
   ASSERT_NE(status.ToString().find(table_expression), std::string::npos);
+  ASSERT_NE(status.ToString().find(namespace_expression), std::string::npos);
+  ASSERT_LT(status.ToString().find(table_expression), status.ToString().find(namespace_expression));
 
   status = CallAdmin("delete_namespace");
   ASSERT_NOK(status);
@@ -2229,6 +2461,7 @@ TEST_F(AdminCliTest, PrintArgumentExpressions) {
   status = CallAdmin("delete_index");
   ASSERT_NOK(status);
   ASSERT_NE(status.ToString().find(index_expression), std::string::npos);
+  ASSERT_NE(status.ToString().find(namespace_expression), std::string::npos);
 
   status = CallAdmin("add_universe_key_to_all_masters");
   ASSERT_NOK(status);

--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -299,6 +299,32 @@ TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
   }
 }
 
+// An --init_master_addrs value that splits to nothing ("," -- ParseStrings uses SkipEmpty) used
+// to parse as OK with zero addresses, and indexing the empty vector crashed with SIGSEGV
+// (#33435).
+TEST_F(AdminCliTest, MalformedInitMasterAddrs) {
+  const auto exe_path = GetAdminToolPath();
+  std::string output;
+  std::string error;
+
+  for (const auto& bad_value : {",", ",,"}) {
+    output.clear();
+    error.clear();
+    ASSERT_NOK(Subprocess::Call(
+        ToStringVector(exe_path, "--init_master_addrs", bad_value, "list_tables"), &output,
+        &error))
+        << "--init_master_addrs=" << bad_value << " unexpectedly succeeded";
+    // Naming the flag proves we took the targeted path: a crash prints no such line, and the
+    // pre-SetUsage InvalidArgument path printed only the gflags warning.
+    ASSERT_STR_CONTAINS(error, "Invalid --init_master_addrs");
+    ASSERT_STR_NOT_CONTAINS(error, "SetUsageMessage");
+    ASSERT_STR_NOT_CONTAINS(output, "SetUsageMessage");
+    // A bad flag value is not a usage error, so neither stream gets the operation catalog.
+    ASSERT_STR_NOT_CONTAINS(output, "Operations:");
+    ASSERT_STR_NOT_CONTAINS(error, "Operations:");
+  }
+}
+
 // Test yb-admin config change while running a workload.
 // 1. Instantiate external mini cluster with 3 TS.
 // 2. Create table with 2 replicas.

--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -282,6 +282,11 @@ TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
   ASSERT_STR_NOT_CONTAINS(output, "Argument definitions:");
   ASSERT_STR_NOT_CONTAINS(output, "Flags from");
   ASSERT_STR_NOT_CONTAINS(output, "yb-admin_cli.cc:");
+  // google::ProgramUsage() emits this when SetUsageMessage() has not been called. Any path that
+  // prints usage before SetUsage() runs shows it as the entire message -- see the
+  // --init_master_addrs test below.
+  ASSERT_STR_NOT_CONTAINS(output, "SetUsageMessage");
+  ASSERT_STR_NOT_CONTAINS(error, "SetUsageMessage");
 
   // The Operations: list must number only the entries it actually prints. It used to number by
   // each command's index in the full (including hidden) command table, so a hidden command's slot
@@ -292,22 +297,26 @@ TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
        ++it) {
     operation_numbers.push_back(std::stoi((*it)[1].str()));
   }
-  ASSERT_FALSE(operation_numbers.empty());
+  // A floor, not just non-empty: the whole point of this test is that the visible list is
+  // numbered 1..N with no gap, and ASSERT_FALSE(empty()) would pass a build that printed one line.
+  ASSERT_GE(operation_numbers.size(), 100);
   for (size_t idx = 0; idx < operation_numbers.size(); ++idx) {
     ASSERT_EQ(operation_numbers[idx], static_cast<int>(idx) + 1)
         << "gap or duplicate in operation numbering at position " << idx;
   }
 }
 
-// An --init_master_addrs value that splits to nothing ("," -- ParseStrings uses SkipEmpty) used
-// to parse as OK with zero addresses, and indexing the empty vector crashed with SIGSEGV
-// (#33435).
+// A malformed --init_master_addrs must be reported on its own terms. The flag is read in Run()
+// before SetUsage() has been called, so returning InvalidArgument here makes main() print an unset
+// google::ProgramUsage() -- the user's entire error message becomes "Warning: SetUsageMessage()
+// never called". A value that splits to nothing ("," -- ParseStrings uses SkipEmpty) used to index
+// an empty vector and crash (#33435).
 TEST_F(AdminCliTest, MalformedInitMasterAddrs) {
   const auto exe_path = GetAdminToolPath();
   std::string output;
   std::string error;
 
-  for (const auto& bad_value : {",", ",,"}) {
+  for (const auto& bad_value : {"host:99999", "host:abc", ",", ",,"}) {
     output.clear();
     error.clear();
     ASSERT_NOK(Subprocess::Call(

--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -212,12 +212,12 @@ class AdminCliTest : public AdminTestBase {
 // cluster (the operation is checked before yb-admin connects to the master): prefix matches,
 // fuzzy (edit-distance) matches, and that an invalid operation no longer dumps the full command
 // list (the original complaint in the issue) while running with no operation still prints the
-// full usage as help.
+// full usage as help, structured into sections and without the raw gflags dump.
 TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
   const auto exe_path = GetAdminToolPath();
   constexpr auto kUnusedMasterAddress = "127.0.0.1:0";
   // This marker only appears in the full usage/command listing (which is printed to stdout).
-  constexpr auto kFullUsageMarker = "<operation> must be one of";
+  constexpr auto kFullUsageMarker = "Operations:";
   std::string output;
   std::string error;
 
@@ -265,10 +265,38 @@ TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
       nullptr, &error));
   ASSERT_STR_NOT_CONTAINS(error, "Did you mean one of these?");
 
-  // Running with no operation at all should still print the full usage as help on stdout.
+  // Running with no operation at all should still print the full usage as help on stdout,
+  // structured with clear sections, and without leaking the raw gflags dump (source path, flag
+  // types/defaults) that google::ShowUsageWithFlagsRestrict used to append.
   ASSERT_NOK(Subprocess::Call(
       ToStringVector(exe_path, "--master_addresses", kUnusedMasterAddress), &output, &error));
+  ASSERT_STR_CONTAINS(output, "Usage:");
+  ASSERT_STR_CONTAINS(output, "Common global flags:");
+  ASSERT_STR_CONTAINS(output, "Tip:");
+  ASSERT_STR_CONTAINS(output, "Example:");
   ASSERT_STR_CONTAINS(output, kFullUsageMarker);
+  // The <namespace>/<table>/<index> placeholder definitions are no longer dumped in a global
+  // footer here -- only a minority of operations use them, and RunCommand() already surfaces the
+  // relevant definition alongside a specific command's usage on a bad-arguments error instead
+  // (see PrintArgumentExpressions below).
+  ASSERT_STR_NOT_CONTAINS(output, "Argument definitions:");
+  ASSERT_STR_NOT_CONTAINS(output, "Flags from");
+  ASSERT_STR_NOT_CONTAINS(output, "yb-admin_cli.cc:");
+
+  // The Operations: list must number only the entries it actually prints. It used to number by
+  // each command's index in the full (including hidden) command table, so a hidden command's slot
+  // left a gap in the visible numbering, e.g. "85. ..." followed directly by "87. ...".
+  std::vector<int> operation_numbers;
+  std::regex operation_number_re(R"(\n\s*(\d+)\. \S)");
+  for (std::sregex_iterator it(output.begin(), output.end(), operation_number_re), end; it != end;
+       ++it) {
+    operation_numbers.push_back(std::stoi((*it)[1].str()));
+  }
+  ASSERT_FALSE(operation_numbers.empty());
+  for (size_t idx = 0; idx < operation_numbers.size(); ++idx) {
+    ASSERT_EQ(operation_numbers[idx], static_cast<int>(idx) + 1)
+        << "gap or duplicate in operation numbering at position " << idx;
+  }
 }
 
 // Test yb-admin config change while running a workload.
@@ -2149,9 +2177,10 @@ TEST_F(AdminCliTest, TestListNamespaces) {
 }
 
 TEST_F(AdminCliTest, PrintArgumentExpressions) {
-  const auto namespace_expression = "<namespace>:\n [(ycql|ysql).]<namespace_name> (default ycql.)";
-  const auto table_expression = "<table>:\n <namespace> <table_name> | tableid.<table_id>";
-  const auto index_expression = "<index>:\n  <namespace> <index_name> | tableid.<index_id>";
+  const auto namespace_expression =
+      "<namespace>\n  [(ycql|ysql).]<namespace_name> (default: ycql.)";
+  const auto table_expression = "<table>\n  <namespace> <table_name> | tableid.<table_id>";
+  const auto index_expression = "<index>\n  <namespace> <index_name> | tableid.<index_id>";
 
   BuildAndStart();
   auto status = CallAdmin("delete_table");
@@ -2171,6 +2200,19 @@ TEST_F(AdminCliTest, PrintArgumentExpressions) {
   ASSERT_EQ(status.ToString().find(namespace_expression), std::string::npos);
   ASSERT_EQ(status.ToString().find(table_expression), std::string::npos);
   ASSERT_EQ(status.ToString().find(index_expression), std::string::npos);
+
+  // import_snapshot's usage_arguments_ is "<file_name> [<namespace> <table_name>
+  // [<table_name>]...]" -- <namespace> only ever appears bracketed. Called with no arguments at
+  // all, it fails argument-count validation before touching the placeholder, so this only
+  // exercises the bracket-stripping fix, not a namespace-specific error.
+  status = CallAdmin("import_snapshot");
+  ASSERT_NOK(status);
+  ASSERT_NE(status.ToString().find(namespace_expression), std::string::npos);
+
+  // list_change_data_streams' usage_arguments_ is "[<namespace>]" -- also always bracketed.
+  status = CallAdmin("list_change_data_streams", "extra_arg_1", "extra_arg_2");
+  ASSERT_NOK(status);
+  ASSERT_NE(status.ToString().find(namespace_expression), std::string::npos);
 }
 
 TEST_F(AdminCliTest, TestCompactionStatusBeforeCompaction) {

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -107,6 +107,14 @@ const Status ClusterAdminCli::kInvalidArguments =
 
 namespace {
 
+// Read a flag's compiled-in default so the usage text cannot drift from the DEFINE_ that sets
+// it. yb::ParseCommandLineFlags() rewrites a flag's default only when the program set it
+// programmatically before parsing, so this returns the DEFINE_'d value on either side of the parse.
+std::string FlagDefault(const char* flag_name) {
+  google::CommandLineFlagInfo info;
+  return google::GetCommandLineFlagInfo(flag_name, &info) ? info.default_value : "";
+}
+
 constexpr auto kBlacklistAdd = "ADD";
 constexpr auto kBlacklistRemove = "REMOVE";
 constexpr int32 kDefaultRpcPort = 9100;
@@ -538,16 +546,17 @@ Status ClusterAdminCli::Run(int argc, char** argv) {
   const string addrs = FLAGS_master_addresses;
   if (!FLAGS_init_master_addrs.empty()) {
     std::vector<HostPort> init_master_addrs;
-    RETURN_NOT_OK(HostPort::ParseStrings(
-        FLAGS_init_master_addrs, master::kMasterDefaultPort, &init_master_addrs));
-    // ParseStrings() splits with SkipEmpty(), so a value of "," parses to zero addresses and
-    // returns OK; indexing that is out of bounds (#33435). Not InvalidArgument: SetUsage() has
-    // not run yet, so main()'s InvalidArgument branch would print an unset
-    // google::ProgramUsage() -- "Warning: SetUsageMessage() never called" as the entire error
-    // message.
-    if (init_master_addrs.empty()) {
-      cerr << "Invalid --init_master_addrs '" << FLAGS_init_master_addrs
-           << "': no addresses found" << endl;
+    const auto parse_status = HostPort::ParseStrings(
+        FLAGS_init_master_addrs, master::kMasterDefaultPort, &init_master_addrs);
+    // Neither failure may return InvalidArgument: SetUsage() has not run yet, so main()'s
+    // InvalidArgument branch would print an unset google::ProgramUsage() -- "Warning:
+    // SetUsageMessage() never called" as the entire error message. ParseStrings() also splits with
+    // SkipEmpty(), so a value of "," parses to zero addresses and returns OK; indexing that is out
+    // of bounds (#33435).
+    if (!parse_status.ok() || init_master_addrs.empty()) {
+      cerr << "Invalid --init_master_addrs '" << FLAGS_init_master_addrs << "': "
+           << (parse_status.ok() ? "no addresses found" : parse_status.message().ToBuffer())
+           << endl;
       return STATUS(RuntimeError, "Invalid --init_master_addrs");
     }
     client_.reset(new ClusterAdminClient(
@@ -621,10 +630,12 @@ void ClusterAdminCli::SetUsage(const string& prog_name) {
       << "  " << prog_name << " [global flags] <operation> [args]" << endl
       << endl
       << "Common global flags:" << endl
-      << "  --master_addresses host:port[,host:port,...]  (default: localhost:7100)" << endl
+      << "  --master_addresses host:port[,host:port,...]  (default: "
+      << FlagDefault("master_addresses") << ")" << endl
       << "  --init_master_addrs host:port                 (alternative to --master_addresses)"
       << endl
-      << "  --timeout_ms <millisec>                       (default: 60000)" << endl
+      << "  --timeout_ms <millisec>                       (default: "
+      << FlagDefault("timeout_ms") << ")" << endl
       << "  --certs_dir_name <dir>" << endl
       << "  --flagfile <path>" << endl
       << endl

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -540,6 +540,16 @@ Status ClusterAdminCli::Run(int argc, char** argv) {
     std::vector<HostPort> init_master_addrs;
     RETURN_NOT_OK(HostPort::ParseStrings(
         FLAGS_init_master_addrs, master::kMasterDefaultPort, &init_master_addrs));
+    // ParseStrings() splits with SkipEmpty(), so a value of "," parses to zero addresses and
+    // returns OK; indexing that is out of bounds (#33435). Not InvalidArgument: SetUsage() has
+    // not run yet, so main()'s InvalidArgument branch would print an unset
+    // google::ProgramUsage() -- "Warning: SetUsageMessage() never called" as the entire error
+    // message.
+    if (init_master_addrs.empty()) {
+      cerr << "Invalid --init_master_addrs '" << FLAGS_init_master_addrs
+           << "': no addresses found" << endl;
+      return STATUS(RuntimeError, "Invalid --init_master_addrs");
+    }
     client_.reset(new ClusterAdminClient(
         init_master_addrs[0], MonoDelta::FromMilliseconds(FLAGS_timeout_ms)));
   } else {

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -113,9 +113,11 @@ constexpr int32 kDefaultRpcPort = 9100;
 const string kMinus = "minus";
 
 const std::string namespace_expression =
-    "<namespace>:\n [(ycql|ysql).]<namespace_name> (default ycql.)";
-const std::string table_expression = "<table>:\n <namespace> <table_name> | tableid.<table_id>";
-const std::string index_expression = "<index>:\n  <namespace> <index_name> | tableid.<index_id>";
+    "<namespace>\n  [(ycql|ysql).]<namespace_name> (default: ycql.)";
+const std::string table_expression =
+    "<table>\n  <namespace> <table_name> | tableid.<table_id>";
+const std::string index_expression =
+    "<index>\n  <namespace> <index_name> | tableid.<index_id>";
 
 Status GetUniverseConfig(ClusterAdminClient* client, const ClusterAdminCli::CLIArguments&) {
   RETURN_NOT_OK_PREPEND(client->GetUniverseConfig(), "Unable to get universe config");
@@ -430,11 +432,21 @@ std::string ClusterAdminCli::GetArgumentExpressions(const std::string& usage_arg
   std::stringstream ss(usage_arguments);
   std::string next_argument;
   while (ss >> next_argument) {
-    if (next_argument == "<namespace>" || next_argument == "<source_namespace>") {
+    // usage_arguments_ marks optional arguments with surrounding '[' ']' and repeated ones with
+    // a trailing "...", e.g. "[<namespace> <table_name> [<table_name>]...]". Strip those
+    // decorations before comparing, otherwise a placeholder inside brackets never matches and its
+    // definition is silently omitted.
+    const auto begin = next_argument.find_first_not_of('[');
+    const auto end = next_argument.find_last_not_of("].");
+    const std::string token = (begin == std::string::npos || end == std::string::npos ||
+                                begin > end)
+                                   ? std::string()
+                                   : next_argument.substr(begin, end - begin + 1);
+    if (token == "<namespace>" || token == "<source_namespace>") {
       expressions += namespace_expression + '\n';
-    } else if (next_argument == "<table>") {
+    } else if (token == "<table>") {
       expressions += table_expression + '\n';
-    } else if (next_argument == "<index>") {
+    } else if (token == "<index>") {
       expressions += index_expression + '\n';
     }
   }
@@ -595,32 +607,42 @@ void ClusterAdminCli::Register(
 void ClusterAdminCli::SetUsage(const string& prog_name) {
   ostringstream str;
 
-  str << prog_name << " [--master_addresses server1:port,server2:port,server3:port,...] "
-      << " [--timeout_ms <millisec>] [--certs_dir_name <dir_name>]" << endl
-      << "  [--flagfile <path/to/master/conf/server.conf>]" << endl
-      << "  <operation>" << endl
+  str << "Usage:" << endl
+      << "  " << prog_name << " [global flags] <operation> [args]" << endl
       << endl
-      << "Tip: Use --flagfile with the master's server.conf to automatically pick up" << endl
-      << "master_addresses and certs_dir, avoiding manual flag entry." << endl
-      << "Example: " << prog_name
-      << " --flagfile master/conf/server.conf list_all_masters" << endl
+      << "Common global flags:" << endl
+      << "  --master_addresses host:port[,host:port,...]  (default: localhost:7100)" << endl
+      << "  --init_master_addrs host:port                 (alternative to --master_addresses)"
       << endl
-      << "<operation> must be one of:" << endl;
+      << "  --timeout_ms <millisec>                       (default: 60000)" << endl
+      << "  --certs_dir_name <dir>" << endl
+      << "  --flagfile <path>" << endl
+      << endl
+      << "Tip:" << endl
+      << "  Use --flagfile with the master's server.conf to automatically pick up" << endl
+      << "  master_addresses and certs_dir, avoiding manual flag entry." << endl
+      << endl
+      << "Example:" << endl
+      << "  " << prog_name << " --flagfile /path/to/master/conf/server.conf list_all_masters"
+      << endl
+      << endl
+      << "Operations:" << endl;
 
-  for (size_t i = 0; i < commands_.size(); ++i) {
-    const auto& command = commands_[i];
+  // Number only the operations actually printed, so a hidden command's slot in commands_ doesn't
+  // leave a gap in the visible list (e.g. "85. ..." followed by "87. ..." with no "86.").
+  size_t visible_number = 0;
+  for (const auto& command : commands_) {
     if (command.hidden_) {
       continue;
     }
-    str << ' ' << i + 1 << ". " << command.name_ << (command.usage_arguments_.empty() ? "" : " ")
-        << command.usage_arguments_ << endl;
+    str << "  " << ++visible_number << ". " << command.name_
+        << (command.usage_arguments_.empty() ? "" : " ") << command.usage_arguments_ << endl;
   }
 
-  str << endl;
-  str << namespace_expression << endl;
-  str << table_expression << endl;
-  str << index_expression << endl;
-
+  // Argument placeholders like <namespace>/<table>/<index> are defined per-command instead of
+  // in a global footer here: only a minority of operations use them (see GetArgumentExpressions),
+  // and RunCommand() already prints the relevant definition alongside a specific command's usage
+  // when that command's arguments are invalid.
   google::SetUsageMessage(str.str());
 }
 
@@ -3313,7 +3335,11 @@ int main(int argc, char** argv) {
   }
 
   if (s.IsInvalidArgument()) {
-    google::ShowUsageWithFlagsRestrict(argv[0], __FILE__);
+    // Print the usage message set up by ClusterAdminCli::SetUsage directly, rather than
+    // google::ShowUsageWithFlagsRestrict(argv[0], __FILE__), which additionally dumps every gflag
+    // defined in this file with its build-relative source path, type, and default -- noise that
+    // buries the operation catalog the usage message already lists in full.
+    std::cout << google::ProgramUsage();
   }
 
   return 1;

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <unordered_set>
 #include <utility>
 
@@ -104,6 +105,8 @@ namespace tools {
 
 const Status ClusterAdminCli::kInvalidArguments =
     STATUS(InvalidArgument, "Invalid arguments for operation");
+
+const Status ClusterAdminCli::kErrorReported = STATUS(RuntimeError, "Error already reported");
 
 namespace {
 
@@ -436,7 +439,9 @@ size_t EditDistance(const string& lhs, const string& rhs) {
 }  // namespace
 
 std::string ClusterAdminCli::GetArgumentExpressions(const std::string& usage_arguments) {
-  std::string expressions;
+  bool has_namespace = false;
+  bool has_table = false;
+  bool has_index = false;
   std::stringstream ss(usage_arguments);
   std::string next_argument;
   while (ss >> next_argument) {
@@ -451,12 +456,25 @@ std::string ClusterAdminCli::GetArgumentExpressions(const std::string& usage_arg
                                    ? std::string()
                                    : next_argument.substr(begin, end - begin + 1);
     if (token == "<namespace>" || token == "<source_namespace>") {
-      expressions += namespace_expression + '\n';
+      has_namespace = true;
     } else if (token == "<table>") {
-      expressions += table_expression + '\n';
+      has_table = true;
     } else if (token == "<index>") {
-      expressions += index_expression + '\n';
+      has_index = true;
     }
+  }
+  // The <table> and <index> definitions themselves reference <namespace>, so it must be defined
+  // whenever they are. Each placeholder is emitted once, referencing definitions first.
+  has_namespace |= has_table || has_index;
+  std::string expressions;
+  if (has_table) {
+    expressions += table_expression + '\n';
+  }
+  if (has_index) {
+    expressions += index_expression + '\n';
+  }
+  if (has_namespace) {
+    expressions += namespace_expression + '\n';
   }
   return expressions.empty() ? "" : "Definitions: " + expressions;
 }
@@ -519,14 +537,17 @@ Status ClusterAdminCli::RunCommand(
     const Command& command, const CLIArguments& command_args, const std::string& program_name) {
   auto s = command.action_(command_args, client_.get());
   if (!s.ok()) {
+    if (s.IsRuntimeError() && s.message() == kErrorReported.message()) {
+      // The action already wrote its complete report to stderr (e.g. help's suggestions for an
+      // unknown operation); prefixing it with "Error running ..." would bury it.
+      return s;
+    }
     if (s.IsRemoteError() && s.ToString().find("rpc error 2")) {
       cerr << "The cluster doesn't support " << command.name_ << ": " << s << std::endl;
     } else {
       cerr << "Error running " << command.name_ << ": " << s << endl;
       if (s.IsInvalidArgument()) {
-        cerr << Format("Usage: $0 $1 $2", program_name, command.name_, command.usage_arguments_)
-             << endl
-             << GetArgumentExpressions(command.usage_arguments_);
+        PrintCommandUsage(command, program_name, cerr);
       }
     }
     return STATUS(RuntimeError, "Error running command");
@@ -534,39 +555,216 @@ Status ClusterAdminCli::RunCommand(
   return Status::OK();
 }
 
-Status ClusterAdminCli::Run(int argc, char** argv) {
-  const string prog_name = argv[0];
-  FLAGS_logtostderr = true;
-  FLAGS_minloglevel = 2;
-  ParseCommandLineFlags(&argc, &argv, true);
-  InitGoogleLoggingSafe(prog_name.c_str());
+void ClusterAdminCli::PrintCommandUsage(
+    const Command& command, const std::string& prog_name, std::ostream& out) {
+  out << Format("Usage: $0 $1 $2", prog_name, command.name_, command.usage_arguments_) << endl
+      << GetArgumentExpressions(command.usage_arguments_);
+}
 
-  HybridTime::TEST_SetPrettyToString(true);
+void ClusterAdminCli::PrintOverview(const std::string& prog_name, std::ostream& out) {
+  // gflags renders the usage message as "progname: <usage>" in every --help* header, so printing
+  // it the same way here keeps the overview and those headers byte-identical by construction.
+  out << prog_name << ": " << google::ProgramUsage();
+}
 
-  const string addrs = FLAGS_master_addresses;
-  if (!FLAGS_init_master_addrs.empty()) {
-    std::vector<HostPort> init_master_addrs;
-    const auto parse_status = HostPort::ParseStrings(
-        FLAGS_init_master_addrs, master::kMasterDefaultPort, &init_master_addrs);
-    // Neither failure may return InvalidArgument: SetUsage() has not run yet, so main()'s
-    // InvalidArgument branch would print an unset google::ProgramUsage() -- "Warning:
-    // SetUsageMessage() never called" as the entire error message. ParseStrings() also splits with
-    // SkipEmpty(), so a value of "," parses to zero addresses and returns OK; indexing that is out
-    // of bounds (#33435).
-    if (!parse_status.ok() || init_master_addrs.empty()) {
-      cerr << "Invalid --init_master_addrs '" << FLAGS_init_master_addrs << "': "
-           << (parse_status.ok() ? "no addresses found" : parse_status.message().ToBuffer())
-           << endl;
-      return STATUS(RuntimeError, "Invalid --init_master_addrs");
+size_t ClusterAdminCli::PrintOperationNames(std::ostream& out, const std::string& filter) const {
+  const auto filter_lower = ToLowerCase(filter);
+  std::vector<const Command*> matches;
+  for (const auto& [name, index] : command_indexes_) {
+    const auto& command = commands_[index];
+    if (command.hidden_) {
+      continue;
     }
-    client_.reset(new ClusterAdminClient(
-        init_master_addrs[0], MonoDelta::FromMilliseconds(FLAGS_timeout_ms)));
-  } else {
-    client_.reset(new ClusterAdminClient(addrs, MonoDelta::FromMilliseconds(FLAGS_timeout_ms)));
+    if (!filter_lower.empty() && ToLowerCase(name).find(filter_lower) == std::string::npos) {
+      continue;
+    }
+    matches.push_back(&command);
+  }
+  if (matches.empty()) {
+    return 0;
   }
 
+  if (filter.empty()) {
+    out << "Operations (" << matches.size() << "):" << endl;
+  } else {
+    out << "Operations matching '" << filter << "' (" << matches.size() << "):" << endl;
+  }
+
+  // Entries are capped to one terminal line: a dozen usage strings run past 100 columns (one to
+  // 338) and would wrap the list into unevenly broken lines. The full syntax is one
+  // "help <operation>" away.
+  constexpr size_t kMaxLineWidth = 100;
+  // Numbers are display-only ("help 42" is an unknown operation, not operation #42) and appear in
+  // the full list only: the numbers index the full list, so repeating them in a filtered view
+  // would be misleading, and renumbering it would give one operation two numbers. Filtered
+  // entries get a plain "*" marker instead -- a list-item signal without an index. ASCII, not a
+  // bullet character: yb-admin runs in shells where a non-UTF-8 locale would garble one.
+  const auto number_width = std::to_string(matches.size()).size();
+  size_t number = 0;
+  for (const auto* command : matches) {
+    std::string line = "  ";
+    if (filter.empty()) {
+      const auto number_str = std::to_string(++number);
+      line += std::string(number_width - number_str.size(), ' ') + number_str + ". ";
+    } else {
+      line += "* ";
+    }
+    line += command->name_;
+    if (!command->usage_arguments_.empty()) {
+      line += " " + command->usage_arguments_;
+    }
+    if (line.size() > kMaxLineWidth) {
+      line = line.substr(0, kMaxLineWidth - 3) + "...";
+    }
+    out << line << endl;
+  }
+  return matches.size();
+}
+
+void ClusterAdminCli::ReportUnknownOperation(
+    const std::string& op, const std::string& prog_name) const {
+  cerr << "Invalid operation: " << op << endl;
+  const auto suggestions = GetSuggestedCommands(op);
+  if (!suggestions.empty()) {
+    cerr << "Did you mean one of these?" << endl;
+    for (const auto& suggestion : suggestions) {
+      cerr << "  " << suggestion << endl;
+    }
+  }
+  cerr << endl << "Run '" << prog_name << " help' to list all operations." << endl;
+}
+
+std::optional<ClusterAdminCli::HelpRequest> ClusterAdminCli::ScanForHelpRequest(
+    int argc, char** argv) const {
+  bool help_requested = false;
+  bool helpshort = false;
+  std::string operation;
+  for (int i = 1; i < argc; ++i) {
+    const std::string token = argv[i];
+    if (token == "--") {
+      // gflags treats everything after a bare "--" as positional; so does this scan.
+      break;
+    }
+    if (token.empty() || token[0] != '-') {
+      // The first positional token naming a registered operation selects which help page to
+      // show. Every token is scanned, not just argv[1]: real commands lead with flags, e.g.
+      // "yb-admin --flagfile server.conf delete_table --help". The scan only ever selects a help
+      // page and never which operation to run, so a free-text argument that happens to equal an
+      // operation name can at worst pick the wrong page.
+      if (operation.empty() && command_indexes_.count(token) > 0) {
+        operation = token;
+      }
+      continue;
+    }
+    const auto name_begin = token.find_first_not_of('-');
+    if (name_begin == std::string::npos || name_begin > 2) {
+      continue;
+    }
+    std::string name = token.substr(name_begin);
+    std::string value;
+    bool has_value = false;
+    const auto eq = name.find('=');
+    if (eq != std::string::npos) {
+      value = name.substr(eq + 1);
+      name = name.substr(0, eq);
+      has_value = true;
+    }
+    if (name == "help" || name == "h" || name == "helpshort") {
+      // The =<bool> form is parsed, not merely matched: "--help=false"/"=0"/"=no" is not a
+      // request and must keep falling through to the bare-invocation path.
+      const auto value_lower = ToLowerCase(value);
+      if (!has_value ||
+          (value_lower != "false" && value_lower != "f" && value_lower != "0" &&
+           value_lower != "no" && value_lower != "n")) {
+        help_requested = true;
+        helpshort |= name == "helpshort";
+      }
+      continue;
+    }
+    if (!has_value) {
+      // gflags accepts the two-token form "--flag value" for every non-boolean flag, so a help
+      // token in the value slot is data, not a request: "--master_addresses --help" sets the
+      // flag to the string "--help". The flag registry is populated by static initializers, so
+      // it is queryable before the parse.
+      google::CommandLineFlagInfo info;
+      if (google::GetCommandLineFlagInfo(name.c_str(), &info) && info.type != "bool") {
+        ++i;
+      }
+    }
+  }
+  if (!help_requested) {
+    return std::nullopt;
+  }
+  HelpRequest request;
+  request.operation = operation;
+  request.helpshort = helpshort;
+  return request;
+}
+
+void ClusterAdminCli::PrintHelpRequest(
+    const HelpRequest& request, const std::string& prog_name, std::ostream& out) {
+  if (!request.operation.empty()) {
+    PrintCommandUsage(commands_[command_indexes_[request.operation]], prog_name, out);
+    return;
+  }
+  PrintOverview(prog_name, out);
+  if (!request.helpshort) {
+    return;
+  }
+  // The tier gflags' --helpshort was meant to fill: the flags this tool itself defines. Formatted
+  // from GetAllFlags() rather than google::ShowUsageWithFlagsRestrict(), which would print
+  // gflags' "Flags from ../../src/yb/tools/..." headers -- the same build-relative path leak
+  // #33017 removed from the default path. Matching on the filename's basename keeps the filter
+  // independent of build layout.
+  std::vector<google::CommandLineFlagInfo> all_flags;
+  google::GetAllFlags(&all_flags);
+  std::vector<std::pair<std::string, std::string>> own_flags;
+  size_t width = 0;
+  for (const auto& info : all_flags) {
+    // The tool's own flags live in yb-admin_cli.cc, yb-admin_client.cc, and tools_utils.cc
+    // (--certs_dir_name, --client_node_name).
+    const auto basename = BaseName(info.filename);
+    if (!boost::starts_with(basename, "yb-admin") && basename != "tools_utils.cc") {
+      continue;
+    }
+    auto left = Format("--$0 <$1>", info.name, info.type);
+    auto default_value =
+        info.type == "string" ? Format("\"$0\"", info.default_value) : info.default_value;
+    width = std::max(width, left.size());
+    own_flags.emplace_back(std::move(left), std::move(default_value));
+  }
+  std::sort(own_flags.begin(), own_flags.end());
+  out << endl << prog_name << "'s own flags:" << endl;
+  for (const auto& [left, default_value] : own_flags) {
+    out << "  " << left << std::string(width - left.size() + 2, ' ') << "(default: "
+        << default_value << ")" << endl;
+  }
+}
+
+Status ClusterAdminCli::Run(int argc, char** argv) {
+  prog_name_ = BaseName(argv[0]);
+  FLAGS_logtostderr = true;
+  FLAGS_minloglevel = 2;
+
+  // Registration and SetUsage() run before the flag parse: RegisterCommandHandlers() needs no
+  // flags and no client, and every surface gflags renders inside ParseCommandLineFlags()
+  // (--helpfull, --helpon, --helpmatch, a help flag inside a --flagfile) prints
+  // google::ProgramUsage() as its header -- which is "Warning: SetUsageMessage() never called"
+  // until SetUsage() has run.
   RegisterCommandHandlers();
-  SetUsage(prog_name);
+  SetUsage(prog_name_);
+
+  // Help must work on a broken cluster: the scan reads raw argv, so it answers before the flag
+  // parse can fail on a malformed --flagfile or a garbage flag value.
+  if (const auto request = ScanForHelpRequest(argc, argv)) {
+    PrintHelpRequest(*request, prog_name_, std::cout);
+    return Status::OK();
+  }
+
+  ParseCommandLineFlags(&argc, &argv, true);
+  InitGoogleLoggingSafe(prog_name_.c_str());
+
+  HybridTime::TEST_SetPrettyToString(true);
 
   CLIArguments args;
   for (int i = 0; i < argc; ++i) {
@@ -579,56 +777,101 @@ Status ClusterAdminCli::Run(int argc, char** argv) {
 
   // Find operation handler by operation name.
   const string op = args[1];
-  auto cmd = command_indexes_.find(op);
+  const auto cmd = command_indexes_.find(op);
 
   if (cmd == command_indexes_.end()) {
-    cerr << "Invalid operation: " << op << endl;
-
-    const auto suggestions = GetSuggestedCommands(op);
-    if (!suggestions.empty()) {
-      cerr << "Did you mean one of these?" << endl;
-      for (const auto& suggestion : suggestions) {
-        cerr << "  " << suggestion << endl;
-      }
-    }
-    cerr << "Run '" << prog_name << "' with no operation to see all available operations." << endl;
-
+    ReportUnknownOperation(op, prog_name_);
     // The targeted error and suggestions above are more helpful than the full command list, so
     // return a non-InvalidArgument status to keep main() from additionally dumping the usage.
     return STATUS_FORMAT(RuntimeError, "Invalid operation: $0", op);
   }
 
-  // Init client.
-  Status s = client_->Init();
+  auto& command = commands_[cmd->second];
+  if (command.needs_client_) {
+    // Client construction sits below the operation lookup so that `help` never touches the
+    // network and connection flags are validated only when an operation actually needs them.
+    const string addrs = FLAGS_master_addresses;
+    if (!FLAGS_init_master_addrs.empty()) {
+      std::vector<HostPort> init_master_addrs;
+      const auto parse_status = HostPort::ParseStrings(
+          FLAGS_init_master_addrs, master::kMasterDefaultPort, &init_master_addrs);
+      // Report a bad value directly instead of returning InvalidArgument, which main() answers
+      // with the full overview -- a 22-line answer to a one-line problem. ParseStrings() also
+      // splits with SkipEmpty(), so a value of "," parses to zero addresses and returns OK;
+      // indexing that is out of bounds (#33435).
+      if (!parse_status.ok() || init_master_addrs.empty()) {
+        cerr << "Invalid --init_master_addrs '" << FLAGS_init_master_addrs << "': "
+             << (parse_status.ok() ? "no addresses found" : parse_status.message().ToBuffer())
+             << endl;
+        return STATUS(RuntimeError, "Invalid --init_master_addrs");
+      }
+      client_.reset(new ClusterAdminClient(
+          init_master_addrs[0], MonoDelta::FromMilliseconds(FLAGS_timeout_ms)));
+    } else {
+      client_.reset(new ClusterAdminClient(addrs, MonoDelta::FromMilliseconds(FLAGS_timeout_ms)));
+    }
 
-  if (PREDICT_FALSE(!s.ok())) {
-    cerr << s.CloneAndPrepend(
-                 "Unable to establish connection to leader master at [" + addrs +
-                 "]."
-                 " Please verify the addresses and check if server is up, or if you're"
-                 " missing --certs_dir_name.\n\n")
-                .ToString()
-         << endl;
-    return STATUS(RuntimeError, "Error connecting to cluster");
+    Status s = client_->Init();
+
+    if (PREDICT_FALSE(!s.ok())) {
+      // The guidance and the status are printed separately: prepending a message that ends in
+      // newlines onto the status leaves the ": " separator stranded at the start of a line.
+      cerr << "Unable to establish connection to leader master at [" << addrs << "]."
+           << " Please verify the addresses and check if server is up, or if you're"
+           << " missing --certs_dir_name." << endl
+           << endl
+           << s << endl;
+      return STATUS(RuntimeError, "Error connecting to cluster");
+    }
   }
 
   CLIArguments command_args(args.begin() + 2, args.end());
-  auto& command = commands_[cmd->second];
-  return RunCommand(command, command_args, args[0]);
+  return RunCommand(command, command_args, prog_name_);
 }
 
 void ClusterAdminCli::Register(
-    string&& cmd_name, const std::string& cmd_args, Action&& action, bool hidden) {
+    string&& cmd_name, const std::string& cmd_args, Action&& action, bool hidden,
+    bool needs_client) {
   command_indexes_[cmd_name] = commands_.size();
-  commands_.push_back({std::move(cmd_name), cmd_args, std::move(action), hidden});
+  // The usage strings are hand-written; trim them once here so a stray space (list_snapshots'
+  // args led with one) cannot render a double separator on any surface that prints them.
+  commands_.push_back({std::move(cmd_name), boost::algorithm::trim_copy(cmd_args),
+                       std::move(action), hidden, needs_client});
 }
 
 void ClusterAdminCli::SetUsage(const string& prog_name) {
-  ostringstream str;
+  // The short overview every help surface shares (see PrintOverview). It opens with a one-line
+  // tool summary, not "Usage:", because gflags prefixes it with "progname: " when rendering.
+  // The operation catalog is not listed here -- `help` prints it -- so the computed count on the
+  // help line is what tells a user of the old full dump that the list still exists in full.
+  const auto visible_operations = std::count_if(
+      commands_.begin(), commands_.end(), [](const Command& command) { return !command.hidden_; });
 
-  str << "Usage:" << endl
+  ostringstream str;
+  str << "administer a YugabyteDB cluster from the command line." << endl
+      << endl
+      << "Usage:" << endl
       << "  " << prog_name << " [global flags] <operation> [args]" << endl
       << endl
+      << "Get help:" << endl;
+
+  const std::vector<pair<string, string>> help_lines = {
+      {prog_name + " help", Format("List all $0 operations", visible_operations)},
+      {prog_name + " help <operation>", "Usage of one operation"},
+      {prog_name + " help <text>", "Operations whose name contains <text>"},
+      {prog_name + " --helpshort", prog_name + "'s own global flags"},
+      {prog_name + " --helpmatch=<substring>", "Inherited flags matching a substring"},
+      {prog_name + " --helpfull", "All flags (long)"},
+  };
+  size_t width = 0;
+  for (const auto& [invocation, description] : help_lines) {
+    width = std::max(width, invocation.size());
+  }
+  for (const auto& [invocation, description] : help_lines) {
+    str << "  " << invocation << string(width - invocation.size() + 2, ' ') << description << endl;
+  }
+
+  str << endl
       << "Common global flags:" << endl
       << "  --master_addresses host:port[,host:port,...]  (default: "
       << FlagDefault("master_addresses") << ")" << endl
@@ -637,33 +880,12 @@ void ClusterAdminCli::SetUsage(const string& prog_name) {
       << "  --timeout_ms <millisec>                       (default: "
       << FlagDefault("timeout_ms") << ")" << endl
       << "  --certs_dir_name <dir>" << endl
-      << "  --flagfile <path>" << endl
-      << endl
-      << "Tip:" << endl
-      << "  Use --flagfile with the master's server.conf to automatically pick up" << endl
-      << "  master_addresses and certs_dir, avoiding manual flag entry." << endl
+      << "  --flagfile <path>                             (use the master's server.conf)" << endl
       << endl
       << "Example:" << endl
       << "  " << prog_name << " --flagfile /path/to/master/conf/server.conf list_all_masters"
-      << endl
-      << endl
-      << "Operations:" << endl;
+      << endl;
 
-  // Number only the operations actually printed, so a hidden command's slot in commands_ doesn't
-  // leave a gap in the visible list (e.g. "85. ..." followed by "87. ..." with no "86.").
-  size_t visible_number = 0;
-  for (const auto& command : commands_) {
-    if (command.hidden_) {
-      continue;
-    }
-    str << "  " << ++visible_number << ". " << command.name_
-        << (command.usage_arguments_.empty() ? "" : " ") << command.usage_arguments_ << endl;
-  }
-
-  // Argument placeholders like <namespace>/<table>/<index> are defined per-command instead of
-  // in a global footer here: only a minority of operations use them (see GetArgumentExpressions),
-  // and RunCommand() already prints the relevant definition alongside a specific command's usage
-  // when that command's arguments are invalid.
   google::SetUsageMessage(str.str());
 }
 
@@ -3124,7 +3346,42 @@ Status xcluster_failover_action(
 }  // namespace
 
 void ClusterAdminCli::RegisterCommandHandlers() {
-  DCHECK_ONLY_NOTNULL(client_);
+  // help is registered like any other operation so that it appears in the operation list, gets
+  // suggested for typos ("yb-admin hepl"), and inherits RunCommand()'s standard error formatting.
+  // needs_client is false: help must answer on a broken cluster, without waiting out --timeout_ms.
+  Register(
+      "help", "[<operation>]",
+      [this](const CLIArguments& args, ClusterAdminClient*) -> Status {
+        if (args.size() > 1) {
+          return kInvalidArguments;
+        }
+        if (args.empty()) {
+          PrintOperationNames(std::cout);
+          std::cout << endl
+                    << "Run '" << prog_name_
+                    << " help <operation>' for the usage of one operation." << endl
+                    << "Run '" << prog_name_ << " help <text>' to filter, e.g. '" << prog_name_
+                    << " help snapshot'." << endl;
+          return Status::OK();
+        }
+        const auto& topic = args[0];
+        const auto cmd = command_indexes_.find(topic);
+        if (cmd != command_indexes_.end()) {
+          // An exact match reaches hidden operations too: the list omits them, but a support
+          // engineer who already knows the name can read its syntax.
+          PrintCommandUsage(commands_[cmd->second], prog_name_, std::cout);
+          return Status::OK();
+        }
+        if (PrintOperationNames(std::cout, topic) > 0) {
+          std::cout << endl
+                    << "Run '" << prog_name_
+                    << " help <operation>' for the usage of one operation." << endl;
+          return Status::OK();
+        }
+        ReportUnknownOperation(topic, prog_name_);
+        return kErrorReported;
+      },
+      /* hidden = */ false, /* needs_client = */ false);
 
   REGISTER_COMMAND(change_config);
   REGISTER_COMMAND(list_tablet_servers);
@@ -3355,12 +3612,13 @@ int main(int argc, char** argv) {
     return 0;
   }
 
-  if (s.IsInvalidArgument()) {
-    // Print the usage message set up by ClusterAdminCli::SetUsage directly, rather than
-    // google::ShowUsageWithFlagsRestrict(argv[0], __FILE__), which additionally dumps every gflag
-    // defined in this file with its build-relative source path, type, and default -- noise that
-    // buries the operation catalog the usage message already lists in full.
-    std::cout << google::ProgramUsage();
+  // Print the overview the same way every help surface prints it, rather than
+  // google::ShowUsageWithFlagsRestrict(argv[0], __FILE__), which additionally dumps every gflag
+  // defined in this file with its build-relative source path, type, and default. The
+  // IsUsageMessageSet() guard keeps a future reorder from ever printing gflags' "Warning:
+  // SetUsageMessage() never called" as the message.
+  if (s.IsInvalidArgument() && yb::IsUsageMessageSet()) {
+    yb::tools::ClusterAdminCli::PrintOverview(yb::BaseName(argv[0]), std::cout);
   }
 
   return 1;

--- a/src/yb/tools/yb-admin_cli.h
+++ b/src/yb/tools/yb-admin_cli.h
@@ -32,8 +32,10 @@
 #pragma once
 
 #include <functional>
+#include <iosfwd>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -62,6 +64,14 @@ class ClusterAdminCli {
 
   static const Status kInvalidArguments;
 
+  // Returned by an action that has already written its complete error report to stderr.
+  // RunCommand() adds nothing on top of it; main() still exits non-zero.
+  static const Status kErrorReported;
+
+  // Writes the short overview: the usage message prefixed with the program name, exactly as
+  // gflags renders it in the --help* headers.
+  static void PrintOverview(const std::string& prog_name, std::ostream& out);
+
  protected:
   typedef std::function<Status(const CLIArguments&, ClusterAdminClient* client)> Action;
 
@@ -70,15 +80,41 @@ class ClusterAdminCli {
     std::string usage_arguments_;
     Action action_;
     bool hidden_;
+    // Whether Run() must construct and connect a ClusterAdminClient before dispatching to
+    // action_. False for operations like `help` that must work with no reachable cluster.
+    bool needs_client_ = true;
   };
 
   void Register(
-      std::string&& cmd_name, const std::string& cmd_args, Action&& action, bool hidden = false);
+      std::string&& cmd_name, const std::string& cmd_args, Action&& action, bool hidden = false,
+      bool needs_client = true);
   void SetUsage(const std::string& prog_name);
 
   virtual void RegisterCommandHandlers();
 
  private:
+  // A help request found in raw argv before the flag parse (see ScanForHelpRequest).
+  struct HelpRequest {
+    // First token that names a registered operation, or empty for the plain overview.
+    std::string operation;
+    // Whether --helpshort was requested, adding yb-admin's own flags to the overview.
+    bool helpshort = false;
+  };
+
+  // Scans raw argv for --help/-h/--helpshort before the flag parse, so help works with a
+  // malformed --flagfile or garbage flag values. Returns nullopt when help was not requested.
+  std::optional<HelpRequest> ScanForHelpRequest(int argc, char** argv) const;
+  void PrintHelpRequest(const HelpRequest& request, const std::string& prog_name,
+                        std::ostream& out);
+  // Prints "Usage: <prog> <operation> <args>" plus the argument-placeholder definitions -- the
+  // one code path behind `help <operation>`, `<operation> --help`, and the bad-argument error.
+  void PrintCommandUsage(const Command& command, const std::string& prog_name, std::ostream& out);
+  // Prints the visible operations alphabetically -- numbered when filter is empty, or the
+  // case-insensitive substring matches when it is not. Returns how many entries were printed;
+  // prints nothing (not even a header) when a non-empty filter matches nothing.
+  size_t PrintOperationNames(std::ostream& out, const std::string& filter = "") const;
+  // Prints "Invalid operation: <op>" with closest-match suggestions to stderr.
+  void ReportUnknownOperation(const std::string& op, const std::string& prog_name) const;
   Status RunCommand(
       const Command& command, const CLIArguments& command_args, const std::string& program_name);
   std::string GetArgumentExpressions(const std::string& usage_arguments);
@@ -89,6 +125,9 @@ class ClusterAdminCli {
   std::vector<Command> commands_;
   std::map<std::string, size_t> command_indexes_;
   std::unique_ptr<ClusterAdminClient> client_;
+  // BaseName(argv[0]), set at the top of Run(); actions (the `help` lambda) need it and only
+  // receive (args, client).
+  std::string prog_name_;
 };
 
 using CLIArgumentsIterator = ClusterAdminCli::CLIArguments::const_iterator;

--- a/src/yb/util/flags/flags.cc
+++ b/src/yb/util/flags/flags.cc
@@ -227,7 +227,8 @@ DECLARE_bool(help);
 TAG_FLAG(help, stable);
 
 DECLARE_bool(helpfull);
-// We hide --helpfull because it's the same as --help for now.
+// Hidden from YB's own flag listings; servers still render --help as the full dump, while
+// yb-admin intercepts --help and advertises --helpfull from its own overview instead.
 TAG_FLAG(helpfull, stable);
 TAG_FLAG(helpfull, hidden);
 


### PR DESCRIPTION
## Summary

Phase 1b-b of the yb-admin help UX program ([#32640](https://github.com/yugabyte/yugabyte-db/issues/32640)). The full design — measurements of all twelve help surfaces, output specimens, and the decisions with their reasons — is in [#33431](https://github.com/yugabyte/yugabyte-db/issues/33431).

yb-admin has twelve reachable help surfaces and nine were broken. The one our docs point at, `yb-admin --help`, printed `Warning: SetUsageMessage() never called` followed by 1,564 lines of raw gflags output. Root cause: `ClusterAdminCli::Run()` parsed flags — where gflags renders help — before `SetUsage()` ran.

**What changes:**

* Registration and `SetUsage()` now precede the flag parse, and a raw-argv scan intercepts `--help`/`-help`/`--h`/`-h`/`--helpshort` before it, so help answers even with a malformed `--flagfile` or garbage flag values, exit 0. The scan parses `=<bool>` values (`--help=false` is not a request) and skips two-token flag values (`--master_addresses --help` sets the flag; it is not a request).
* Bare `yb-admin` prints a 22-line overview. The catalog moves to a new `help` operation: numbered alphabetical full list (entries capped at one terminal line), `help <operation>` for one operation's usage, `help <text>` as a case-insensitive substring filter, typo suggestions for anything else.
* `help` is a registered operation with `needs_client_ = false`: it never builds a client, so it cannot hang out `--timeout_ms` on a broken cluster, and `yb-admin hepl` gets a suggestion like any other typo.
* `help <operation>`, `<operation> --help`, and the bad-argument error print one shared block, so they cannot drift; the overview and the gflags `--help*` headers are one string by construction.
* Placeholder definitions expand transitively (`<table>`/`<index>` reference `<namespace>`, which now prints with them); usage strings are trimmed at registration.
* `--helpshort` is repaired (was `No modules matched`): overview plus the ten flags yb-admin itself defines, read from the flag registry. `--helpfull`/`--helpon`/`--helpmatch` keep dumping flags, now under a real header. `--helpxml`, `--help_auto_flag_json`, `--version` untouched.
* `main()` prints usage only when the usage message is set, so no path can ever print the gflags warning again; the connect-failure report no longer renders a stranded `": "` line.
* Docs: `stable` tree repointed at `yb-admin help`, gated with "Available in v2026.2 and later" and a pointer to `--help` for earlier versions — the stable tree documents the released v2026.1 binaries, which don't have the `help` operation. Older versioned trees are unchanged.

**Release notes / anything that scrapes yb-admin output:**

* Bare `yb-admin` no longer lists the operations — `yb-admin 2>/dev/null | grep X` now returns nothing. Use `yb-admin help | grep X` or `yb-admin help X`.
* `--help` and `--helpshort` exit 0 (were 1). Nothing in-tree consumes the old codes.
* The list is alphabetical, so every operation's number changes; numbers are display-only and not accepted as input.
* `yb-admin -h` now works (was an unknown-flag error).

**Stacked on [#33395](https://github.com/yugabyte/yugabyte-db/pull/33395)** (Phase 1b-a): the first commit here is that PR's commit. The rest are kept separate for cherry-picking: the [#33435](https://github.com/yugabyte/yugabyte-db/issues/33435) segfault fix (`--init_master_addrs=,`), its error-path polish, this restructure, and the [#33433](https://github.com/yugabyte/yugabyte-db/issues/33433) yugabyted passthrough fix.

## Test plan

- [x] `ybd release --cxx-test tools_yb-admin-test` — full suite, 67/67 pass locally (macOS arm64).
  - New tests: `HelpFlagsPrintOverview`, `HelpListsAllOperations`, `HelpOperationDispatch`, `HelpNeedsNoCluster`, `HelpMatchesBadArgumentUsage`.
  - Updated: `InvalidOperationSuggestsClosestCommands`, `PrintArgumentExpressions`, `MalformedInitMasterAddrs`.
- [x] All twelve help surfaces verified by hand against the built binary; the specimens in #33431 §4 reproduce byte-for-byte, including `--help=false`, `--master_addresses --help`, a help flag after `--flagfile <file> <operation>`, and `help` against a closed port (answers immediately instead of waiting out `--timeout_ms`).
- [x] Client-path regression check against a local RF1 cluster: `list_tables`, `list_all_masters`, `list_namespaces`, `get_universe_config`, `--init_master_addrs` happy path, connect-failure message.
- [ ] Full CI on this PR.

