### PR TITLE
[#33434] DocDB: Stop framing every yb-admin remote error as a version mismatch

### DIFF
--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -60,6 +60,8 @@
 #include "yb/master/master_cluster_client.h"
 #include "yb/master/master_defaults.h"
 
+#include "yb/rpc/outbound_call.h"
+
 #include "yb/tools/admin-test-base.h"
 #include "yb/tools/yb-admin_util.h"
 
@@ -209,16 +211,43 @@ class AdminCliTest : public AdminTestBase {
   TmpDirProvider tmp_dir_;
 };
 
-// RunCommand() frames an error as "The cluster doesn't support <operation>" only for
-// ERROR_NO_SUCH_METHOD. Before #33434 the predicate used find() as a bool -- npos is truthy --
-// so every remote error (leaderless master, unreachable peer) got the version-mismatch framing.
-TEST_F(AdminCliTest, NoSuchMethodErrorDetection) {
-  ASSERT_TRUE(IsNoSuchMethodError(
-      STATUS(RemoteError, "Call rejected, no such method (rpc error 2)")));
-  // The regression: a generic remote error is not a version mismatch.
-  ASSERT_FALSE(IsNoSuchMethodError(STATUS(RemoteError, "Leader not ready to serve requests")));
-  // Same text under a different code is not a remote rejection at all.
-  ASSERT_FALSE(IsNoSuchMethodError(STATUS(TimedOut, "no response (rpc error 2)")));
+namespace {
+
+// Build a status the way OutboundCall::SetFailed() does, so the predicate is exercised against a
+// real error code rather than a hand-written rendering of one.
+Status RemoteErrorWithCode(const std::string& message, rpc::ErrorStatusPB::RpcErrorCodePB code) {
+  return STATUS(RemoteError, message).CloneAndAddErrorCode(rpc::RpcError(code));
+}
+
+}  // namespace
+
+// RunCommand() frames an error as "The cluster doesn't support <operation>" only when the cluster
+// could not route the RPC. Before #33434 the predicate used find() as a bool -- npos is truthy --
+// so every remote error (a leader rejecting the call, a tablet not found) got the version-mismatch
+// framing.
+TEST_F(AdminCliTest, UnsupportedRpcErrorDetection) {
+  // Service known, method unknown: the RPC was added to an existing service.
+  ASSERT_TRUE(IsUnsupportedRpcError(RemoteErrorWithCode(
+      "Call on service X received from Y with an invalid method name: Z",
+      rpc::ErrorStatusPB::ERROR_NO_SUCH_METHOD)));
+  // Service itself unknown: the whole service postdates the cluster.
+  ASSERT_TRUE(IsUnsupportedRpcError(RemoteErrorWithCode(
+      "Service X not registered on Y", rpc::ErrorStatusPB::ERROR_NO_SUCH_SERVICE)));
+
+  // The regression: a remote error the cluster *did* route is not a version mismatch.
+  ASSERT_FALSE(IsUnsupportedRpcError(RemoteErrorWithCode(
+      "Leader not ready to serve requests", rpc::ErrorStatusPB::ERROR_APPLICATION)));
+  // A remote error carrying no rpc code at all decodes to 0, not to a missing method.
+  ASSERT_FALSE(IsUnsupportedRpcError(STATUS(RemoteError, "Leader not ready to serve requests")));
+  // Not a remote rejection at all.
+  ASSERT_FALSE(IsUnsupportedRpcError(STATUS(TimedOut, "no response")));
+
+  // Pin the rendering the previous implementation matched on: a status carrying the code really
+  // does print "(rpc error 2)". If this ever changes, a text-matching predicate would silently
+  // stop firing -- which is why the check above reads the code instead.
+  ASSERT_STR_CONTAINS(
+      RemoteErrorWithCode("m", rpc::ErrorStatusPB::ERROR_NO_SUCH_METHOD).ToString(),
+      "(rpc error 2)");
 }
 
 // Verify the "did you mean" help for a misspelled operation, none of which needs a running

--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -61,6 +61,7 @@
 #include "yb/master/master_defaults.h"
 
 #include "yb/tools/admin-test-base.h"
+#include "yb/tools/yb-admin_util.h"
 
 #include "yb/tools/tools_test_utils.h"
 #include "yb/util/backoff_waiter.h"
@@ -207,6 +208,18 @@ class AdminCliTest : public AdminTestBase {
 
   TmpDirProvider tmp_dir_;
 };
+
+// RunCommand() frames an error as "The cluster doesn't support <operation>" only for
+// ERROR_NO_SUCH_METHOD. Before #33434 the predicate used find() as a bool -- npos is truthy --
+// so every remote error (leaderless master, unreachable peer) got the version-mismatch framing.
+TEST_F(AdminCliTest, NoSuchMethodErrorDetection) {
+  ASSERT_TRUE(IsNoSuchMethodError(
+      STATUS(RemoteError, "Call rejected, no such method (rpc error 2)")));
+  // The regression: a generic remote error is not a version mismatch.
+  ASSERT_FALSE(IsNoSuchMethodError(STATUS(RemoteError, "Leader not ready to serve requests")));
+  // Same text under a different code is not a remote rejection at all.
+  ASSERT_FALSE(IsNoSuchMethodError(STATUS(TimedOut, "no response (rpc error 2)")));
+}
 
 // Verify the "did you mean" help for a misspelled operation, none of which needs a running
 // cluster (the operation is checked before yb-admin connects to the master): prefix matches,

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -499,7 +499,7 @@ Status ClusterAdminCli::RunCommand(
     const Command& command, const CLIArguments& command_args, const std::string& program_name) {
   auto s = command.action_(command_args, client_.get());
   if (!s.ok()) {
-    if (s.IsRemoteError() && s.ToString().find("rpc error 2")) {
+    if (IsNoSuchMethodError(s)) {
       cerr << "The cluster doesn't support " << command.name_ << ": " << s << std::endl;
     } else {
       cerr << "Error running " << command.name_ << ": " << s << endl;

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -499,7 +499,7 @@ Status ClusterAdminCli::RunCommand(
     const Command& command, const CLIArguments& command_args, const std::string& program_name) {
   auto s = command.action_(command_args, client_.get());
   if (!s.ok()) {
-    if (IsNoSuchMethodError(s)) {
+    if (IsUnsupportedRpcError(s)) {
       cerr << "The cluster doesn't support " << command.name_ << ": " << s << std::endl;
     } else {
       cerr << "Error running " << command.name_ << ": " << s << endl;

--- a/src/yb/tools/yb-admin_util.cc
+++ b/src/yb/tools/yb-admin_util.cc
@@ -22,6 +22,7 @@
 #include "yb/util/logging.h"
 #include "yb/util/net/net_util.h"
 #include "yb/util/result.h"
+#include "yb/util/status.h"
 
 DEFINE_NON_RUNTIME_bool(yb_admin_force_use_private_ip, false,
     "Prefer the private RPC address over the broadcast address when a server has registered "
@@ -72,6 +73,15 @@ bool CompareListTabletServersEntries(
 }
 
 }  // namespace
+
+bool IsNoSuchMethodError(const Status& s) {
+  // ERROR_NO_SUCH_METHOD (rpc_header.proto) is rendered as "rpc error 2" by outbound_call's
+  // error category; the code is not carried structurally on Status, so the rendered text is
+  // the only thing to match. The npos comparison is the point: find() returns npos — truthy —
+  // on a miss, and treating it as a bool made every remote error look like a version mismatch
+  // (#33434).
+  return s.IsRemoteError() && s.ToString().find("rpc error 2") != std::string::npos;
+}
 
 string SnapshotIdToString(const SnapshotId& snapshot_id) {
   auto txn_snapshot_id = TryFullyDecodeTxnSnapshotId(snapshot_id);

--- a/src/yb/tools/yb-admin_util.cc
+++ b/src/yb/tools/yb-admin_util.cc
@@ -18,6 +18,8 @@
 #include "yb/common/snapshot.h"
 #include "yb/common/wire_protocol.h"
 
+#include "yb/rpc/outbound_call.h"
+
 #include "yb/util/flags.h"
 #include "yb/util/logging.h"
 #include "yb/util/net/net_util.h"
@@ -74,13 +76,19 @@ bool CompareListTabletServersEntries(
 
 }  // namespace
 
-bool IsNoSuchMethodError(const Status& s) {
-  // ERROR_NO_SUCH_METHOD (rpc_header.proto) is rendered as "rpc error 2" by outbound_call's
-  // error category; the code is not carried structurally on Status, so the rendered text is
-  // the only thing to match. The npos comparison is the point: find() returns npos — truthy —
-  // on a miss, and treating it as a bool made every remote error look like a version mismatch
-  // (#33434).
-  return s.IsRemoteError() && s.ToString().find("rpc error 2") != std::string::npos;
+bool IsUnsupportedRpcError(const Status& s) {
+  // Messenger::QueueInboundCall() answers a call it cannot route with ERROR_NO_SUCH_METHOD when the
+  // service is registered but the method is not, and ERROR_NO_SUCH_SERVICE when the service itself
+  // is absent. A cluster that predates the operation produces one or the other depending on whether
+  // the RPC was added to an existing service, so both carry the framing RunCommand() applies.
+  //
+  // Read the code off the Status rather than matching Status::ToString(): OutboundCall::SetFailed()
+  // attaches it with CloneAndAddErrorCode(RpcError(...)), which is how client.cc and
+  // client_master_rpc.cc test the same condition. A status with no rpc code decodes to 0, so it
+  // never matches.
+  const auto rpc_error = rpc::RpcError(s);
+  return rpc_error == rpc::ErrorStatusPB::ERROR_NO_SUCH_METHOD ||
+         rpc_error == rpc::ErrorStatusPB::ERROR_NO_SUCH_SERVICE;
 }
 
 string SnapshotIdToString(const SnapshotId& snapshot_id) {

--- a/src/yb/tools/yb-admin_util.h
+++ b/src/yb/tools/yb-admin_util.h
@@ -25,9 +25,10 @@
 namespace yb {
 namespace tools {
 
-// Returns true when a command failed because the server does not implement the requested RPC
-// (ERROR_NO_SUCH_METHOD) — i.e. the cluster predates the operation.
-bool IsNoSuchMethodError(const Status& s);
+// Returns true when a command failed because the cluster does not implement the requested RPC —
+// either the method (ERROR_NO_SUCH_METHOD) or the whole service (ERROR_NO_SUCH_SERVICE) is
+// unknown to it, i.e. the cluster predates the operation.
+bool IsUnsupportedRpcError(const Status& s);
 
 std::string SnapshotIdToString(const SnapshotId& snapshot_id);
 

--- a/src/yb/tools/yb-admin_util.h
+++ b/src/yb/tools/yb-admin_util.h
@@ -20,8 +20,14 @@
 #include "yb/master/master_client.pb.h"
 #include "yb/master/master_cluster.pb.h"
 
+#include "yb/util/status_fwd.h"
+
 namespace yb {
 namespace tools {
+
+// Returns true when a command failed because the server does not implement the requested RPC
+// (ERROR_NO_SUCH_METHOD) — i.e. the cluster predates the operation.
+bool IsNoSuchMethodError(const Status& s);
 
 std::string SnapshotIdToString(const SnapshotId& snapshot_id);
 


### PR DESCRIPTION
## Summary

`RunCommand()` decides whether to print `The cluster doesn't support <operation>` from the RPC error on the failing status — but the check was `find("rpc error 2")` used as a bool, and `npos` is truthy, so the branch fired for **every** `RemoteError`. A leader rejecting a call was reported as a version-compatibility problem, on the error path where a user is least able to second-guess the framing. Present since `10ef220697d` (2022).

The predicate moves to `yb-admin_util` as `IsUnsupportedRpcError()` and reads the RPC error code off the `Status` rather than matching `Status::ToString()`. `OutboundCall::SetFailed()` attaches it with `CloneAndAddErrorCode(RpcError(error_pb_->code()))`, which is how `client.cc:3237`/`:3261`, `client_master_rpc.cc:153` and `ysql_initdb_major_upgrade_handler.cc:116` already test this condition. A status with no rpc code decodes to 0 (`status_ec.h` `Decode(nullptr)` returns `Value()`), so it cannot false-positive.

It accepts **both** codes that mean the cluster could not route the call: `ERROR_NO_SUCH_METHOD` when the service is registered but the method is not, and `ERROR_NO_SUCH_SERVICE` when the service itself is absent (`messenger.cc:530-542`). An RPC added to an existing service produces the first; a whole new service produces the second. Matching only `NO_SUCH_METHOD` would have regressed the second case to `Error running <op>` — the pre-fix always-true branch covered it by accident.

The extraction is what makes it testable: `yb-admin_cli.cc` compiles only into the binary, while `yb-admin_util.cc` is in `yb-admin_lib`, which `yb-admin-test` links.

Fixes #33434.

---

Revised after review (thanks @yb-agentk-dev). The first revision kept the text match and deferred the structural check to follow-up; the review established that the code is available structurally and that the original comment claimed otherwise, contradicting #33434's own text. It also caught that the test hand-embedded `(rpc error 2)` in the message rather than attaching the code, so it never exercised the rendering it depended on, and that `ERROR_NO_SUCH_SERVICE` would have been dropped. All three are addressed in the second commit.

Previously opened as #33447, which was stacked on a three-PR chain and therefore showed all of it. This is the same fix against `master`.

**Landing order — this PR and #33470 overlap in 4 files.** Land #33469 first, then rebase #33470. `git merge-tree` on the current tips conflicts in `yb-admin_util.h`, `yb-admin_util.cc`, `yb-admin-test.cc` and `yb-admin_cli.cc`. Three of those are adjacent-insertion conflicts — each branch adds a different function, declaration, or test at the same spot — so the resolution is **keep both sides**.

The fourth is the one that matters. `yb-admin_cli.cc` in `RunCommand()`:

```cpp
// WRONG — taking either side wholesale drops a fix.
// Resolve to this:
if (s.IsRuntimeError() && s.message() == kErrorReported.message()) {
  // The action already wrote its complete report to stderr (e.g. help's suggestions for an
  // unknown operation); prefixing it with "Error running ..." would bury it.
  return s;
}
if (IsUnsupportedRpcError(s)) {
  cerr << "The cluster doesn't support " << command.name_ << ": " << s << std::endl;
```

Keep #33470's `kErrorReported` early return **and** #33469's `IsUnsupportedRpcError(s)` predicate, and drop #33470's stale `s.IsRemoteError() && s.ToString().find("rpc error 2")` line — that is the `npos` bug #33469 fixes, and it is only present in #33470 as untouched context.

## Test plan

Release build, macOS arm64 (clang21). No cluster needed — the predicate is pure.

- [x] `AdminCliTest.UnsupportedRpcErrorDetection`, with statuses built the way `SetFailed()` does, via `CloneAndAddErrorCode(rpc::RpcError(...))`:
  - `ERROR_NO_SUCH_METHOD` → true; `ERROR_NO_SUCH_SERVICE` → true
  - `ERROR_APPLICATION` → false (the regression this fixes)
  - `RemoteError` with no rpc code → false (pins the decode-to-0 behaviour)
  - non-remote status → false
  - a coded status still renders `(rpc error 2)` — documents what the old text match depended on, so a rendering change is caught rather than silently turning the predicate always-false
- [x] Full `tools_yb-admin-test` suite: **62/62 pass, 0 failures**.
- [x] `build-support/lint.sh --rev origin/master`: 0 errors.
- [x] Confirmed this branch carries only this fix: bare `yb-admin` still prints master's dump, `help` is still an invalid operation, and `list_server` still gets no token suggestions — no leakage from #33470.
- [ ] Full CI (in progress).

