### PR TITLE
[DOC-1457] v2024.2.11.0-b36 release notes

### DIFF
--- a/docs/content/stable/releases/yba-releases/v2024.2.md
+++ b/docs/content/stable/releases/yba-releases/v2024.2.md
@@ -29,6 +29,32 @@ To migrate universe nodes to the new automated provisioning, you can follow the 
 
 Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywhere](/v2024.2/yugabyte-platform/upgrade/prepare-to-upgrade/).
 
+## v2024.2.11.0 - August 25, 2026 {#v2024.2.11.0}
+
+**Build:** `2024.2.11.0-b36`
+
+**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.11.0/yugabytedb-2024.2.11.0-b36-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.11.0/yugabytedb-anywhere-2024.2.11.0-b36-third-party-licenses.html)
+
+### Downloads
+
+{{< release-downloads version="2024.2.11.0" build="36" type="yba" >}}
+
+### Improvements
+
+#### Other
+
+* Rejects xCluster restarts when target tables are already in another replication to ensure replication consistency. PLAT-19929 
+
+### Bug fixes
+
+#### Other
+
+* Allows setting flags for DB upgrades in xCluster configurations by honoring `undefok`. PLAT-21411 
+* Simplifies the process of running the `sudo systemctl daemon-reload` command on non-sudo user-systemd nodes, preventing task failure and node stalling. PLAT-21468 
+* Updates Prometheus to version 3.13.1 addressing security issues including cross-site scripting in the UI and secure handling of HTTP clients' credentials, and upgrades PostgreSQL to version 14.23. PLAT-21546,PLAT-21720 
+* Adjusts universe table list column widths for better visibility and navigation. PLAT-21373 
+* Reverts `bootstrapParams` as a required field in Swagger docs for patch releases to avoid confusion. PLAT-21685 
+
 ## v2024.2.10.0 - July 9, 2026 {#v2024.2.10.0}
 
 **Build:** `2024.2.10.0-b62`

--- a/docs/content/stable/releases/yba-releases/v2024.2.md
+++ b/docs/content/stable/releases/yba-releases/v2024.2.md
@@ -41,13 +41,9 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 
 ### Improvements
 
-#### Other
-
 * Rejects xCluster restarts when target tables are already in another replication to ensure replication consistency. PLAT-19929 
 
 ### Bug fixes
-
-#### Other
 
 * Allows setting flags for DB upgrades in xCluster configurations by honoring `undefok`. PLAT-21411 
 * Simplifies the process of running the `sudo systemctl daemon-reload` command on non-sudo user-systemd nodes, preventing task failure and node stalling. PLAT-21468 

--- a/docs/content/stable/releases/ybdb-releases/v2024.2.md
+++ b/docs/content/stable/releases/ybdb-releases/v2024.2.md
@@ -23,6 +23,74 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 
 {{< /note >}}
 
+## v2024.2.11.0 - August 25, 2026 {#v2024.2.11.0}
+
+**Build:** `2024.2.11.0-b36`
+
+**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.11.0/yugabytedb-2024.2.11.0-b36-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.11.0/yugabytedb-anywhere-2024.2.11.0-b36-third-party-licenses.html)
+
+### Downloads
+
+{{< release-downloads version="2024.2.11.0" build="36" >}}
+
+### Improvements
+
+#### YSQL
+
+* Reduces YSQL connection timeout to about 90 seconds for faster detection of dead sockets. {{<issue 31638>}} 
+* Allows `ysql_catalog_preload_additional_table_list` to accept `pg_aggregate`, reducing cross-region round trips in aggregate queries. {{<issue 33237>}} 
+
+#### DocDB
+
+* Upgrades OpenSSL to version 3.5.7 and FIPS provider to 3.1.2. {{<issue 30735>}} 
+* Clarifies error messages for the `are_nodes_safe_to_take_down` command regarding quorum safety. {{<issue 31232>}} 
+
+### Bug fixes
+
+#### YSQL
+
+* Ensures consistent handling of NULL values in unique indexes with `yb_enable_inplace_index_update` flag adjustments. {{<issue 32220>}} 
+* Reduces initial query failures in new YSQL connections caused by negative cache. {{<issue 32971>}} 
+* Resolves crashes involving batched INSERT ...ON CONFLICT operations on unique indexes with INCLUDE columns. {{<issue 32223>}} 
+* Ensures `yb_index_check` works in single snapshot mode by using schema-qualified names. {{<issue 32141>}} 
+* Reduces memory spikes by preloading only the `pg_rewrite` list under minimal preload. {{<issue 32398>}} 
+* Fixes estimation of ybctid width and array bounds errors in Index Scan cost model. {{<issue 32517>}} 
+* Fixes inaccurate results by correctly including storage index filters in Bitmap Index Scan rechecks. {{<issue 32134>}} 
+* Fixes handling of NULL in AVG function to ensure proper index increment. {{<issue 32403>}} 
+* Allows support of OpenSSL 3.2 and above, addressing issues causing encryption tests to fail and catering to OpenSSL 3.0 going EOL in September. {{<issue 32829>}} 
+* Fixes `COPY FROM` to correctly check NOT NULL constraints for omitted columns. {{<issue 32473>}} 
+* Enhances index backfill reads to fail loudly with `Snapshot too old` instead of silently creating incorrect indexes. {{<issue 32560>}} 
+* Adjusts the PostgreSQL logic to prevent partial hash keys qualification, solving error issues on user queries in two specific scenarios: presence of a hash-code-search scan key and presence of a ybctid scan key. {{<issue 29079>}} 
+
+#### DocDB
+
+* Ensures consistency during simultaneous tablet splits and peer changes by retrying RBS attempts when conflicts occur. {{<issue 27056>}} 
+* Resolves race conditions between Remote Bootstrap and configuration changes, effectively managing the deletion of outdated tablet replicas. {{<issue 31930>}},{{<issue 31241>}} 
+* Adds percentage-based disk space checks for write operations. {{<issue 32200>}} 
+* Ensures removal of orphaned tablet replicas after recovery from a network partition. {{<issue 22212>}} 
+* Ensures failed tablet splits retry correctly, keeping tables usable. {{<issue 32438>}} 
+
+#### CDC
+
+* Advances CDC checkpoint when only aborted transactions exist at WAL end, preventing errors. {{<issue 32541>}} 
+* Ensures safe hybrid time in a GetChanges call remains unaltered during graceful shutdown of a tablet, preventing potential consistency issues in Virtual WAL. {{<issue 32847>}} 
+* Now deletes associated streams when a database is dropped to prevent errors. {{<issue 27835>}} 
+* Eliminates silent stalling in the slot by restoring loud failure when a walsender requests WAL operations whose segments were garbage collected and the TServer has been restarted since the garbage collection. {{<issue 33198>}} 
+
+#### Other
+
+* Reduces false CI failures and unintended behaviour by preventing the pr-title workflow from executing PR body as shell code, thus improving its stability. {{<issue 33169>}} 
+
+### Other
+
+#### YSQL
+
+* Prevents deletion of newly created databases due to stale heartbeat cache. {{<issue 32457>}} 
+
+#### DocDB
+
+* Ensures transaction promotions are properly persisted, preventing data loss during peer restarts with the `enable_transaction_metadata_update` flag. {{<issue 32520>}} 
+
 ## v2024.2.10.0 - July 9, 2026 {#v2024.2.10.0}
 
 **Build:** `2024.2.10.0-b62`

