### PR TITLE
[#33503] DocDB: Fix DiskFullTest on hosts with more than 10TB of free disk space

### DIFF
--- a/src/yb/integration-tests/disk_full-test.cc
+++ b/src/yb/integration-tests/disk_full-test.cc
@@ -18,6 +18,8 @@
 
 #include "yb/server/clock.h"
 
+#include "yb/util/size_literals.h"
+
 DECLARE_uint64(reject_writes_min_disk_space_mb);
 DECLARE_uint32(reject_writes_min_disk_space_pct);
 DECLARE_uint32(reject_writes_min_disk_space_check_interval_sec);
@@ -51,8 +53,10 @@ TEST_F(YCqlDiskFullTest, YB_DISABLE_TEST_IN_ASAN(TestDiskFull)) {
   }
   ++i;
 
-  // Set a large limit to simulate disk full.
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_reject_writes_min_disk_space_mb) = 10 * 1024 * 1024;  // 10TB
+  // Set a limit above the actual free space to simulate disk full.
+  const auto free_space_mb =
+      ASSERT_RESULT(Env::Default()->GetFreeSpaceBytes(GetTestDataDirectory())) / 1_MB;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_reject_writes_min_disk_space_mb) = free_space_mb * 2;
   SleepFor(2s);
 
   ASSERT_NOK_STR_CONTAINS(WriteRow(session, i, i), "has insufficient disk space");
@@ -122,8 +126,10 @@ TEST_F(YSqlDiskFullTest, YB_DISABLE_TEST_IN_ASAN(TestDiskFull)) {
   }
   ++i;
 
