### PR TITLE
[#33454] DocDB: don't double-count rows scanned when a response is size-truncated

### DIFF
--- a/src/postgres/src/test/regress/expected/yb.orig.fetch_limits.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.fetch_limits.out
@@ -1,4 +1,7 @@
--- If size limit is exceeded, last row has to be rescanned.
+-- If size limit is exceeded, the last row is truncated from the response and
+-- rescanned on the next request. The rows scanned metric counts each row
+-- once (the rescanned row is not double-counted). The number of read
+-- requests still reflects the rescans, so paging behavior remains observable.
 -- with too large row and too low size limit it means rescan of the each row,
 -- except the last on the tablet.
 -- Use explicit number of tablets to achieve predictable number of rows scanned

--- a/src/postgres/src/test/regress/sql/yb.orig.fetch_limits.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.fetch_limits.sql
@@ -1,4 +1,7 @@
--- If size limit is exceeded, last row has to be rescanned.
+-- If size limit is exceeded, the last row is truncated from the response and
+-- rescanned on the next request. The rows scanned metric counts each row
+-- once (the rescanned row is not double-counted). The number of read
+-- requests still reflects the rescans, so paging behavior remains observable.
 -- with too large row and too low size limit it means rescan of the each row,
 -- except the last on the tablet.
 -- Use explicit number of tablets to achieve predictable number of rows scanned

--- a/src/yb/docdb/pgsql_operation.cc
+++ b/src/yb/docdb/pgsql_operation.cc
@@ -2872,6 +2872,15 @@ Result<std::tuple<size_t, bool>> PgsqlReadOperation::ExecuteScalar() {
         RETURN_NOT_OK(PopulateResultSet(row, result_buffer_));
         if (fetched_rows > 0 && result_buffer_->size() > response_size_limit) {
           RETURN_NOT_OK(result_buffer_->Truncate(row_start));
+          // The row was counted in scanned_table_rows_ (and in the colocated index
+          // state's scanned_rows) before the size check, but it is not included in
+          // the response and will be scanned again on the next request (the paging
+          // state is set to ReadKey::kCurrent). Undo the count so the metrics report
+          // each row exactly once - see also PgsqlReadOperation::ExecuteBatchKeys.
+          --scanned_table_rows_;
+          if (index_state) {
+            --index_state->scanned_rows;
+          }
           fetch_limit = FetchLimit::kExceeded;
           // skips the fetched_rows increment and the other limit's check, which may change
           // the fetch_limit value
@@ -3004,6 +3013,12 @@ Result<size_t> PgsqlReadOperation::ExecuteBatchKeys(KeyProvider& key_provider) {
                     << "Response buffer size: " << result_buffer_->size()
                     << ", response size limit: " << response_size_limit;
             RETURN_NOT_OK(result_buffer_->Truncate(row_start));
+            // The row was counted in scanned_table_rows_ before the size check, but it is
+            // not included in the response and will be scanned again on the next request
+            // (batch_arg_count is set to processed_keys, so the client resends the key).
+            // Undo the count so the metrics report each row exactly once - see also
+            // PgsqlReadOperation::ExecuteScalar.
+            --scanned_table_rows_;
             // TODO GHI #25788, for now fail instead of returning incomplete results
             RSTATUS_DCHECK(!request_.batch_arguments().empty(),
                            IllegalState, "Pagination is required, but not supported");


### PR DESCRIPTION
In `PgsqlReadOperation::ExecuteScalar` and `PgsqlReadOperation::ExecuteBatchKeys`, `scanned_table_rows_` is incremented before the response size check. When appending a row pushes the response buffer over the size limit, the row is truncated from the response and the paging state is set to `ReadKey::kCurrent` (or `batch_arg_count` is set to `processed_keys`), so the next request scans the same row again and counts it a second time.

Decrement the counters when the row is truncated, so the `Rows Scanned` metrics report each row exactly once. The number of read requests still reflects the rescans, so paging behavior remains observable.

**For the colocated index path:** the index iterator (`index_state->scanned_rows`) also resumes at the current row, so decrement that counter too.

**Test expected outputs:** `yb.orig.fetch_limits` and `yb.orig.fetch_limits_joins` expected output will change — rows scanned values drop to the actual row counts, while read request values are unchanged. The test header comment has been updated to reflect the new semantics.

Fixes #33454.