### PR TITLE
[#33486] YSQL: Fix PgIndexBackfillBackendsManager.NoAbortTxn under table locks

### DIFF
--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -2836,20 +2836,21 @@ TEST_P(PgIndexBackfillBackendsManager, YB_DISABLE_TEST_IN_TSAN(NoAbortTxn)) {
   // Reset connection to eliminate cache/heartbeat-delay issues of indislive=t, indisready=t.
   conn_->Reset();
 
+  // With object locking, CREATE INDEX waits for existing lockers before requesting the backfill,
+  // so open the transaction only after that wait, paused just before the read time is picked.
+  ASSERT_OK(cluster_->SetFlagOnMasters("TEST_pause_compute_safe_time_for_backfill_read", "true"));
+  LogWaiter pause_log_waiter(
+      cluster_->GetLeaderMaster(),
+      "Pausing due to flag TEST_pause_compute_safe_time_for_backfill_read");
+  ASSERT_OK(cluster_->SetFlagOnTServers("ysql_yb_test_block_index_phase", "none"));
+  ASSERT_OK(pause_log_waiter.WaitFor(30s * kTimeMultiplier));
+
   LOG(INFO) << "Begin txn";
   ASSERT_OK(conn_->Execute("BEGIN"));
   ASSERT_OK(conn_->ExecuteFormat("UPDATE $0 SET j = 5 WHERE i = 3", kTableName));
-  ASSERT_OK(cluster_->SetFlagOnTServers("ysql_yb_test_block_index_phase", "none"));
-  if (EnableTableLocks()) {
-    // With object locking, CREATE INDEX waits for existing lockers (WaitForLockers) before
-    // choosing the backfill safe time, so the transaction must commit before the safe time
-    // can be established.
-    ASSERT_OK(conn_->Execute("COMMIT"));
-    ASSERT_OK(WaitForBackfillSafeTime(kYBTableName));
-  } else {
-    ASSERT_OK(WaitForBackfillSafeTime(kYBTableName));
-    ASSERT_OK(conn_->Execute("COMMIT"));
-  }
+  ASSERT_OK(cluster_->SetFlagOnMasters("TEST_pause_compute_safe_time_for_backfill_read", "false"));
+  ASSERT_OK(WaitForBackfillSafeTime(kYBTableName));
+  ASSERT_OK(conn_->Execute("COMMIT"));
   ASSERT_OK(cluster_->SetFlagOnMasters("TEST_block_do_backfill", "false"));
   thread_holder_.Stop();
 

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -2812,10 +2812,11 @@ INSTANTIATE_TEST_CASE_P(, PgIndexBackfillBackendsManager, ::testing::Bool());
 //   CREATE INDEX
 //   - indislive
 //   - indisready
+//   - backfill
+//     - get safe time for read (paused)
 //                                                BEGIN
 //                                                UPDATE a row of the indexed table
-//   - backfill
-//     - get safe time for read
+//     - get safe time for read (picked)
 //                                                COMMIT
 //     - do the actual backfill
 //   - indisvalid
@@ -2824,7 +2825,12 @@ TEST_P(PgIndexBackfillBackendsManager, YB_DISABLE_TEST_IN_TSAN(NoAbortTxn)) {
   ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (i int PRIMARY KEY, j int) SPLIT INTO 1 TABLETS",
                                  kTableName));
   ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (1, 2), (3, 4)", kTableName));
-  ASSERT_OK(cluster_->SetFlagOnTServers("ysql_yb_test_block_index_phase", "backfill"));
+
+  // Arm the pause before CREATE INDEX starts: the pause message is logged only once.
+  ASSERT_OK(cluster_->SetFlagOnMasters("TEST_pause_compute_safe_time_for_backfill_read", "true"));
+  LogWaiter pause_log_waiter(
+      cluster_->GetLeaderMaster(),
+      "Pausing due to flag TEST_pause_compute_safe_time_for_backfill_read");
 
   thread_holder_.AddThreadFunctor([this] {
     LOG(INFO) << "Begin create thread";
@@ -2838,11 +2844,6 @@ TEST_P(PgIndexBackfillBackendsManager, YB_DISABLE_TEST_IN_TSAN(NoAbortTxn)) {
 
   // With object locking, CREATE INDEX waits for existing lockers before requesting the backfill,
   // so open the transaction only after that wait, paused just before the read time is picked.
-  ASSERT_OK(cluster_->SetFlagOnMasters("TEST_pause_compute_safe_time_for_backfill_read", "true"));
-  LogWaiter pause_log_waiter(
-      cluster_->GetLeaderMaster(),
-      "Pausing due to flag TEST_pause_compute_safe_time_for_backfill_read");
-  ASSERT_OK(cluster_->SetFlagOnTServers("ysql_yb_test_block_index_phase", "none"));
   ASSERT_OK(pause_log_waiter.WaitFor(30s * kTimeMultiplier));
 
   LOG(INFO) << "Begin txn";

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -2840,8 +2840,16 @@ TEST_P(PgIndexBackfillBackendsManager, YB_DISABLE_TEST_IN_TSAN(NoAbortTxn)) {
   ASSERT_OK(conn_->Execute("BEGIN"));
   ASSERT_OK(conn_->ExecuteFormat("UPDATE $0 SET j = 5 WHERE i = 3", kTableName));
   ASSERT_OK(cluster_->SetFlagOnTServers("ysql_yb_test_block_index_phase", "none"));
-  ASSERT_OK(WaitForBackfillSafeTime(kYBTableName));
-  ASSERT_OK(conn_->Execute("COMMIT"));
+  if (EnableTableLocks()) {
+    // With object locking, CREATE INDEX waits for existing lockers (WaitForLockers) before
+    // choosing the backfill safe time, so the transaction must commit before the safe time
+    // can be established.
+    ASSERT_OK(conn_->Execute("COMMIT"));
+    ASSERT_OK(WaitForBackfillSafeTime(kYBTableName));
+  } else {
+    ASSERT_OK(WaitForBackfillSafeTime(kYBTableName));
+    ASSERT_OK(conn_->Execute("COMMIT"));
+  }
   ASSERT_OK(cluster_->SetFlagOnMasters("TEST_block_do_backfill", "false"));
   thread_holder_.Stop();
 


### PR DESCRIPTION
## Summary

With object locking enabled, `CREATE INDEX` waits for pre-existing lockers (`WaitForLockers`) between the `indisready` and backfill phases, so the backfill safe time cannot be established while the test's transaction still holds its ROW EXCLUSIVE lock. The test committed only after `WaitForBackfillSafeTime`, which deadlocks whenever the lock is visible to the wait. It passes on Linux today only because fastpath (shared-memory) locks are invisible to `WaitForConflictingLockers`' conflict scan.

Reorder the table-locks variant to commit before waiting for the backfill safe time; the non-table-locks variant keeps the original order.

## Test plan

- [x] `pg_index_backfill-test --gtest_filter 'PgIndexBackfillBackendsManager.NoAbortTxn/*'` passes on macOS arm64 (release), both variants.
- [x] On Linux, verified the old order deadlocks once the conflicting lock is visible to `WaitForLockers` (object lock fastpath disabled), and the reordered test passes.