-  // Set a large limit to simulate disk full.
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_reject_writes_min_disk_space_mb) = 10 * 1024 * 1024;  // 10TB
+  // Set a limit above the actual free space to simulate disk full.
+  const auto free_space_mb =
+      ASSERT_RESULT(Env::Default()->GetFreeSpaceBytes(GetTestDataDirectory())) / 1_MB;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_reject_writes_min_disk_space_mb) = free_space_mb * 2;
   SleepFor(2s);
 
   ASSERT_NOK_STR_CONTAINS(

--- a/src/yb/integration-tests/disk_full-test.cc
+++ b/src/yb/integration-tests/disk_full-test.cc
@@ -26,20 +26,20 @@ DECLARE_uint32(reject_writes_min_disk_space_check_interval_sec);
 
 namespace yb {
 
-template <class Base>
-class DiskFullTestBase : public Base {
- protected:
-  // Sets reject_writes_min_disk_space_mb above the actual free space to simulate disk full.
-  void SimulateDiskFull() {
-    const auto free_space_mb =
-        ASSERT_RESULT(Env::Default()->GetFreeSpaceBytes(GetTestDataDirectory())) / 1_MB;
-    ANNOTATE_UNPROTECTED_WRITE(FLAGS_reject_writes_min_disk_space_mb) =
-        std::max<uint64_t>(free_space_mb * 2, 1);
-    SleepFor(2s);
-  }
-};
+namespace {
 
-class YCqlDiskFullTest : public DiskFullTestBase<client::KeyValueTableTest<MiniCluster>> {
+// Sets reject_writes_min_disk_space_mb above the actual free space to simulate disk full.
+void SimulateDiskFull() {
+  const auto free_space_mb =
+      ASSERT_RESULT(Env::Default()->GetFreeSpaceBytes(GetTestDataDirectory())) / 1_MB;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_reject_writes_min_disk_space_mb) =
+      std::max<uint64_t>(free_space_mb * 2, 1);
+  SleepFor(2s);
+}
+
+}  // namespace
+
+class YCqlDiskFullTest : public client::KeyValueTableTest<MiniCluster> {
  public:
   YCqlDiskFullTest() = default;
 
@@ -107,7 +107,7 @@ TEST_F(YCqlDiskFullTest, YB_DISABLE_TEST_IN_ASAN(TestDiskFullPercentage)) {
   ASSERT_OK(WriteRow(session, i, i));
 }
 
-class YSqlDiskFullTest : public DiskFullTestBase<pgwrapper::PgMiniTestBase> {
+class YSqlDiskFullTest : public pgwrapper::PgMiniTestBase {
  public:
   YSqlDiskFullTest() = default;
 

--- a/src/yb/integration-tests/disk_full-test.cc
+++ b/src/yb/integration-tests/disk_full-test.cc
@@ -26,7 +26,20 @@ DECLARE_uint32(reject_writes_min_disk_space_check_interval_sec);
 
 namespace yb {
 
-class YCqlDiskFullTest : public client::KeyValueTableTest<MiniCluster> {
+template <class Base>
+class DiskFullTestBase : public Base {
+ protected:
+  // Sets reject_writes_min_disk_space_mb above the actual free space to simulate disk full.
+  void SimulateDiskFull() {
+    const auto free_space_mb =
+        ASSERT_RESULT(Env::Default()->GetFreeSpaceBytes(GetTestDataDirectory())) / 1_MB;
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_reject_writes_min_disk_space_mb) =
+        std::max<uint64_t>(free_space_mb * 2, 1);
+    SleepFor(2s);
+  }
+};
+
+class YCqlDiskFullTest : public DiskFullTestBase<client::KeyValueTableTest<MiniCluster>> {
  public:
   YCqlDiskFullTest() = default;
 
@@ -53,11 +66,7 @@ TEST_F(YCqlDiskFullTest, YB_DISABLE_TEST_IN_ASAN(TestDiskFull)) {
   }
   ++i;
 
-  // Set a limit above the actual free space to simulate disk full.
-  const auto free_space_mb =
-      ASSERT_RESULT(Env::Default()->GetFreeSpaceBytes(GetTestDataDirectory())) / 1_MB;
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_reject_writes_min_disk_space_mb) = free_space_mb * 2;
-  SleepFor(2s);
+  ASSERT_NO_FATALS(SimulateDiskFull());
 
   ASSERT_NOK_STR_CONTAINS(WriteRow(session, i, i), "has insufficient disk space");
 
@@ -98,7 +107,7 @@ TEST_F(YCqlDiskFullTest, YB_DISABLE_TEST_IN_ASAN(TestDiskFullPercentage)) {
   ASSERT_OK(WriteRow(session, i, i));
 }
 
-class YSqlDiskFullTest : public pgwrapper::PgMiniTestBase {
+class YSqlDiskFullTest : public DiskFullTestBase<pgwrapper::PgMiniTestBase> {
  public:
   YSqlDiskFullTest() = default;
 
@@ -126,11 +135,7 @@ TEST_F(YSqlDiskFullTest, YB_DISABLE_TEST_IN_ASAN(TestDiskFull)) {
   }
   ++i;
 
-  // Set a limit above the actual free space to simulate disk full.
-  const auto free_space_mb =
-      ASSERT_RESULT(Env::Default()->GetFreeSpaceBytes(GetTestDataDirectory())) / 1_MB;
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_reject_writes_min_disk_space_mb) = free_space_mb * 2;
-  SleepFor(2s);
+  ASSERT_NO_FATALS(SimulateDiskFull());
 
   ASSERT_NOK_STR_CONTAINS(
       conn.ExecuteFormat(insert_query, table_name1, i), "has insufficient disk space");


### PR DESCRIPTION
## Summary

Both TestDiskFull cases fail on machines with more than 10TB of free disk space: they simulate a full disk by hardcoding `reject_writes_min_disk_space_mb` to 10TB, so on bigger disks the write is not rejected. Derive the threshold from the test filesystem's actual free space (doubled for margin) instead.

## Test plan

- [x] `disk_full-test` passes on a Linux host with ~14TB free on the test filesystem (release build); both TestDiskFull cases failed there before this change.