--- a/docs/content/stable/releases/ybdb-releases/v2024.2.md
+++ b/docs/content/stable/releases/ybdb-releases/v2024.2.md
@@ -58,6 +58,7 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 * Fixes inaccurate results by correctly including storage index filters in Bitmap Index Scan rechecks. {{<issue 32134>}} 
 * Fixes handling of NULL in AVG function to ensure proper index increment. {{<issue 32403>}} 
 * Allows support of OpenSSL 3.2 and above, addressing issues causing encryption tests to fail and catering to OpenSSL 3.0 going EOL in September. {{<issue 32829>}} 
+* Prevents deletion of newly created databases due to stale heartbeat cache. {{<issue 32457>}} 
 * Fixes `COPY FROM` to correctly check NOT NULL constraints for omitted columns. {{<issue 32473>}} 
 * Enhances index backfill reads to fail loudly with `Snapshot too old` instead of silently creating incorrect indexes. {{<issue 32560>}} 
 * Adjusts the PostgreSQL logic to prevent partial hash keys qualification, solving error issues on user queries in two specific scenarios: presence of a hash-code-search scan key and presence of a ybctid scan key. {{<issue 29079>}} 
@@ -69,6 +70,7 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 * Adds percentage-based disk space checks for write operations. {{<issue 32200>}} 
 * Ensures removal of orphaned tablet replicas after recovery from a network partition. {{<issue 22212>}} 
 * Ensures failed tablet splits retry correctly, keeping tables usable. {{<issue 32438>}} 
+* Ensures transaction promotions are properly persisted, preventing data loss during peer restarts with the `enable_transaction_metadata_update` flag. {{<issue 32520>}} 
 
 #### CDC
 
@@ -80,16 +82,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 #### Other
 
 * Reduces false CI failures and unintended behaviour by preventing the pr-title workflow from executing PR body as shell code, thus improving its stability. {{<issue 33169>}} 
-
-### Other
-
-#### YSQL
-
-* Prevents deletion of newly created databases due to stale heartbeat cache. {{<issue 32457>}} 
-
-#### DocDB
-
-* Ensures transaction promotions are properly persisted, preventing data loss during peer restarts with the `enable_transaction_metadata_update` flag. {{<issue 32520>}} 
 
 ## v2024.2.10.0 - July 9, 2026 {#v2024.2.10.0}
 

--- a/docs/content/stable/releases/ybdb-releases/v2024.2.md
+++ b/docs/content/stable/releases/ybdb-releases/v2024.2.md
@@ -79,10 +79,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 * Now deletes associated streams when a database is dropped to prevent errors. {{<issue 27835>}} 
 * Eliminates silent stalling in the slot by restoring loud failure when a walsender requests WAL operations whose segments were garbage collected and the TServer has been restarted since the garbage collection. {{<issue 33198>}} 
 
-#### Other
-
-* Reduces false CI failures and unintended behaviour by preventing the pr-title workflow from executing PR body as shell code, thus improving its stability. {{<issue 33169>}} 
-
 ## v2024.2.10.0 - July 9, 2026 {#v2024.2.10.0}
 
 **Build:** `2024.2.10.0-b62`

--- a/docs/data/currentVersions.json
+++ b/docs/data/currentVersions.json
@@ -41,9 +41,9 @@
     {
       "series": "v2024.2",
       "display": "v2024.2 (LTS)",
-      "version": "2024.2.10.0",
-      "versionShort": "2024.2.10",
-      "appVersion": "2024.2.10.0-b62",
+      "version": "2024.2.11.0",
+      "versionShort": "2024.2.11",
+      "appVersion": "2024.2.11.0-b36",
       "isStable": true,
       "isLTS": true,
       "initialRelease": "2024-12-09",


### PR DESCRIPTION
----
## Summary by Gitar

- **Documentation:**
    - Added release notes for `v2024.2.11.0-b36` covering YugabyteDB and YugabyteDB Anywhere changes
    - Updated `currentVersions.json` to point to version `2024.2.11.0` as the latest stable release

<sub>This will update automatically on new commits.</sub>