### PR TITLE
fix(odyssey): use _exit(0) instead of exit(0) to prevent SIGSEGV on shutdown [DB-22457]

### DIFF
--- a/src/odyssey/sources/sighandler.c
+++ b/src/odyssey/sources/sighandler.c
@@ -5,6 +5,7 @@
 
 #include <sys/ipc.h>
 #include <sys/shm.h>
+#include <unistd.h>
 #include "yb/yql/ysql_conn_mgr_wrapper/ysql_conn_mgr_stats.h"
 
 static inline od_retcode_t
@@ -118,7 +119,7 @@ od_attribute_noreturn() void od_system_shutdown(od_system_t *system,
 	/* stop machinaruim and free */
 	od_instance_free(instance);
 #endif
-	exit(0);
+	_exit(0);
 }
 
 void od_system_signal_handler(void *arg)


### PR DESCRIPTION
## Problem

When YSQL Connection Manager (Odyssey) receives SIGTERM/SIGINT while a worker thread is in the middle of a client TLS handshake, the process can crash with SIGSEGV instead of exiting cleanly.

**Root cause**: `od_system_shutdown()` calls `exit(0)`, which runs atexit handlers including `OPENSSL_cleanup()`. Worker threads are stopped via `machine_stop()` (flag-only, no join, no epoll wakeup) and the process only waits 1ms (`machine_sleep(1)`) before calling `exit(0)`. If a worker is still inside `SSL_accept()` (TLS handshake), it accesses freed OpenSSL context → SIGSEGV in `inner_evp_generic_fetch`.

## Fix

Replace `exit(0)` with `_exit(0)` in `od_system_shutdown()`. `_exit(0)` skips atexit/destructor processing entirely, so `OPENSSL_cleanup` never runs. The OS reclaims all resources.

This is consistent with the existing decision (#28415, 2e9cbba) to skip explicit cleanup during shutdown because the OS will reclaim everything.

## Suggested fix options (from issue #32739)

The issue author suggested three options in order of preference:
1. ✅ `_exit(0)` instead of `exit(0)` — **this PR (option 1)**
2. `OPENSSL_INIT_NO_ATEXIT`
3. Properly join workers before exiting (more invasive)

## Testing

- Builds: `cc -c` compiles the modified file (no new dependencies, `_exit` is POSIX)
- Behavior: the process exits immediately without atexit/destructor processing, worker threads are terminated by the OS, no concurrent OpenSSL usage after `_exit()`
- No regression: all pre-exit cleanup (cron stop, shared memory cleanup) is already done before the `_exit()` call, matching the existing `#ifdef OD_SYSTEM_SHUTDOWN_CLEANUP` skip pattern

Fixes #32739