### PR TITLE
[#33482] DocDB: Disable RobustLentObjectTest.TestCrash on macOS

### DIFF
--- a/src/yb/util/shmem/robust_lent_object-test.cc
+++ b/src/yb/util/shmem/robust_lent_object-test.cc
@@ -88,7 +88,8 @@ TEST_F(RobustLentObjectTest, TestPointerNotDestroyedEarly) {
   }));
 }
 
-TEST_F(RobustLentObjectTest, TestCrash) {
+// macOS has no PTHREAD_MUTEX_ROBUST, so the parent would block forever on the dead child's lock.
+TEST_F(RobustLentObjectTest, YB_DISABLE_TEST_ON_MACOS(TestCrash)) {
   std::optional<RobustLendGuard<int>> guard{ASSERT_RESULT(MakeAndLend(/*value=*/1234))};
 
   // Test that child process exiting with lock held doesn't block parent from destroying object.


### PR DESCRIPTION
## Summary

`RobustLentObjectTest.TestCrash` verifies that a process dying while holding a `RobustMutex` in shared memory does not block the lender: the child exits via `std::_Exit(0)` with the lock held, and the parent recovers it in `Revoke()` through the `EOWNERDEAD` path.

That path requires `PTHREAD_MUTEX_ROBUST`, which Darwin does not implement. `RobustMutexImpl` compiles the robustness attribute out on macOS and uses a plain process-shared mutex ("hope for the best", per the comment in `robust_mutex.h`), so the parent blocks forever on the dead child's lock and the test hangs until the harness timeout instead of failing.

The mechanism under test intentionally does not exist on macOS, so disable the test there with `YB_DISABLE_TEST_ON_MACOS`.

## Test plan

- [x] Verified the hang on macOS: parent blocked in `RobustLentObject::Revoke()` after the child exits with the lock held.
- [x] No change on Linux: `YB_DISABLE_TEST_ON_MACOS` expands to the bare test name there.
