### PR TITLE
[#33506] DocDB: Preflush snapshots before Raft submission

### DIFF
--- a/architecture/design/snapshot-preflush.md
+++ b/architecture/design/snapshot-preflush.md
@@ -1,0 +1,54 @@
+# Snapshot preflush
+
+`--snapshot_create_flush_before_submit=true` makes the tablet leader flush its captured replica
+set before submitting `CREATE_ON_TABLET`. It is disabled by default because requiring every
+replica changes snapshot availability: a healthy write quorum is insufficient if another replica
+cannot finish its flush.
+
+The leader pins snapshot history, resolves intents, captures the active Raft configuration, and
+launches local flushing and follower `FlushTablets` RPCs concurrently. A bounded orchestration
+pool waits for completion; flush I/O uses a separate bounded executor. Neither the preparer nor
+`UpdateConsensus` waits for preflight. Writes and replication can continue, subject to normal
+storage contention and write stalls.
+
+Before submission, the leader rechecks its term, membership, and deadline. A failed attempt is
+returned to the master for retry. Errors from a missing follower tablet are not reported as if
+the leader's target tablet disappeared. There is no fallback that submits despite a failed flush.
+The history guard stays alive through submission and is released when an attempt fails.
+
+## Limits
+
+| Flag | Default | Scope |
+| --- | --- | --- |
+| `snapshot_create_flush_before_submit` | `false` | Runtime; enables preflight on the leader |
+| `snapshot_preflush_timeout_ms` | `10000` | Runtime; capped by the snapshot RPC deadline |
+| `snapshot_preflush_concurrency` | `4` | Startup; admitted preflights per server |
+| `tablet_flush_concurrency` | `4` | Startup; admitted admin/local flush jobs per server |
+
+Admission is non-waiting and excludes overlapping work for the same tablet. Overload is a
+retryable error. An RPC timeout does not stop a physical flush: receiver admission remains held
+until the job finishes, and late completions cannot submit an expired snapshot attempt. Partial
+failures stop further launches but retain the batch's reservations until already-started work and
+RocksDB flush-job cleanup retire. The first error and its tablet ID survive this draining phase.
+
+A terminal vector failure fails dependent intents flushes without bypassing durability ordering.
+Storage filter errors make the affected RocksDB read-only, even with paranoid checks disabled.
+These error paths also apply to ordinary admin flushing when snapshot preflight is disabled.
+
+Preflight completion does not establish a common flushed OpId or exclude later writes, replica
+restarts, or membership changes. `TabletSnapshots::Create()` retains its synchronous all-DB flush
+for correctness. A lagging follower or a busy tablet can still have significant apply-time work.
+
+## Observation and rollback
+
+`snapshot_preflush_duration_us` measures the preflight separately from apply-time
+`Snapshot_WaitingForFlush`. The `snapshot_preflush_active`, `snapshot_preflush_failures`,
+`snapshot_preflush_timeouts`, and `snapshot_preflush_rejections` metrics expose admission and
+failure behavior. `tablet_flush_active` counts admitted receiver jobs, including failed jobs still
+draining; `tablet_flush_pool` metrics expose worker queue and run time. A job can contain multiple
+tablets and storage flushes, so occupancy is not a count of all physical RocksDB flushes.
+
+Disable the feature flag to return to direct snapshot submission and the final synchronous flush.
+There are no new wire fields, Raft entry types, or on-disk formats. In mixed-version deployments,
+only leaders supporting and enabling the flag orchestrate preflight. Supported older followers
+use the existing admin flush RPC; mixed versions do not provide a cluster-wide latency guarantee.

--- a/src/yb/ann_methods/vector_lsm-test.cc
+++ b/src/yb/ann_methods/vector_lsm-test.cc
@@ -33,6 +33,7 @@
 #include "yb/util/size_literals.h"
 #include "yb/util/status_format.h"
 #include "yb/util/sync_point.h"
+#include "yb/util/test_thread_holder.h"
 #include "yb/util/test_util.h"
 #include "yb/util/thread_holder.h"
 #include "yb/util/tsan_util.h"
@@ -45,6 +46,7 @@
 using namespace std::literals;
 using namespace yb::size_literals;
 
+DECLARE_bool(TEST_enable_sync_points);
 DECLARE_bool(TEST_vector_index_exact);
 DECLARE_bool(TEST_vector_index_skip_manifest_update_during_shutdown);
 DECLARE_bool(vector_index_enable_compactions);
@@ -280,6 +282,9 @@ class VectorLSMTest
   vector_index::StoreVectorPayload store_vector_payload() const {
     return StorePayload(GetParam());
   }
+
+  void TestFlushRetirement(bool fail);
+  void TestOutOfOrderFlush(bool fail);
 
   void TestBootstrap(bool flush);
 
@@ -691,6 +696,183 @@ MergeFilterPtr VectorLSMTest::GetMergeFilter() {
 void VectorLSMTest::SetMergeFilter(MergeFilterPtr&& filter) {
   std::lock_guard lock(merge_filter_mutex_);
   merge_filter_ = std::move(filter);
+}
+
+void VectorLSMTest::TestFlushRetirement(bool fail) {
+  Status status;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_enable_sync_points) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_enable_compactions) = false;
+  FloatVectorLSM lsm;
+  ASSERT_OK(OpenVectorLSM(lsm, 4, 1000));
+  ASSERT_OK(InsertRandom(lsm, 4, 8));
+  ASSERT_OK(WaitForBackgroundInsertsDone(lsm));
+  CountDownLatch retiring(1), release(1), completed(1);
+  auto* sync = SyncPoint::GetInstance();
+  if (fail) {
+    sync->SetCallBack("VectorLSM::DoSaveChunk:Status", [](void* arg) {
+      *static_cast<Status*>(arg) = STATUS(IOError, "injected vector save failure");
+    });
+  }
+  sync->SetCallBack("VectorLSM::SaveChunk:BeforeRetirement", [&](void* arg) {
+    if (arg == &lsm) {
+      retiring.CountDown();
+      release.Wait();
+    }
+  });
+  sync->EnableProcessing();
+  TestThreadHolder threads;
+  auto cleanup = ScopeExit([&] {
+    release.CountDown();
+    threads.JoinAll();
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  ASSERT_OK(lsm.Flush(/* wait = */ false));
+  ASSERT_TRUE(retiring.WaitFor(5s));
+  threads.AddThreadFunctor([&] {
+    status = lsm.WaitForFlush();
+    completed.CountDown();
+  });
+  ASSERT_FALSE(completed.WaitFor(20ms));
+  release.CountDown();
+  ASSERT_TRUE(completed.WaitFor(5s));
+  threads.JoinAll();
+  if (fail) {
+    ASSERT_TRUE(status.IsIOError()) << status;
+    ASSERT_TRUE(lsm.Flush(false).IsIOError());
+    ASSERT_TRUE(InsertRandom(lsm, 4, 1).IsIOError());
+    ASSERT_TRUE(lsm.WaitForFlush().IsIOError());
+  } else {
+    ASSERT_OK(status);
+  }
+}
+
+TEST_P(VectorLSMTest, FlushWaitsForRetirement) {
+  TestFlushRetirement(false);
+}
+
+TEST_P(VectorLSMTest, FlushErrorWaitsForRetirement) {
+  TestFlushRetirement(true);
+}
+
+void VectorLSMTest::TestOutOfOrderFlush(bool fail) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_enable_sync_points) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_enable_compactions) = false;
+  FloatVectorLSM lsm;
+  ASSERT_OK(OpenVectorLSM(lsm, 4, 1000));
+  ASSERT_OK(InsertRandom(lsm, 4, 8));
+  ASSERT_OK(WaitForBackgroundInsertsDone(lsm));
+
+  CountDownLatch first_saving(1), release_first(1), completed(1);
+  std::atomic<size_t> saves{0};
+  Status status;
+  auto* sync = SyncPoint::GetInstance();
+  sync->SetCallBack("VectorLSM::DoSaveChunk:Status", [&](void* arg) {
+    if (saves.fetch_add(1) == 0) {
+      first_saving.CountDown();
+      release_first.Wait();
+      if (fail) {
+        *static_cast<Status*>(arg) = STATUS(IOError, "injected earlier chunk failure");
+      }
+    }
+  });
+  sync->EnableProcessing();
+  TestThreadHolder threads;
+  auto cleanup = ScopeExit([&] {
+    release_first.CountDown();
+    threads.JoinAll();
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  ASSERT_OK(lsm.Flush(/* wait = */ false));
+  ASSERT_TRUE(first_saving.WaitFor(5s * kTimeMultiplier));
+  ASSERT_OK(lsm.GetFlushStatus());
+  ASSERT_OK(InsertRandom(lsm, 4, 8));
+  ASSERT_OK(WaitForBackgroundInsertsDone(lsm));
+  threads.AddThreadFunctor([&] {
+    status = lsm.Flush(/* wait = */ true);
+    completed.CountDown();
+  });
+  // B has saved and retired, but cannot enter the manifest ahead of A. No B task remains to
+  // discover A's eventual failure and complete B's synchronous promise.
+  ASSERT_OK(WaitFor([&] {
+    return lsm.NumSavedImmutableChunks() == 1 && lsm.TEST_PendingSaveTasks() == 1;
+  }, 5s * kTimeMultiplier, "later save task retired"));
+  ASSERT_FALSE(completed.WaitFor(20ms));
+  release_first.CountDown();
+  ASSERT_TRUE(completed.WaitFor(5s * kTimeMultiplier));
+  threads.JoinAll();
+  if (fail) {
+    ASSERT_TRUE(status.IsIOError()) << status;
+    ASSERT_TRUE(lsm.GetFlushStatus().IsIOError());
+    ASSERT_TRUE(lsm.WaitForFlush().IsIOError());
+  } else {
+    ASSERT_OK(status);
+    ASSERT_OK(lsm.GetFlushStatus());
+    ASSERT_OK(lsm.WaitForFlush());
+  }
+}
+
+TEST_P(VectorLSMTest, OutOfOrderSynchronousFlush) {
+  TestOutOfOrderFlush(false);
+}
+
+TEST_P(VectorLSMTest, EarlierFailureCompletesSynchronousFlush) {
+  TestOutOfOrderFlush(true);
+}
+
+TEST_P(VectorLSMTest, ManifestFailureReleasesCompactionWaiter) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_enable_sync_points) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_enable_compactions) = false;
+  FloatVectorLSM lsm;
+  ASSERT_OK(OpenVectorLSM(lsm, 4, 1000));
+  for (size_t i = 0; i != 2; ++i) {
+    ASSERT_OK(InsertRandomAndFlush(lsm, 4, 8));
+  }
+  ASSERT_OK(InsertRandom(lsm, 4, 8));
+  ASSERT_OK(WaitForBackgroundInsertsDone(lsm));
+  CountDownLatch writing(1), release(1), waiting(1), completed(1), shutdown_done(1);
+  Status status;
+  auto* sync = SyncPoint::GetInstance();
+  sync->SetCallBack("VectorLSM::AddChunkToManifest:Status", [&](void* arg) {
+    writing.CountDown();
+    release.Wait();
+    *static_cast<Status*>(arg) = STATUS(IOError, "injected manifest failure");
+  });
+  sync->SetCallBack("VectorLSM::AcquireManifest:Waiting", [&](void* arg) {
+    if (arg == &lsm) {
+      waiting.CountDown();
+    }
+  });
+  sync->EnableProcessing();
+  TestThreadHolder threads;
+  auto cleanup = ScopeExit([&] {
+    release.CountDown();
+    threads.JoinAll();
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  ASSERT_OK(lsm.Flush(/* wait = */ false));
+  ASSERT_TRUE(writing.WaitFor(5s * kTimeMultiplier));
+  threads.AddThreadFunctor([&] {
+    status = lsm.Compact(/* wait = */ true);
+    completed.CountDown();
+  });
+  ASSERT_TRUE(waiting.WaitFor(5s * kTimeMultiplier));
+  ASSERT_FALSE(completed.WaitFor(20ms));
+  release.CountDown();
+  ASSERT_TRUE(completed.WaitFor(5s * kTimeMultiplier));
+  threads.JoinAll();
+  ASSERT_TRUE(status.IsIOError()) << status;
+  ASSERT_TRUE(lsm.WaitForFlush().IsIOError());
+  ASSERT_TRUE(lsm.Compact(/* wait = */ true).IsIOError());
+  threads.AddThreadFunctor([&] {
+    lsm.StartShutdown();
+    lsm.CompleteShutdown();
+    shutdown_done.CountDown();
+  });
+  ASSERT_TRUE(shutdown_done.WaitFor(5s * kTimeMultiplier));
+  threads.JoinAll();
 }
 
 TEST_P(VectorLSMTest, Simple) {

--- a/src/yb/docdb/doc_vector_index.cc
+++ b/src/yb/docdb/doc_vector_index.cc
@@ -435,6 +435,10 @@ class DocVectorIndexImpl : public DocVectorIndex {
       return lsm_.GetFlushAbility();
   }
 
+  Status GetFlushStatus() const override {
+    return lsm_.GetFlushStatus();
+  }
+
   Status CreateCheckpoint(const std::string& out) override {
     return lsm_.CreateCheckpoint(out);
   }

--- a/src/yb/docdb/doc_vector_index.h
+++ b/src/yb/docdb/doc_vector_index.h
@@ -163,6 +163,9 @@ class DocVectorIndex {
   storage::UserFrontierPtr GetInMemoryFrontier(storage::UpdateUserValueType type);
 
   virtual storage::FlushAbility GetFlushAbility() = 0;
+
+  // Returns terminal failure without waiting for in-flight saves.
+  virtual Status GetFlushStatus() const = 0;
   virtual Status CreateCheckpoint(const std::string& out) = 0;
   virtual const std::string& ToString() const = 0;
   virtual Result<bool> HasVectorId(const vector_index::VectorId& vector_id) const = 0;

--- a/src/yb/docdb/non_transactional_batch_writer-test.cc
+++ b/src/yb/docdb/non_transactional_batch_writer-test.cc
@@ -73,6 +73,7 @@ class CountingVectorIndex : public DocVectorIndex {
     LOG(FATAL) << "Unexpected call";
   }
   storage::FlushAbility GetFlushAbility() override { LOG(FATAL) << "Unexpected call"; }
+  Status GetFlushStatus() const override { LOG(FATAL) << "Unexpected call"; }
   Status CreateCheckpoint(const std::string&) override { LOG(FATAL) << "Unexpected call"; }
   const std::string& ToString() const override { LOG(FATAL) << "Unexpected call"; }
   Result<bool> HasVectorId(const vector_index::VectorId&) const override {

--- a/src/yb/integration-tests/snapshot-test.cc
+++ b/src/yb/integration-tests/snapshot-test.cc
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <future>
 
 #include <gtest/gtest.h>
 
@@ -23,6 +24,7 @@
 #include "yb/common/wire_protocol.h"
 
 #include "yb/consensus/consensus.h"
+#include "yb/consensus/consensus.pb.h"
 
 #include "yb/integration-tests/cluster_itest_util.h"
 #include "yb/integration-tests/cluster_verifier.h"
@@ -54,21 +56,30 @@
 
 #include "yb/tools/yb-admin_util.h"
 
+#include "yb/tserver/backup.proxy.h"
 #include "yb/tserver/mini_tablet_server.h"
 #include "yb/tserver/tablet_server.h"
 #include "yb/tserver/ts_tablet_manager.h"
+#include "yb/tserver/tserver_admin.proxy.h"
 
 #include "yb/util/backoff_waiter.h"
 #include "yb/util/cast.h"
+#include "yb/util/countdown_latch.h"
 #include "yb/util/pb_util.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/status_format.h"
+#include "yb/util/sync_point.h"
 #include "yb/util/test_thread_holder.h"
 
 using namespace std::literals;
 
+DECLARE_bool(TEST_enable_remote_bootstrap);
 DECLARE_bool(enable_async_snapshot_directory_cleanup);
+DECLARE_bool(enable_load_balancing);
 DECLARE_bool(enable_ysql);
+DECLARE_bool(snapshot_create_flush_before_submit);
+DECLARE_bool(TEST_enable_sync_points);
+DECLARE_int32(snapshot_preflush_timeout_ms);
 DECLARE_uint64(log_segment_size_bytes);
 DECLARE_int32(log_min_seconds_to_retain);
 DECLARE_uint64(snapshot_coordinator_cleanup_delay_ms);
@@ -201,6 +212,22 @@ class SnapshotTest : public SnapshotTestBase<MiniCluster> {
     controller_.Reset();
     controller_.set_timeout(10s);
     return &controller_;
+  }
+
+  Result<tserver::TabletSnapshotOpResponsePB> CreateTabletSnapshot(
+      MiniTabletServer* leader, const TabletId& tablet_id, const TxnSnapshotId& snapshot_id) {
+    tserver::TabletSnapshotOpRequestPB request;
+    request.set_dest_uuid(leader->server()->permanent_uuid());
+    request.set_operation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET);
+    request.add_tablet_id(tablet_id);
+    request.set_snapshot_id(snapshot_id.AsSlice().ToBuffer());
+    tserver::TabletSnapshotOpResponsePB response;
+    tserver::TabletServerBackupServiceProxy proxy(
+        &client_->proxy_cache(), HostPort::FromBoundEndpoint(leader->bound_rpc_addr()));
+    RpcController controller;
+    controller.set_timeout(10s);
+    RETURN_NOT_OK(proxy.TabletSnapshotOp(request, &response, &controller));
+    return response;
   }
 
   Status CheckAllSnapshots(
@@ -573,6 +600,219 @@ TEST_F(SnapshotTest, CreateSnapshot) {
   ASSERT_NO_FATALS(VerifySnapshotFiles(snapshot_id));
 
   ASSERT_OK(cluster_->RestartSync());
+}
+
+TEST_F(SnapshotTest, PreflushDoesNotBlockReplication) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_create_flush_before_submit) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_preflush_timeout_ms) = 20000;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_enable_sync_points) = true;
+  auto workload = CreateDefaultWorkload();
+  workload.set_num_tablets(1);
+  workload.Setup();
+  auto peers = ASSERT_RESULT(ListTabletPeersForTableName(cluster_.get(), kTableName.table_name()));
+  ASSERT_EQ(peers.size(), 3);
+  const auto tablet_id = peers.front()->tablet_id();
+  auto last_tablet = ASSERT_RESULT(peers.back()->shared_tablet());
+  CountDownLatch flushed(3), release_others(1), release_last(1), others_released(2);
+  std::atomic<bool> submitted{false};
+  auto* sync = SyncPoint::GetInstance();
+  sync->SetCallBack("TabletFlusher::Flushed", [&](void* arg) {
+    auto* tablet = static_cast<tablet::Tablet*>(arg);
+    if (tablet->tablet_id() != tablet_id) {
+      return;
+    }
+    flushed.CountDown();
+    if (tablet == last_tablet.get()) {
+      release_last.Wait();
+    } else {
+      release_others.Wait();
+      others_released.CountDown();
+    }
+  });
+  sync->SetCallBack("SnapshotPreflush::BeforeSubmit", [&](void*) {
+    submitted.store(true, std::memory_order_release);
+  });
+  sync->EnableProcessing();
+  TestThreadHolder threads;
+  auto cleanup = ScopeExit([&] {
+    release_others.CountDown();
+    release_last.CountDown();
+    workload.StopAndJoin();
+    threads.JoinAll();
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  TxnSnapshotId snapshot_id;
+  threads.AddThreadFunctor([&] { snapshot_id = CreateSnapshot(); });
+  ASSERT_TRUE(flushed.WaitFor(10s));
+  ASSERT_FALSE(submitted.load(std::memory_order_acquire));
+  std::vector<int64_t> applied_before;
+  for (const auto& peer : peers) {
+    applied_before.push_back(ASSERT_RESULT(peer->GetConsensus())->GetLastAppliedOpId().index);
+  }
+  // Hold completion after the physical flush, so this tests replication independence rather
+  // than how many writes RocksDB can buffer with its disk progress artificially stopped.
+  workload.Start();
+  workload.WaitInserted(100);
+  workload.StopAndJoin();
+  for (size_t i = 0; i != peers.size(); ++i) {
+    auto consensus = ASSERT_RESULT(peers[i]->GetConsensus());
+    ASSERT_OK(WaitFor([&] {
+      return consensus->GetLastAppliedOpId().index > applied_before[i];
+    }, 5s, "Replica applies writes during snapshot preflight"));
+  }
+  release_others.CountDown();
+  ASSERT_TRUE(others_released.WaitFor(5s));
+  ASSERT_FALSE(submitted.load(std::memory_order_acquire));
+  release_last.CountDown();
+  threads.JoinAll();
+  ASSERT_TRUE(submitted.load(std::memory_order_acquire));
+  ASSERT_NO_FATALS(VerifySnapshotFiles(snapshot_id));
+}
+
+TEST_F(SnapshotTest, UnavailablePreflushReplicaDoesNotBlockQuorumWrites) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_create_flush_before_submit) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_preflush_timeout_ms) = 1000;
+  auto workload = CreateDefaultWorkload();
+  workload.set_num_tablets(1);
+  workload.Setup();
+  const auto peers = ASSERT_RESULT(
+      ListTabletPeersForTableName(cluster_.get(), kTableName.table_name()));
+  ASSERT_EQ(peers.size(), 3);
+  const auto tablet_id = peers.front()->tablet_id();
+  auto* leader = GetLeaderForTablet(cluster_.get(), tablet_id);
+  ASSERT_NE(leader, nullptr);
+  auto* follower = cluster_->mini_tablet_server(leader == cluster_->mini_tablet_server(0) ? 1 : 0);
+  follower->Shutdown();
+  auto restart = ScopeExit([&] {
+    workload.StopAndJoin();
+    ASSERT_OK(follower->RestartStoppedServer());
+    ASSERT_OK(follower->WaitStarted());
+  });
+  const auto snapshot_id = TxnSnapshotId::GenerateRandom();
+  workload.Start();
+  const auto response = ASSERT_RESULT(CreateTabletSnapshot(leader, tablet_id, snapshot_id));
+  ASSERT_TRUE(response.has_error());
+  // A follower failure must remain retryable, not report that the leader's tablet disappeared.
+  ASSERT_NE(response.error().code(), tserver::TabletServerErrorPB::TABLET_NOT_FOUND);
+  workload.WaitInserted(100);
+  workload.StopAndJoin();
+  const auto leader_peer = ASSERT_RESULT(GetLeaderPeerForTablet(cluster_.get(), tablet_id));
+  const auto snapshot_dir = JoinPathSegments(
+      leader_peer->tablet_metadata()->snapshots_dir(), snapshot_id.ToString());
+  ASSERT_FALSE(leader_peer->tablet_metadata()->fs_manager()->env()->FileExists(snapshot_dir));
+}
+
+TEST_F(SnapshotTest, SameTermMembershipChangeRejectsPreflight) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_create_flush_before_submit) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_enable_sync_points) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_load_balancing) = false;
+  auto workload = CreateDefaultWorkload();
+  workload.set_num_tablets(1);
+  workload.Setup();
+  const auto peers = ASSERT_RESULT(
+      ListTabletPeersForTableName(cluster_.get(), kTableName.table_name()));
+  ASSERT_EQ(peers.size(), 3);
+  const auto tablet_id = peers.front()->tablet_id();
+  auto* leader = GetLeaderForTablet(cluster_.get(), tablet_id);
+  ASSERT_NE(leader, nullptr);
+  auto leader_peer = ASSERT_RESULT(GetLeaderPeerForTablet(cluster_.get(), tablet_id));
+  auto consensus = ASSERT_RESULT(leader_peer->GetConsensus());
+  const auto original_term = consensus->LeaderTerm();
+  const auto follower = *std::find_if(peers.begin(), peers.end(), [&](const auto& peer) {
+    return peer != leader_peer;
+  });
+  const auto snapshot_id = TxnSnapshotId::GenerateRandom();
+  Result<tserver::TabletSnapshotOpResponsePB> response = STATUS(IllegalState, "Not sent");
+  CountDownLatch ready(1), release(1);
+  auto* sync = SyncPoint::GetInstance();
+  sync->SetCallBack("SnapshotPreflush::BeforeSubmit", [&](void*) {
+    ready.CountDown();
+    release.Wait();
+  });
+  sync->EnableProcessing();
+  TestThreadHolder threads;
+  auto cleanup = ScopeExit([&] {
+    release.CountDown();
+    threads.JoinAll();
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  threads.AddThreadFunctor([&] {
+    response = CreateTabletSnapshot(leader, tablet_id, snapshot_id);
+  });
+  ASSERT_TRUE(ready.WaitFor(5s));
+  consensus::ChangeConfigRequestPB change;
+  change.set_tablet_id(tablet_id);
+  change.set_type(consensus::REMOVE_SERVER);
+  change.mutable_server()->set_permanent_uuid(follower->permanent_uuid());
+  std::optional<tserver::TabletServerErrorPB::Code> error;
+  auto changed = std::make_shared<std::promise<Status>>();
+  auto changed_future = changed->get_future();
+  ASSERT_OK(consensus->ChangeConfig(change,
+      [changed](const Status& status) { changed->set_value(status); }, &error));
+  ASSERT_EQ(changed_future.wait_for(5s), std::future_status::ready);
+  ASSERT_OK(changed_future.get());
+  ASSERT_EQ(consensus->LeaderTerm(), original_term);
+  release.CountDown();
+  threads.JoinAll();
+  const auto reply = ASSERT_RESULT(std::move(response));
+  ASSERT_TRUE(reply.has_error());
+  const auto status = StatusFromPB(reply.error().status());
+  ASSERT_TRUE(status.IsTryAgain()) << status;
+  ASSERT_STR_CONTAINS(status.ToString(), "configuration changed");
+  ASSERT_FALSE(leader_peer->tablet_metadata()->fs_manager()->env()->FileExists(JoinPathSegments(
+      leader_peer->tablet_metadata()->snapshots_dir(), snapshot_id.ToString())));
+}
+
+TEST_F(SnapshotTest, MissingFollowerTabletIsRetryable) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_create_flush_before_submit) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_load_balancing) = false;
+  auto workload = CreateDefaultWorkload();
+  workload.set_num_tablets(1);
+  workload.Setup();
+  const auto peers = ASSERT_RESULT(
+      ListTabletPeersForTableName(cluster_.get(), kTableName.table_name()));
+  ASSERT_EQ(peers.size(), 3);
+  const auto tablet_id = peers.front()->tablet_id();
+  auto* leader = GetLeaderForTablet(cluster_.get(), tablet_id);
+  ASSERT_NE(leader, nullptr);
+  auto* follower = cluster_->mini_tablet_server(leader == cluster_->mini_tablet_server(0) ? 1 : 0);
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_enable_remote_bootstrap) = false;
+  auto restore_bootstrap = ScopeExit([&] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_enable_remote_bootstrap) = true;
+  });
+  std::optional<tserver::TabletServerErrorPB::Code> error;
+  ASSERT_OK(follower->server()->tablet_manager()->DeleteTablet(
+      tablet_id, tablet::TABLET_DATA_DELETED, tablet::ShouldAbortActiveTransactions::kFalse,
+      std::nullopt, false, false, &error));
+  // Verify the follower's actual wire response, rather than simulating a transport failure.
+  tserver::TabletServerAdminServiceProxy proxy(
+      &client_->proxy_cache(), HostPort::FromBoundEndpoint(follower->bound_rpc_addr()));
+  tserver::FlushTabletsRequestPB request;
+  request.set_dest_uuid(follower->server()->permanent_uuid());
+  request.add_tablet_ids(tablet_id);
+  tserver::FlushTabletsResponsePB response;
+  RpcController controller;
+  controller.set_timeout(5s);
+  ASSERT_OK(proxy.FlushTablets(request, &response, &controller));
+  ASSERT_TRUE(response.has_error());
+  ASSERT_EQ(response.error().code(), tserver::TabletServerErrorPB::TABLET_NOT_FOUND);
+  const auto snapshot_id = TxnSnapshotId::GenerateRandom();
+  const auto reply = ASSERT_RESULT(CreateTabletSnapshot(leader, tablet_id, snapshot_id));
+  ASSERT_TRUE(reply.has_error());
+  ASSERT_NE(reply.error().code(), tserver::TabletServerErrorPB::TABLET_NOT_FOUND);
+  ASSERT_TRUE(StatusFromPB(reply.error().status()).IsTryAgain()) << reply.DebugString();
+  auto cleanup = ScopeExit([&] { workload.StopAndJoin(); });
+  workload.Start();
+  workload.WaitInserted(100);
+  workload.StopAndJoin();
+  auto leader_peer = ASSERT_RESULT(GetLeaderPeerForTablet(cluster_.get(), tablet_id));
+  ASSERT_FALSE(leader_peer->tablet_metadata()->fs_manager()->env()->FileExists(JoinPathSegments(
+      leader_peer->tablet_metadata()->snapshots_dir(), snapshot_id.ToString())));
+  // Permanent deletion deliberately prevents remote bootstrap; remove the test table before
+  // the fixture's cluster-wide health verification rather than trying to resurrect this replica.
+  ASSERT_OK(client_->DeleteTable(kTableName, /* wait = */ true));
 }
 
 // Verifies that snapshot deletion completes once the snapshot directory is tombstoned, without

--- a/src/yb/rocksdb/db.h
+++ b/src/yb/rocksdb/db.h
@@ -743,6 +743,13 @@ class DB {
     return WaitForFlush(DefaultColumnFamily());
   }
 
+  // Wait for queued/running flush jobs, including error cleanup, to retire. Unlike WaitForFlush,
+  // this does not return early on a background error. It does not request another memtable flush
+  // or report durability; callers must retain the Flush/WaitForFlush status separately.
+  // May also wait for concurrently scheduled flushes. The caller must prevent DB shutdown until
+  // this returns: shutdown can abandon unscheduled work rather than drain it.
+  virtual void WaitForFlushJobs() = 0;
+
   // Sync the wal. Note that Write() followed by SyncWAL() is not exactly the
   // same as Write() with sync=true: in the latter case the changes won't be
   // visible until the sync is done.

--- a/src/yb/rocksdb/db/db_impl.cc
+++ b/src/yb/rocksdb/db/db_impl.cc
@@ -2114,10 +2114,11 @@ Result<FileNumbersHolder> DBImpl::FlushMemTableToOutputFile(
         << cfd->current()->storage_info()->LevelSummary(&tmp);
   }
 
-  if (!file_number_holder.ok() && !file_number_holder.status().IsShutdownInProgress()
-      && db_options_.paranoid_checks && bg_error_.ok()) {
-    // if a bad error happened (not ShutdownInProgress) and paranoid_checks is
-    // true, mark DB read-only
+  if (!file_number_holder.ok() && bg_error_.ok() &&
+      (flush_job.filter_failed() ||
+       (!file_number_holder.status().IsShutdownInProgress() && db_options_.paranoid_checks))) {
+    // A failed dependency cannot be retried indefinitely, even with paranoid checks disabled or
+    // when the dependency (rather than this DB) is shutting down. Wake waiters with the error.
     bg_error_.TrySet(file_number_holder.status());
   }
   RETURN_NOT_OK(file_number_holder);
@@ -3242,6 +3243,13 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
   return s;
 }
 
+void DBImpl::WaitForFlushJobs() {
+  InstrumentedMutexLock lock(&mutex_);
+  while (bg_flush_scheduled_ != 0 || unscheduled_flushes_ != 0) {
+    bg_cv_.Wait();
+  }
+}
+
 Status DBImpl::WaitForFlushMemTable(ColumnFamilyData* cfd) {
   Status s;
   // Wait until the flush completes
@@ -3588,6 +3596,7 @@ void DBImpl::WaitAfterBackgroundError(
             "Waiting after background $0 error: $1, Accumulated background error counts: $2",
             job_name, s, error_cnt).c_str());
     LogFlush(db_options_.info_log);
+    TEST_SYNC_POINT_CALLBACK("DBImpl::WaitAfterBackgroundError", this);
     env_->SleepForMicroseconds(1000000);
     mutex_.Lock();
   }
@@ -3628,6 +3637,7 @@ void DBImpl::BackgroundJobComplete(
 }
 
 void DBImpl::BackgroundCallFlush(ColumnFamilyData* cfd) {
+  TEST_SYNC_POINT_CALLBACK("DBImpl::BackgroundCallFlush:Start", this);
   bool made_progress = false;
   JobContext job_context(next_job_id_.fetch_add(1), true);
 

--- a/src/yb/rocksdb/db/db_impl.h
+++ b/src/yb/rocksdb/db/db_impl.h
@@ -206,6 +206,7 @@ class DBImpl : public DB {
                        ColumnFamilyHandle* column_family) override;
   using DB::WaitForFlush;
   virtual Status WaitForFlush(ColumnFamilyHandle* column_family) override;
+  void WaitForFlushJobs() override;
   virtual Status UpdateFrontiers(const yb::storage::UserFrontiers& frontiers) override;
   virtual Status SyncWAL() override;
 

--- a/src/yb/rocksdb/db/db_test.cc
+++ b/src/yb/rocksdb/db/db_test.cc
@@ -4712,6 +4712,8 @@ class ModelDB: public DB {
     return Status::OK();
   }
 
+  void WaitForFlushJobs() override {}
+
   Status SyncWAL() override {
     return Status::OK();
   }

--- a/src/yb/rocksdb/db/flush_job.cc
+++ b/src/yb/rocksdb/db/flush_job.cc
@@ -153,7 +153,12 @@ Result<FileNumbersHolder> FlushJob::Run(FileMetaData* file_meta) {
   // Save the contents of the earliest memtable as a new Table
   FileMetaData meta;
   autovector<MemTable*> mems;
-  cfd_->imm()->PickMemtablesToFlush(&mems, mem_table_flush_filter_, &mutable_cf_options_);
+  auto filter_status = cfd_->imm()->PickMemtablesToFlush(
+      &mems, mem_table_flush_filter_, &mutable_cf_options_);
+  if (!filter_status.ok()) {
+    filter_failed_ = true;
+    return filter_status;
+  }
   if (mems.empty()) {
     // A temporary workaround for repeated "Nothing in memtable to flush" messages in a
     // transactional workload due to the flush filter preventing us from flushing any memtables in

--- a/src/yb/rocksdb/db/flush_job.h
+++ b/src/yb/rocksdb/db/flush_job.h
@@ -84,6 +84,7 @@ class FlushJob {
 
   Result<FileNumbersHolder> Run(FileMetaData* file_meta = nullptr);
   TableProperties GetTableProperties() const { return table_properties_; }
+  bool filter_failed() const { return filter_failed_; }
 
  private:
   void ReportStartedFlush();
@@ -102,6 +103,7 @@ class FlushJob {
   std::vector<SequenceNumber> existing_snapshots_;
   SequenceNumber earliest_write_conflict_snapshot_;
   MemTableFilter mem_table_flush_filter_;
+  bool filter_failed_ = false;
   FileNumbersProvider* file_numbers_provider_;
   JobContext* job_context_;
   LogBuffer* log_buffer_;

--- a/src/yb/rocksdb/db/flush_job_test.cc
+++ b/src/yb/rocksdb/db/flush_job_test.cc
@@ -19,6 +19,7 @@
 //
 
 #include <algorithm>
+#include <future>
 #include <map>
 #include <string>
 
@@ -38,6 +39,7 @@
 
 #include "yb/util/string_util.h"
 #include "yb/util/test_macros.h"
+#include "yb/util/test_thread_holder.h"
 
 using std::unique_ptr;
 
@@ -91,6 +93,34 @@ class FlushJobTest : public RocksDBTest {
     ASSERT_OK(s);
     // Make "CURRENT" file that points to the new manifest file.
     s = SetCurrentFile(env_, dbname_, 1, nullptr, db_options_.disableDataSync);
+  }
+
+  void TestBackgroundFilterFailure(const Status& failure) {
+    Options options;
+    options.create_if_missing = true;
+    options.paranoid_checks = false;
+    options.mem_table_flush_filter_factory = std::make_shared<std::function<MemTableFilter()>>(
+        [failure] {
+          return [failure](const MemTable&, bool) -> yb::Result<bool> { return failure; };
+        });
+    auto db = ASSERT_RESULT(DB::Open(options, dbname_ + "/filtered"));
+    ASSERT_OK(db->Put(WriteOptions(), "key", "value"));
+    std::promise<Status> result;
+    auto future = result.get_future();
+    yb::TestThreadHolder threads;
+    threads.AddThreadFunctor([&] {
+      result.set_value(db->Flush(FlushOptions(FlushReason::kTestOnly)));
+    });
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    auto status = future.get();
+    ASSERT_EQ(status.code(), failure.code());
+    ASSERT_STR_CONTAINS(status.ToString(), failure.message().ToBuffer());
+    threads.JoinAll();
+    db->WaitForFlushJobs();
+    ASSERT_TRUE(db->GetLiveFilesMetaData().empty());
+    std::string value;
+    ASSERT_OK(db->Get(ReadOptions(), "key", &value));
+    ASSERT_EQ(value, "value");
   }
 
   Env* env_;
@@ -186,6 +216,53 @@ TEST_F(FlushJobTest, NonEmpty) {
   values.Check(fd.smallest, fd.largest);
   mock_table_factory_->AssertSingleFile(inserted_keys);
   job_context.Clean();
+}
+
+TEST_F(FlushJobTest, FilterFailureRollsBackSelection) {
+  auto cfd = versions_->GetColumnFamilySet()->GetDefault();
+  auto* imm = cfd->imm();
+  autovector<MemTable*> to_delete;
+  autovector<MemTable*> expected;
+  for (SequenceNumber seq = 1; seq != 3; ++seq) {
+    auto* mem = cfd->ConstructNewMemtable(*cfd->GetLatestMutableCFOptions(), kMaxSequenceNumber);
+    mem->Ref();
+    const auto key = ToString(seq);
+    Slice key_slice(key), value_slice("value");
+    mem->Add(seq, kTypeValue, SliceParts(&key_slice, 1), SliceParts(&value_slice, 1));
+    imm->Add(mem, &to_delete);
+    expected.push_back(mem);
+  }
+  ASSERT_TRUE(to_delete.empty());
+  autovector<MemTable*> selected;
+  size_t checks = 0;
+  auto status = imm->PickMemtablesToFlush(
+      &selected, [&](const MemTable&, bool) -> yb::Result<bool> {
+    if (++checks == 2) {
+      return STATUS(IOError, "injected flush dependency failure");
+    }
+    return true;
+  });
+  ASSERT_TRUE(status.IsIOError()) << status;
+  ASSERT_EQ(checks, 2);
+  ASSERT_TRUE(selected.empty());
+  ASSERT_EQ(imm->NumNotFlushed(), 2);
+  ASSERT_TRUE(imm->IsFlushPending());
+
+  ASSERT_OK(imm->PickMemtablesToFlush(&selected, [](const MemTable&, bool) { return false; }));
+  ASSERT_TRUE(selected.empty());
+  ASSERT_OK(imm->PickMemtablesToFlush(&selected));
+  ASSERT_EQ(selected.size(), 2);
+  ASSERT_EQ(selected[0], expected[0]);
+  ASSERT_EQ(selected[1], expected[1]);
+  imm->RollbackMemtableFlush(selected, 0);
+}
+
+TEST_F(FlushJobTest, FilterErrorStopsBackgroundFlush) {
+  TestBackgroundFilterFailure(STATUS(IOError, "failed flush dependency"));
+}
+
+TEST_F(FlushJobTest, DependencyShutdownStopsBackgroundFlush) {
+  TestBackgroundFilterFailure(STATUS(ShutdownInProgress, "flush dependency is shutting down"));
 }
 
 TEST_F(FlushJobTest, Snapshots) {

--- a/src/yb/rocksdb/db/memtable_list.cc
+++ b/src/yb/rocksdb/db/memtable_list.cc
@@ -41,7 +41,6 @@
 #include "yb/util/result.h"
 
 using yb::Result;
-using std::ostringstream;
 
 namespace rocksdb {
 
@@ -308,11 +307,10 @@ bool MemTableList::IsFlushPending() const {
 }
 
 // Returns the memtables that need to be flushed.
-void MemTableList::PickMemtablesToFlush(
+Status MemTableList::PickMemtablesToFlush(
     autovector<MemTable*>* ret, const MemTableFilter& filter,
     const MutableCFOptions* mutable_cf_options) {
   const auto& memlist = current_->memlist_;
-  bool all_memtables_logged = false;
   bool write_blocked =
       mutable_cf_options &&
       yb::make_signed(current_->memlist_.size()) >= mutable_cf_options->max_write_buffer_number;
@@ -329,20 +327,15 @@ void MemTableList::PickMemtablesToFlush(
           break;
         }
       } else {
-        // This failure usually means that there is an empty immutable memtable. We need to output
-        // additional diagnostics in that case.
-        ostringstream ss;
-        if (!all_memtables_logged) {
-          ss << ". All memtables:\n";
-          for (const MemTable* memtable_for_logging : memlist) {
-            ss << "  " << memtable_for_logging->ToString() << "\n";
-          }
-          all_memtables_logged = true;
+        // A dependency failure must not bypass the filter's durability ordering. Undo any earlier
+        // selections; this job will fail without writing or installing a manifest entry.
+        LOG(ERROR) << "Failed when checking if memtable can be flushed: "
+                   << filter_result.status() << ". Memtable: " << m->ToString();
+        if (!ret->empty()) {
+          RollbackMemtableFlush(*ret, 0);
+          ret->clear();
         }
-        LOG(DFATAL) << "Failed when checking if memtable can be flushed (will still flush it): "
-                    << filter_result.status() << ". Memtable: " << m->ToString()
-                    << ss.str();
-        // Still flush the memtable so that this error does not keep occurring.
+        return filter_result.status();
       }
     }
     assert(!m->flush_completed_);
@@ -355,6 +348,7 @@ void MemTableList::PickMemtablesToFlush(
   }
 
   flush_requested_ = false;  // start-flush request is complete
+  return Status::OK();
 }
 
 void MemTableList::RollbackMemtableFlush(const autovector<MemTable*>& mems,

--- a/src/yb/rocksdb/db/memtable_list.h
+++ b/src/yb/rocksdb/db/memtable_list.h
@@ -204,7 +204,8 @@ class MemTableList {
 
   // Returns the earliest memtables that needs to be flushed. The returned
   // memtables are guaranteed to be in the ascending order of created time.
-  void PickMemtablesToFlush(autovector<MemTable*>* mems,
+  // On filter failure, rolls back all selections and returns the error with mems empty.
+  Status PickMemtablesToFlush(autovector<MemTable*>* mems,
                             const MemTableFilter& filter = MemTableFilter(),
                             const MutableCFOptions* mutable_cf_options = nullptr);
 

--- a/src/yb/rocksdb/db/memtable_list_test.cc
+++ b/src/yb/rocksdb/db/memtable_list_test.cc
@@ -110,7 +110,7 @@ TEST_F(MemTableListTest, Empty) {
   ASSERT_FALSE(list.IsFlushPending());
 
   autovector<MemTable*> mems;
-  list.PickMemtablesToFlush(&mems);
+  ASSERT_OK(list.PickMemtablesToFlush(&mems));
   ASSERT_EQ(0, mems.size());
 
   autovector<MemTable*> to_delete;
@@ -284,7 +284,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
   // Flush this memtable from the list.
   // (It will then be a part of the memtable history).
   autovector<MemTable*> to_flush;
-  list.PickMemtablesToFlush(&to_flush);
+  ASSERT_OK(list.PickMemtablesToFlush(&to_flush));
   ASSERT_EQ(1, to_flush.size());
 
   s = Mock_InstallMemtableFlushResults(
@@ -332,7 +332,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
   ASSERT_EQ(0, to_delete.size());
 
   to_flush.clear();
-  list.PickMemtablesToFlush(&to_flush);
+  ASSERT_OK(list.PickMemtablesToFlush(&to_flush));
   ASSERT_EQ(1, to_flush.size());
 
   // Flush second memtable
@@ -438,7 +438,7 @@ TEST_F(MemTableListTest, FlushPendingTest) {
   ASSERT_FALSE(list.IsFlushPending());
   ASSERT_FALSE(list.imm_flush_needed.load(std::memory_order_acquire));
   autovector<MemTable*> to_flush;
-  list.PickMemtablesToFlush(&to_flush);
+  ASSERT_OK(list.PickMemtablesToFlush(&to_flush));
   ASSERT_EQ(0, to_flush.size());
 
   // Request a flush even though there is nothing to flush
@@ -447,7 +447,7 @@ TEST_F(MemTableListTest, FlushPendingTest) {
   ASSERT_FALSE(list.imm_flush_needed.load(std::memory_order_acquire));
 
   // Attempt to 'flush' to clear request for flush
-  list.PickMemtablesToFlush(&to_flush);
+  ASSERT_OK(list.PickMemtablesToFlush(&to_flush));
   ASSERT_EQ(0, to_flush.size());
   ASSERT_FALSE(list.IsFlushPending());
   ASSERT_FALSE(list.imm_flush_needed.load(std::memory_order_acquire));
@@ -471,7 +471,7 @@ TEST_F(MemTableListTest, FlushPendingTest) {
   ASSERT_TRUE(list.imm_flush_needed.load(std::memory_order_acquire));
 
   // Pick tables to flush
-  list.PickMemtablesToFlush(&to_flush);
+  ASSERT_OK(list.PickMemtablesToFlush(&to_flush));
   ASSERT_EQ(2, to_flush.size());
   ASSERT_EQ(2, list.NumNotFlushed());
   ASSERT_FALSE(list.IsFlushPending());
@@ -492,7 +492,7 @@ TEST_F(MemTableListTest, FlushPendingTest) {
   ASSERT_EQ(0, to_delete.size());
 
   // Pick tables to flush
-  list.PickMemtablesToFlush(&to_flush);
+  ASSERT_OK(list.PickMemtablesToFlush(&to_flush));
   ASSERT_EQ(3, to_flush.size());
   ASSERT_EQ(3, list.NumNotFlushed());
   ASSERT_FALSE(list.IsFlushPending());
@@ -500,7 +500,7 @@ TEST_F(MemTableListTest, FlushPendingTest) {
 
   // Pick tables to flush again
   autovector<MemTable*> to_flush2;
-  list.PickMemtablesToFlush(&to_flush2);
+  ASSERT_OK(list.PickMemtablesToFlush(&to_flush2));
   ASSERT_EQ(0, to_flush2.size());
   ASSERT_EQ(3, list.NumNotFlushed());
   ASSERT_FALSE(list.IsFlushPending());
@@ -518,7 +518,7 @@ TEST_F(MemTableListTest, FlushPendingTest) {
   ASSERT_TRUE(list.imm_flush_needed.load(std::memory_order_acquire));
 
   // Pick tables to flush again
-  list.PickMemtablesToFlush(&to_flush2);
+  ASSERT_OK(list.PickMemtablesToFlush(&to_flush2));
   ASSERT_EQ(1, to_flush2.size());
   ASSERT_EQ(4, list.NumNotFlushed());
   ASSERT_FALSE(list.IsFlushPending());
@@ -539,7 +539,7 @@ TEST_F(MemTableListTest, FlushPendingTest) {
   ASSERT_EQ(0, to_delete.size());
 
   // Pick tables to flush
-  list.PickMemtablesToFlush(&to_flush);
+  ASSERT_OK(list.PickMemtablesToFlush(&to_flush));
   // Should pick 4 of 5 since 1 table has been picked in to_flush2
   ASSERT_EQ(4, to_flush.size());
   ASSERT_EQ(5, list.NumNotFlushed());

--- a/src/yb/rocksdb/options.h
+++ b/src/yb/rocksdb/options.h
@@ -846,6 +846,7 @@ struct ColumnFamilyOptions {
   void Dump(Logger* log) const;
 };
 
+// False defers a memtable; an error fails the flush without persisting any selected memtables.
 using MemTableFilter = std::function<yb::Result<bool>(const MemTable&, bool)>;
 
 using IteratorReplacer =

--- a/src/yb/rocksdb/utilities/stackable_db.h
+++ b/src/yb/rocksdb/utilities/stackable_db.h
@@ -256,6 +256,10 @@ class StackableDB : public DB {
     return db_->WaitForFlush(column_family);
   }
 
+  void WaitForFlushJobs() override {
+    db_->WaitForFlushJobs();
+  }
+
   virtual Status SyncWAL() override {
     return db_->SyncWAL();
   }

--- a/src/yb/tablet/operations/snapshot_operation.cc
+++ b/src/yb/tablet/operations/snapshot_operation.cc
@@ -200,10 +200,6 @@ Status SnapshotOperation::CheckOperationAllowed(
 // ------------------------------------------------------------------------------------------------
 
 Status SnapshotOperation::Prepare(IsLeaderSide is_leader_side) {
-  TRACE("PREPARE SNAPSHOT: Starting");
-  RETURN_NOT_OK(VERIFY_RESULT(tablet_safe())->snapshots().Prepare(this));
-
-  TRACE("PREPARE SNAPSHOT: finished");
   return Status::OK();
 }
 

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -1438,7 +1438,10 @@ void Tablet::RegularDbFilesChanged() {
 
 void Tablet::SetCleanupPool(
     ThreadPool* snapshot_cleanup_pool, rpc::Scheduler* scheduler, ThreadPool* intent_cleanup_pool) {
-  snapshots_->SetCleanupPool(snapshot_cleanup_pool, scheduler);
+  // intent_cleanup_pool is the unbounded raft pool; it doubles as the snapshot preflush pool
+  // because the bounded snapshot cleanup pool can be fully occupied by recursive deletions,
+  // which would starve the preflush until after the snapshot operation has already applied.
+  snapshots_->SetCleanupPool(snapshot_cleanup_pool, scheduler, intent_cleanup_pool);
 
   if (!transaction_participant_) {
     return;

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -1065,6 +1065,17 @@ Result<bool> Tablet::IntentsDbFlushFilter(
     VLOG_WITH_PREFIX_AND_FUNC(4) << "Flush ability: " << AsString(state->flush_ability);
   }
 
+  // A failed vector save cannot satisfy an intents durability dependency. Check even when flush
+  // ability was cached as kAlreadyFlushing; no further save task may remain to make progress.
+  if (state->vector_indexes) {
+    for (size_t idx = 0; idx != state->vector_indexes->size(); ++idx) {
+      if (state->flush_ability[idx + 1] != rocksdb::FlushAbility::kNoNewData &&
+          !state->Flushed(idx + 1, memtable_index)) {
+        RETURN_NOT_OK((*state->vector_indexes)[idx]->GetFlushStatus());
+      }
+    }
+  }
+
   // If regular db does not have anything to flush, it means that we have just added intents,
   // without apply, so it is OK to flush the intents RocksDB.
   if (!state->HasNewData(memtable_index)) {
@@ -1091,6 +1102,7 @@ Result<bool> Tablet::IntentsDbFlushFilter(
     }
   }
 
+  TEST_SYNC_POINT_CALLBACK("Tablet::IntentsDbFlushFilter:Blocked", this);
   return false;
 }
 
@@ -1438,10 +1450,7 @@ void Tablet::RegularDbFilesChanged() {
 
 void Tablet::SetCleanupPool(
     ThreadPool* snapshot_cleanup_pool, rpc::Scheduler* scheduler, ThreadPool* intent_cleanup_pool) {
-  // intent_cleanup_pool is the unbounded raft pool; it doubles as the snapshot preflush pool
-  // because the bounded snapshot cleanup pool can be fully occupied by recursive deletions,
-  // which would starve the preflush until after the snapshot operation has already applied.
-  snapshots_->SetCleanupPool(snapshot_cleanup_pool, scheduler, intent_cleanup_pool);
+  snapshots_->SetCleanupPool(snapshot_cleanup_pool, scheduler);
 
   if (!transaction_participant_) {
     return;

--- a/src/yb/tablet/tablet_retention_policy.cc
+++ b/src/yb/tablet/tablet_retention_policy.cc
@@ -165,7 +165,11 @@ Status TabletRetentionPolicy::RegisterReaderTimestamp(HybridTime timestamp) {
 
 void TabletRetentionPolicy::UnregisterReaderTimestamp(HybridTime timestamp) {
   std::lock_guard lock(mutex_);
-  active_readers_.erase(timestamp);
+  const auto it = active_readers_.find(timestamp);
+  if (it != active_readers_.end()) {
+    // Independent readers can share a timestamp; each guard owns only one registration.
+    active_readers_.erase(it);
+  }
 }
 
 bool TabletRetentionPolicy::ShouldRetainDeleteMarkersInMajorCompaction() const {

--- a/src/yb/tablet/tablet_snapshots-test.cc
+++ b/src/yb/tablet/tablet_snapshots-test.cc
@@ -34,6 +34,7 @@
 #include "yb/tserver/backup.pb.h"
 
 #include "yb/util/backoff_waiter.h"
+#include "yb/util/countdown_latch.h"
 #include "yb/util/env.h"
 #include "yb/util/format.h"
 #include "yb/util/metrics.h"
@@ -209,6 +210,11 @@ class TabletSnapshotsTest : public YBTest {
     ASSERT_OK(ThreadPoolBuilder("snapshot-cleanup-test")
                   .set_max_threads(kCleanupThreadPoolSize)
                   .Build(&cleanup_pool_));
+    // Mirrors production, where the preflush runs on the unbounded raft pool rather than the
+    // bounded cleanup pool.
+    ASSERT_OK(ThreadPoolBuilder("snapshot-preflush-test")
+                  .unlimited_threads()
+                  .Build(&preflush_pool_));
   }
 
   void TearDown() override {
@@ -219,6 +225,7 @@ class TabletSnapshotsTest : public YBTest {
       harness_.reset();
     }
     cleanup_pool_->Shutdown();
+    preflush_pool_->Shutdown();
     messenger_->Shutdown();
     YBTest::TearDown();
   }
@@ -230,7 +237,8 @@ class TabletSnapshotsTest : public YBTest {
   };
 
   void InstallCleanupPool() {
-    harness_->tablet()->snapshots().SetCleanupPool(cleanup_pool_.get(), &messenger_->scheduler());
+    harness_->tablet()->snapshots().SetCleanupPool(
+        cleanup_pool_.get(), &messenger_->scheduler(), preflush_pool_.get());
   }
 
   SnapshotPaths CreateSnapshotDirectory(const std::string& snapshot_id, int64_t op_index) {
@@ -291,6 +299,7 @@ class TabletSnapshotsTest : public YBTest {
   Schema schema_;
   std::unique_ptr<SnapshotCleanupTestEnv> test_env_;
   std::unique_ptr<ThreadPool> cleanup_pool_;
+  std::unique_ptr<ThreadPool> preflush_pool_;
   std::unique_ptr<rpc::Messenger> messenger_;
   std::unique_ptr<TabletTestHarness> harness_;
 };
@@ -494,7 +503,7 @@ TEST_F(TabletSnapshotsTest, SharedPoolBoundsCleanupConcurrency) {
     ASSERT_OK(tablet_harness->Create(/* first_time = */ true));
     ASSERT_OK(tablet_harness->Open());
     tablet_harness->tablet()->snapshots().SetCleanupPool(
-        cleanup_pool_.get(), &messenger_->scheduler());
+        cleanup_pool_.get(), &messenger_->scheduler(), preflush_pool_.get());
 
     const auto snapshot_id = Format("snapshot-$0", i);
     const auto active =
@@ -599,7 +608,8 @@ TEST_F(TabletSnapshotsTest, ShutdownWaitsForRunningCleanup) {
 }
 
 TEST_F(TabletSnapshotsTest, PrepareFlushesTabletForSnapshotCreation) {
-  // Exercise the production path: the flush scheduling call is dispatched to the cleanup pool.
+  // Exercise the dispatch path used once pools are installed. Note this calls
+  // TabletSnapshots::Prepare directly rather than going through the operation lifecycle.
   InstallCleanupPool();
 
   ASSERT_OK(WriteRow(1));
@@ -619,6 +629,34 @@ TEST_F(TabletSnapshotsTest, PrepareFlushesTabletWithoutCleanupPool) {
   ASSERT_OK(WriteRow(1));
   ASSERT_EQ(NumRegularDbSSTFiles(), 0);
 
+  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
+
+  ASSERT_OK(WaitFor(
+      [this] { return NumRegularDbSSTFiles() > 0; }, 10s, "Wait for prepare-triggered flush"));
+}
+
+TEST_F(TabletSnapshotsTest, PreflushNotStarvedByCleanupPool) {
+  InstallCleanupPool();
+
+  // Occupy every cleanup pool worker: one with a blocked recursive snapshot deletion, the rest
+  // with tasks parked on a latch. The preflush must still run because it lives on its own pool.
+  test_env_->BlockDeletes();
+  CreateSnapshotDirectory("snapshot.starve", 1);
+  ASSERT_OK(DeleteSnapshot("snapshot.starve", 1));
+  ASSERT_OK(WaitFor(
+      [this] { return test_env_->active_deletes() == 1; }, 10s,
+      "Wait for blocked snapshot cleanup"));
+
+  CountDownLatch latch(1);
+  auto release = ScopeExit([this, &latch] {
+    latch.CountDown();
+    test_env_->ReleaseDeletes();
+  });
+  for (int i = 0; i < kCleanupThreadPoolSize - 1; ++i) {
+    ASSERT_OK(cleanup_pool_->SubmitFunc([&latch] { latch.Wait(); }));
+  }
+
+  ASSERT_OK(WriteRow(1));
   ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
 
   ASSERT_OK(WaitFor(

--- a/src/yb/tablet/tablet_snapshots-test.cc
+++ b/src/yb/tablet/tablet_snapshots-test.cc
@@ -19,10 +19,12 @@
 
 #include <gtest/gtest.h>
 
+#include "yb/common/ql_protocol_util.h"
 #include "yb/common/wire_protocol-test-util.h"
 
 #include "yb/rpc/messenger.h"
 
+#include "yb/tablet/local_tablet_writer.h"
 #include "yb/tablet/operations/snapshot_operation.h"
 #include "yb/tablet/tablet-test-harness.h"
 #include "yb/tablet/tablet-test-util.h"
@@ -42,6 +44,7 @@
 #include "yb/util/threadpool.h"
 
 DECLARE_bool(enable_async_snapshot_directory_cleanup);
+DECLARE_bool(snapshot_create_flush_on_prepare);
 DECLARE_int32(TEST_snapshot_cleanup_retry_delay_ms);
 
 METRIC_DECLARE_counter(snapshot_cleanup_failures);
@@ -189,6 +192,8 @@ class TabletSnapshotsTest : public YBTest {
     YBTest::SetUp();
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_async_snapshot_directory_cleanup) = true;
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_snapshot_cleanup_retry_delay_ms) = 10;
+    // Tests below toggle this flag; restore the default for each test in this process.
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_create_flush_on_prepare) = true;
 
     schema_ = GetSimpleTestSchema();
     schema_.InitColumnIdsByDefault();
@@ -249,6 +254,27 @@ class TabletSnapshotsTest : public YBTest {
     return harness_->tablet()->snapshots().Delete(operation);
   }
 
+  Status WriteRow(int32_t key) {
+    LocalTabletWriter writer(harness_->tablet());
+    QLWriteRequestPB req;
+    QLAddInt32HashValue(&req, key);
+    QLAddInt32ColumnValue(&req, kFirstColumnId + 1, key);
+    QLAddStringColumnValue(&req, kFirstColumnId + 2, "value");
+    return writer.Write(&req);
+  }
+
+  Status PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::Operation op_type) {
+    tserver::TabletSnapshotOpRequestPB request;
+    request.set_operation(op_type);
+    SnapshotOperation operation(harness_->tablet());
+    operation.AllocateRequest()->CopyFrom(request);
+    return harness_->tablet()->snapshots().Prepare(&operation);
+  }
+
+  uint64_t NumRegularDbSSTFiles() {
+    return harness_->tablet()->GetCurrentVersionNumSSTFiles();
+  }
+
   template <class Metric, class Prototype>
   uint64_t MetricValue(const Prototype& prototype) {
     return harness_->tablet()->GetTabletMetricsEntity()->FindOrNull<Metric>(prototype)->value();
@@ -271,6 +297,10 @@ class TabletSnapshotsTest : public YBTest {
 
 TEST(TabletSnapshotPathTest, AsyncCleanupDisabledByDefault) {
   ASSERT_FALSE(FLAGS_enable_async_snapshot_directory_cleanup);
+}
+
+TEST(TabletSnapshotPathTest, FlushOnPrepareEnabledByDefault) {
+  ASSERT_TRUE(FLAGS_snapshot_create_flush_on_prepare);
 }
 
 TEST(TabletSnapshotPathTest, DeletedSnapshotDirectoryName) {
@@ -566,6 +596,38 @@ TEST_F(TabletSnapshotsTest, ShutdownWaitsForRunningCleanup) {
   shutdown_thread.JoinAll();
   ASSERT_TRUE(shutdown_complete.load(std::memory_order_acquire));
   ASSERT_FALSE(test_env_->FileExists(paths.tombstone));
+}
+
+TEST_F(TabletSnapshotsTest, PrepareFlushesTabletForSnapshotCreation) {
+  ASSERT_OK(WriteRow(1));
+  ASSERT_EQ(NumRegularDbSSTFiles(), 0);
+
+  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
+
+  // The prepare-time flush is asynchronous; it must eventually push the memtable into an SST
+  // without any further nudge.
+  ASSERT_OK(WaitFor(
+      [this] { return NumRegularDbSSTFiles() > 0; }, 10s, "Wait for prepare-triggered flush"));
+}
+
+TEST_F(TabletSnapshotsTest, PrepareDoesNotFlushWhenDisabled) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_create_flush_on_prepare) = false;
+
+  ASSERT_OK(WriteRow(1));
+  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
+
+  // A wrongly scheduled async flush of a single row would complete well within this window.
+  SleepFor(200ms);
+  ASSERT_EQ(NumRegularDbSSTFiles(), 0);
+}
+
+TEST_F(TabletSnapshotsTest, PrepareDoesNotFlushForNonCreateOperations) {
+  ASSERT_OK(WriteRow(1));
+  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::DELETE_ON_TABLET));
+
+  // A wrongly scheduled async flush of a single row would complete well within this window.
+  SleepFor(200ms);
+  ASSERT_EQ(NumRegularDbSSTFiles(), 0);
 }
 
 }  // namespace

--- a/src/yb/tablet/tablet_snapshots-test.cc
+++ b/src/yb/tablet/tablet_snapshots-test.cc
@@ -599,6 +599,9 @@ TEST_F(TabletSnapshotsTest, ShutdownWaitsForRunningCleanup) {
 }
 
 TEST_F(TabletSnapshotsTest, PrepareFlushesTabletForSnapshotCreation) {
+  // Exercise the production path: the flush scheduling call is dispatched to the cleanup pool.
+  InstallCleanupPool();
+
   ASSERT_OK(WriteRow(1));
   ASSERT_EQ(NumRegularDbSSTFiles(), 0);
 
@@ -606,6 +609,18 @@ TEST_F(TabletSnapshotsTest, PrepareFlushesTabletForSnapshotCreation) {
 
   // The prepare-time flush is asynchronous; it must eventually push the memtable into an SST
   // without any further nudge.
+  ASSERT_OK(WaitFor(
+      [this] { return NumRegularDbSSTFiles() > 0; }, 10s, "Wait for prepare-triggered flush"));
+}
+
+TEST_F(TabletSnapshotsTest, PrepareFlushesTabletWithoutCleanupPool) {
+  // Without an installed pool (before InitTabletPeer, or in tests) the preflush falls back to
+  // scheduling the flush inline.
+  ASSERT_OK(WriteRow(1));
+  ASSERT_EQ(NumRegularDbSSTFiles(), 0);
+
+  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
+
   ASSERT_OK(WaitFor(
       [this] { return NumRegularDbSSTFiles() > 0; }, 10s, "Wait for prepare-triggered flush"));
 }

--- a/src/yb/tablet/tablet_snapshots-test.cc
+++ b/src/yb/tablet/tablet_snapshots-test.cc
@@ -34,7 +34,6 @@
 #include "yb/tserver/backup.pb.h"
 
 #include "yb/util/backoff_waiter.h"
-#include "yb/util/countdown_latch.h"
 #include "yb/util/env.h"
 #include "yb/util/format.h"
 #include "yb/util/metrics.h"
@@ -45,7 +44,6 @@
 #include "yb/util/threadpool.h"
 
 DECLARE_bool(enable_async_snapshot_directory_cleanup);
-DECLARE_bool(snapshot_create_flush_on_prepare);
 DECLARE_int32(TEST_snapshot_cleanup_retry_delay_ms);
 
 METRIC_DECLARE_counter(snapshot_cleanup_failures);
@@ -193,8 +191,6 @@ class TabletSnapshotsTest : public YBTest {
     YBTest::SetUp();
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_async_snapshot_directory_cleanup) = true;
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_snapshot_cleanup_retry_delay_ms) = 10;
-    // Tests below toggle this flag; restore the default for each test in this process.
-    ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_create_flush_on_prepare) = true;
 
     schema_ = GetSimpleTestSchema();
     schema_.InitColumnIdsByDefault();
@@ -210,11 +206,6 @@ class TabletSnapshotsTest : public YBTest {
     ASSERT_OK(ThreadPoolBuilder("snapshot-cleanup-test")
                   .set_max_threads(kCleanupThreadPoolSize)
                   .Build(&cleanup_pool_));
-    // Mirrors production, where the preflush runs on the unbounded raft pool rather than the
-    // bounded cleanup pool.
-    ASSERT_OK(ThreadPoolBuilder("snapshot-preflush-test")
-                  .unlimited_threads()
-                  .Build(&preflush_pool_));
   }
 
   void TearDown() override {
@@ -225,7 +216,6 @@ class TabletSnapshotsTest : public YBTest {
       harness_.reset();
     }
     cleanup_pool_->Shutdown();
-    preflush_pool_->Shutdown();
     messenger_->Shutdown();
     YBTest::TearDown();
   }
@@ -237,8 +227,7 @@ class TabletSnapshotsTest : public YBTest {
   };
 
   void InstallCleanupPool() {
-    harness_->tablet()->snapshots().SetCleanupPool(
-        cleanup_pool_.get(), &messenger_->scheduler(), preflush_pool_.get());
+    harness_->tablet()->snapshots().SetCleanupPool(cleanup_pool_.get(), &messenger_->scheduler());
   }
 
   SnapshotPaths CreateSnapshotDirectory(const std::string& snapshot_id, int64_t op_index) {
@@ -276,7 +265,8 @@ class TabletSnapshotsTest : public YBTest {
     request.set_operation(op_type);
     SnapshotOperation operation(harness_->tablet());
     operation.AllocateRequest()->CopyFrom(request);
-    return harness_->tablet()->snapshots().Prepare(&operation);
+    RETURN_NOT_OK(operation.Prepare(IsLeaderSide::kTrue));
+    return operation.Prepare(IsLeaderSide::kFalse);
   }
 
   uint64_t NumRegularDbSSTFiles() {
@@ -299,17 +289,12 @@ class TabletSnapshotsTest : public YBTest {
   Schema schema_;
   std::unique_ptr<SnapshotCleanupTestEnv> test_env_;
   std::unique_ptr<ThreadPool> cleanup_pool_;
-  std::unique_ptr<ThreadPool> preflush_pool_;
   std::unique_ptr<rpc::Messenger> messenger_;
   std::unique_ptr<TabletTestHarness> harness_;
 };
 
 TEST(TabletSnapshotPathTest, AsyncCleanupDisabledByDefault) {
   ASSERT_FALSE(FLAGS_enable_async_snapshot_directory_cleanup);
-}
-
-TEST(TabletSnapshotPathTest, FlushOnPrepareEnabledByDefault) {
-  ASSERT_TRUE(FLAGS_snapshot_create_flush_on_prepare);
 }
 
 TEST(TabletSnapshotPathTest, DeletedSnapshotDirectoryName) {
@@ -503,7 +488,7 @@ TEST_F(TabletSnapshotsTest, SharedPoolBoundsCleanupConcurrency) {
     ASSERT_OK(tablet_harness->Create(/* first_time = */ true));
     ASSERT_OK(tablet_harness->Open());
     tablet_harness->tablet()->snapshots().SetCleanupPool(
-        cleanup_pool_.get(), &messenger_->scheduler(), preflush_pool_.get());
+        cleanup_pool_.get(), &messenger_->scheduler());
 
     const auto snapshot_id = Format("snapshot-$0", i);
     const auto active =
@@ -607,79 +592,10 @@ TEST_F(TabletSnapshotsTest, ShutdownWaitsForRunningCleanup) {
   ASSERT_FALSE(test_env_->FileExists(paths.tombstone));
 }
 
-TEST_F(TabletSnapshotsTest, PrepareFlushesTabletForSnapshotCreation) {
-  // Exercise the dispatch path used once pools are installed. Note this calls
-  // TabletSnapshots::Prepare directly rather than going through the operation lifecycle.
-  InstallCleanupPool();
-
-  ASSERT_OK(WriteRow(1));
-  ASSERT_EQ(NumRegularDbSSTFiles(), 0);
-
-  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
-
-  // The prepare-time flush is asynchronous; it must eventually push the memtable into an SST
-  // without any further nudge.
-  ASSERT_OK(WaitFor(
-      [this] { return NumRegularDbSSTFiles() > 0; }, 10s, "Wait for prepare-triggered flush"));
-}
-
-TEST_F(TabletSnapshotsTest, PrepareFlushesTabletWithoutCleanupPool) {
-  // Without an installed pool (before InitTabletPeer, or in tests) the preflush falls back to
-  // scheduling the flush inline.
-  ASSERT_OK(WriteRow(1));
-  ASSERT_EQ(NumRegularDbSSTFiles(), 0);
-
-  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
-
-  ASSERT_OK(WaitFor(
-      [this] { return NumRegularDbSSTFiles() > 0; }, 10s, "Wait for prepare-triggered flush"));
-}
-
-TEST_F(TabletSnapshotsTest, PreflushNotStarvedByCleanupPool) {
-  InstallCleanupPool();
-
-  // Occupy every cleanup pool worker: one with a blocked recursive snapshot deletion, the rest
-  // with tasks parked on a latch. The preflush must still run because it lives on its own pool.
-  test_env_->BlockDeletes();
-  CreateSnapshotDirectory("snapshot.starve", 1);
-  ASSERT_OK(DeleteSnapshot("snapshot.starve", 1));
-  ASSERT_OK(WaitFor(
-      [this] { return test_env_->active_deletes() == 1; }, 10s,
-      "Wait for blocked snapshot cleanup"));
-
-  CountDownLatch latch(1);
-  auto release = ScopeExit([this, &latch] {
-    latch.CountDown();
-    test_env_->ReleaseDeletes();
-  });
-  for (int i = 0; i < kCleanupThreadPoolSize - 1; ++i) {
-    ASSERT_OK(cleanup_pool_->SubmitFunc([&latch] { latch.Wait(); }));
-  }
-
+TEST_F(TabletSnapshotsTest, PrepareDoesNotFlush) {
   ASSERT_OK(WriteRow(1));
   ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
-
-  ASSERT_OK(WaitFor(
-      [this] { return NumRegularDbSSTFiles() > 0; }, 10s, "Wait for prepare-triggered flush"));
-}
-
-TEST_F(TabletSnapshotsTest, PrepareDoesNotFlushWhenDisabled) {
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_create_flush_on_prepare) = false;
-
-  ASSERT_OK(WriteRow(1));
-  ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET));
-
-  // A wrongly scheduled async flush of a single row would complete well within this window.
-  SleepFor(200ms);
-  ASSERT_EQ(NumRegularDbSSTFiles(), 0);
-}
-
-TEST_F(TabletSnapshotsTest, PrepareDoesNotFlushForNonCreateOperations) {
-  ASSERT_OK(WriteRow(1));
   ASSERT_OK(PrepareSnapshotOperation(tserver::TabletSnapshotOpRequestPB::DELETE_ON_TABLET));
-
-  // A wrongly scheduled async flush of a single row would complete well within this window.
-  SleepFor(200ms);
   ASSERT_EQ(NumRegularDbSSTFiles(), 0);
 }
 

--- a/src/yb/tablet/tablet_snapshots.cc
+++ b/src/yb/tablet/tablet_snapshots.cc
@@ -229,7 +229,8 @@ TabletSnapshots::~TabletSnapshots() {
   CompleteShutdown();
 }
 
-void TabletSnapshots::SetCleanupPool(ThreadPool* thread_pool, rpc::Scheduler* scheduler) {
+void TabletSnapshots::SetCleanupPool(
+    ThreadPool* thread_pool, rpc::Scheduler* scheduler, ThreadPool* preflush_pool) {
   {
     std::lock_guard lock(cleanup_mutex_);
     if (shutting_down_) {
@@ -237,7 +238,9 @@ void TabletSnapshots::SetCleanupPool(ThreadPool* thread_pool, rpc::Scheduler* sc
     }
     DCHECK(!cleanup_token_);
     cleanup_token_ = thread_pool->NewToken(ThreadPool::ExecutionMode::SERIAL);
-    preflush_token_ = thread_pool->NewToken(ThreadPool::ExecutionMode::CONCURRENT);
+    if (preflush_pool) {
+      preflush_token_ = preflush_pool->NewToken(ThreadPool::ExecutionMode::CONCURRENT);
+    }
     retry_task_tracker_.Bind(scheduler);
   }
 
@@ -397,7 +400,7 @@ void TabletSnapshots::SubmitPreflush() {
   // On the leader, Prepare runs on the preparer thread, but on followers it runs inline in
   // UpdateConsensus while the ReplicaState lock is held (see PreparerImpl::Submit). Even a
   // non-waiting Tablet::Flush call synchronously enters the RocksDB write queue to switch the
-  // memtable, so dispatch it to the cleanup pool instead of running it here. The token is
+  // memtable, so dispatch it to the preflush pool instead of running it here. The token is
   // shut down in CompleteShutdown, so the task cannot outlive this object.
   {
     std::lock_guard lock(cleanup_mutex_);
@@ -405,19 +408,22 @@ void TabletSnapshots::SubmitPreflush() {
       return;
     }
     if (preflush_token_) {
-      const Status submit_status = preflush_token_->SubmitFunc([this] {
-        WARN_NOT_OK(
-            Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
-            LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
-      });
-      if (PREDICT_TRUE(submit_status.ok())) {
-        return;
-      }
-      LOG_WITH_PREFIX(WARNING) << "Cannot submit snapshot preflush task: " << submit_status;
+      // A submission failure means the token or pool is shutting down; drop the best-effort
+      // preflush rather than flushing inline, which would reintroduce the consensus-path work.
+      WARN_NOT_OK(
+          preflush_token_->SubmitFunc([this] {
+            WARN_NOT_OK(
+                Flush(
+                    FlushMode::kAsync, FlushFlags::kAllDbs,
+                    rocksdb::FlushReason::kSnapshotCreation),
+                LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
+          }),
+          LogPrefix() + "Cannot submit snapshot preflush task");
+      return;
     }
   }
-  // No pool installed (or submission failed): flush inline. This only happens before
-  // SetCleanupPool is called, i.e. before the tablet serves consensus traffic, and in tests.
+  // No preflush pool installed: flush inline. This only happens before SetCleanupPool is called,
+  // i.e. before the tablet serves consensus traffic, and in tests.
   WARN_NOT_OK(
       Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
       LogPrefix() + "Failed to schedule flush while preparing snapshot creation");

--- a/src/yb/tablet/tablet_snapshots.cc
+++ b/src/yb/tablet/tablet_snapshots.cc
@@ -237,6 +237,7 @@ void TabletSnapshots::SetCleanupPool(ThreadPool* thread_pool, rpc::Scheduler* sc
     }
     DCHECK(!cleanup_token_);
     cleanup_token_ = thread_pool->NewToken(ThreadPool::ExecutionMode::SERIAL);
+    preflush_token_ = thread_pool->NewToken(ThreadPool::ExecutionMode::CONCURRENT);
     retry_task_tracker_.Bind(scheduler);
   }
 
@@ -255,6 +256,7 @@ void TabletSnapshots::StartShutdown() {
 
 void TabletSnapshots::CompleteShutdown() {
   std::unique_ptr<ThreadPoolToken> cleanup_token;
+  std::unique_ptr<ThreadPoolToken> preflush_token;
   {
     std::lock_guard lock(cleanup_mutex_);
     if (!shutting_down_) {
@@ -266,9 +268,13 @@ void TabletSnapshots::CompleteShutdown() {
   {
     std::lock_guard lock(cleanup_mutex_);
     cleanup_token = std::move(cleanup_token_);
+    preflush_token = std::move(preflush_token_);
   }
   if (cleanup_token) {
     cleanup_token->Shutdown();
+  }
+  if (preflush_token) {
+    preflush_token->Shutdown();
   }
   {
     std::lock_guard lock(cleanup_mutex_);
@@ -376,16 +382,45 @@ bool TabletSnapshots::IsLastSnapshotTimeFilePath(const std::string& dir) {
 Status TabletSnapshots::Prepare(SnapshotOperation* operation) {
   if (FLAGS_snapshot_create_flush_on_prepare &&
       operation->operation() == tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET) {
-    // Kick off a flush of all DBs now, overlapping it with Raft replication of this operation.
-    // Create() runs on the Raft apply path, where its synchronous flush blocks every subsequent
-    // operation on this tablet; warming the flush here shrinks that window to the delta written
-    // between prepare and apply. Correctness does not depend on this flush happening or
-    // completing: Create() still flushes synchronously before creating the checkpoint.
-    WARN_NOT_OK(
-        Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
-        LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
+    SubmitPreflush();
   }
   return Status::OK();
+}
+
+void TabletSnapshots::SubmitPreflush() {
+  // Kick off a flush of all DBs now, overlapping it with Raft replication of this operation.
+  // Create() runs on the Raft apply path, where its synchronous flush blocks every subsequent
+  // operation on this tablet; warming the flush here shrinks that window to the delta written
+  // between prepare and apply. Correctness does not depend on this flush happening or completing:
+  // Create() still flushes synchronously before creating the checkpoint.
+  //
+  // On the leader, Prepare runs on the preparer thread, but on followers it runs inline in
+  // UpdateConsensus while the ReplicaState lock is held (see PreparerImpl::Submit). Even a
+  // non-waiting Tablet::Flush call synchronously enters the RocksDB write queue to switch the
+  // memtable, so dispatch it to the cleanup pool instead of running it here. The token is
+  // shut down in CompleteShutdown, so the task cannot outlive this object.
+  {
+    std::lock_guard lock(cleanup_mutex_);
+    if (shutting_down_) {
+      return;
+    }
+    if (preflush_token_) {
+      const Status submit_status = preflush_token_->SubmitFunc([this] {
+        WARN_NOT_OK(
+            Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
+            LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
+      });
+      if (PREDICT_TRUE(submit_status.ok())) {
+        return;
+      }
+      LOG_WITH_PREFIX(WARNING) << "Cannot submit snapshot preflush task: " << submit_status;
+    }
+  }
+  // No pool installed (or submission failed): flush inline. This only happens before
+  // SetCleanupPool is called, i.e. before the tablet serves consensus traffic, and in tests.
+  WARN_NOT_OK(
+      Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
+      LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
 }
 
 Status TabletSnapshots::Create(SnapshotOperation* operation) {

--- a/src/yb/tablet/tablet_snapshots.cc
+++ b/src/yb/tablet/tablet_snapshots.cc
@@ -69,6 +69,12 @@ DEFINE_NON_RUNTIME_int32(snapshot_cleanup_pool_size, 4,
     "Maximum number of concurrent tablet snapshot directory cleanup tasks per process.");
 TAG_FLAG(snapshot_cleanup_pool_size, advanced);
 
+DEFINE_RUNTIME_bool(snapshot_create_flush_on_prepare, true,
+    "Start a non-blocking flush of the tablet when a snapshot create operation is prepared, "
+    "so that most memtable data is already on disk by the time the operation is applied. "
+    "The synchronous flush during apply remains as the correctness backstop.");
+TAG_FLAG(snapshot_create_flush_on_prepare, advanced);
+
 DEFINE_test_flag(int32, delay_tablet_split_metadata_restore_secs, 0,
     "How much time in secs to delay restoring tablet split metadata after restoring "
     "checkpoint.");
@@ -368,6 +374,17 @@ bool TabletSnapshots::IsLastSnapshotTimeFilePath(const std::string& dir) {
 }
 
 Status TabletSnapshots::Prepare(SnapshotOperation* operation) {
+  if (FLAGS_snapshot_create_flush_on_prepare &&
+      operation->operation() == tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET) {
+    // Kick off a flush of all DBs now, overlapping it with Raft replication of this operation.
+    // Create() runs on the Raft apply path, where its synchronous flush blocks every subsequent
+    // operation on this tablet; warming the flush here shrinks that window to the delta written
+    // between prepare and apply. Correctness does not depend on this flush happening or
+    // completing: Create() still flushes synchronously before creating the checkpoint.
+    WARN_NOT_OK(
+        Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
+        LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
+  }
   return Status::OK();
 }
 
@@ -395,7 +412,11 @@ Status TabletSnapshots::Create(const CreateSnapshotData& data) {
   Status s;
   {
     SCOPED_WAIT_STATUS(Snapshot_WaitingForFlush);
-    s = regular_db().Flush(rocksdb::FlushOptions(rocksdb::FlushReason::kSnapshotCreation));
+    // Flush all DBs, not just the regular DB, so the flushes triggered internally by checkpoint
+    // creation below become no-ops; the intents flush would otherwise run while additionally
+    // holding create_checkpoint_lock(). When the prepare-time flush (see Prepare()) already ran,
+    // this only waits for the delta written since then.
+    s = Flush(FlushMode::kSync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation);
   }
 
   if (PREDICT_FALSE(!s.ok())) {

--- a/src/yb/tablet/tablet_snapshots.cc
+++ b/src/yb/tablet/tablet_snapshots.cc
@@ -69,12 +69,6 @@ DEFINE_NON_RUNTIME_int32(snapshot_cleanup_pool_size, 4,
     "Maximum number of concurrent tablet snapshot directory cleanup tasks per process.");
 TAG_FLAG(snapshot_cleanup_pool_size, advanced);
 
-DEFINE_RUNTIME_bool(snapshot_create_flush_on_prepare, true,
-    "Start a non-blocking flush of the tablet when a snapshot create operation is prepared, "
-    "so that most memtable data is already on disk by the time the operation is applied. "
-    "The synchronous flush during apply remains as the correctness backstop.");
-TAG_FLAG(snapshot_create_flush_on_prepare, advanced);
-
 DEFINE_test_flag(int32, delay_tablet_split_metadata_restore_secs, 0,
     "How much time in secs to delay restoring tablet split metadata after restoring "
     "checkpoint.");
@@ -229,8 +223,7 @@ TabletSnapshots::~TabletSnapshots() {
   CompleteShutdown();
 }
 
-void TabletSnapshots::SetCleanupPool(
-    ThreadPool* thread_pool, rpc::Scheduler* scheduler, ThreadPool* preflush_pool) {
+void TabletSnapshots::SetCleanupPool(ThreadPool* thread_pool, rpc::Scheduler* scheduler) {
   {
     std::lock_guard lock(cleanup_mutex_);
     if (shutting_down_) {
@@ -238,9 +231,6 @@ void TabletSnapshots::SetCleanupPool(
     }
     DCHECK(!cleanup_token_);
     cleanup_token_ = thread_pool->NewToken(ThreadPool::ExecutionMode::SERIAL);
-    if (preflush_pool) {
-      preflush_token_ = preflush_pool->NewToken(ThreadPool::ExecutionMode::CONCURRENT);
-    }
     retry_task_tracker_.Bind(scheduler);
   }
 
@@ -259,7 +249,6 @@ void TabletSnapshots::StartShutdown() {
 
 void TabletSnapshots::CompleteShutdown() {
   std::unique_ptr<ThreadPoolToken> cleanup_token;
-  std::unique_ptr<ThreadPoolToken> preflush_token;
   {
     std::lock_guard lock(cleanup_mutex_);
     if (!shutting_down_) {
@@ -271,13 +260,9 @@ void TabletSnapshots::CompleteShutdown() {
   {
     std::lock_guard lock(cleanup_mutex_);
     cleanup_token = std::move(cleanup_token_);
-    preflush_token = std::move(preflush_token_);
   }
   if (cleanup_token) {
     cleanup_token->Shutdown();
-  }
-  if (preflush_token) {
-    preflush_token->Shutdown();
   }
   {
     std::lock_guard lock(cleanup_mutex_);
@@ -382,53 +367,6 @@ bool TabletSnapshots::IsLastSnapshotTimeFilePath(const std::string& dir) {
   return dir.starts_with(kLastSnapshotPrefix);
 }
 
-Status TabletSnapshots::Prepare(SnapshotOperation* operation) {
-  if (FLAGS_snapshot_create_flush_on_prepare &&
-      operation->operation() == tserver::TabletSnapshotOpRequestPB::CREATE_ON_TABLET) {
-    SubmitPreflush();
-  }
-  return Status::OK();
-}
-
-void TabletSnapshots::SubmitPreflush() {
-  // Kick off a flush of all DBs now, overlapping it with Raft replication of this operation.
-  // Create() runs on the Raft apply path, where its synchronous flush blocks every subsequent
-  // operation on this tablet; warming the flush here shrinks that window to the delta written
-  // between prepare and apply. Correctness does not depend on this flush happening or completing:
-  // Create() still flushes synchronously before creating the checkpoint.
-  //
-  // On the leader, Prepare runs on the preparer thread, but on followers it runs inline in
-  // UpdateConsensus while the ReplicaState lock is held (see PreparerImpl::Submit). Even a
-  // non-waiting Tablet::Flush call synchronously enters the RocksDB write queue to switch the
-  // memtable, so dispatch it to the preflush pool instead of running it here. The token is
-  // shut down in CompleteShutdown, so the task cannot outlive this object.
-  {
-    std::lock_guard lock(cleanup_mutex_);
-    if (shutting_down_) {
-      return;
-    }
-    if (preflush_token_) {
-      // A submission failure means the token or pool is shutting down; drop the best-effort
-      // preflush rather than flushing inline, which would reintroduce the consensus-path work.
-      WARN_NOT_OK(
-          preflush_token_->SubmitFunc([this] {
-            WARN_NOT_OK(
-                Flush(
-                    FlushMode::kAsync, FlushFlags::kAllDbs,
-                    rocksdb::FlushReason::kSnapshotCreation),
-                LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
-          }),
-          LogPrefix() + "Cannot submit snapshot preflush task");
-      return;
-    }
-  }
-  // No preflush pool installed: flush inline. This only happens before SetCleanupPool is called,
-  // i.e. before the tablet serves consensus traffic, and in tests.
-  WARN_NOT_OK(
-      Flush(FlushMode::kAsync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation),
-      LogPrefix() + "Failed to schedule flush while preparing snapshot creation");
-}
-
 Status TabletSnapshots::Create(SnapshotOperation* operation) {
   return Create(CreateSnapshotData {
     .snapshot_hybrid_time = HybridTime::FromPB(operation->request()->snapshot_hybrid_time()),
@@ -454,9 +392,8 @@ Status TabletSnapshots::Create(const CreateSnapshotData& data) {
   {
     SCOPED_WAIT_STATUS(Snapshot_WaitingForFlush);
     // Flush all DBs, not just the regular DB, so the flushes triggered internally by checkpoint
-    // creation below become no-ops; the intents flush would otherwise run while additionally
-    // holding create_checkpoint_lock(). When the prepare-time flush (see Prepare()) already ran,
-    // this only waits for the delta written since then.
+    // creation below need not flush intents while additionally holding create_checkpoint_lock().
+    // Preflushing before submission does not cover intervening writes or follower catch-up.
     s = Flush(FlushMode::kSync, FlushFlags::kAllDbs, rocksdb::FlushReason::kSnapshotCreation);
   }
 

--- a/src/yb/tablet/tablet_snapshots.h
+++ b/src/yb/tablet/tablet_snapshots.h
@@ -71,7 +71,12 @@ class TabletSnapshots : public TabletComponent {
 
   Status Open();
 
-  void SetCleanupPool(ThreadPool* thread_pool, rpc::Scheduler* scheduler);
+  // preflush_pool must not be starvable by long-running tasks (e.g. an unbounded pool): the
+  // prepare-time snapshot preflush is only useful if it starts before the operation is applied,
+  // and its token shutdown waits for queued tasks. May be null; then the preflush is scheduled
+  // inline from Prepare.
+  void SetCleanupPool(
+      ThreadPool* thread_pool, rpc::Scheduler* scheduler, ThreadPool* preflush_pool);
   void StartShutdown();
   void CompleteShutdown();
 
@@ -208,9 +213,9 @@ class TabletSnapshots : public TabletComponent {
   // without this mutex, and only the serial token may call RunCleanup.
   std::mutex cleanup_mutex_;
   std::unique_ptr<ThreadPoolToken> cleanup_token_ GUARDED_BY(cleanup_mutex_);
-  // Concurrent-mode token on the same pool as cleanup_token_, used to dispatch the best-effort
-  // prepare-time flush of snapshot creation. Kept separate from the serial cleanup token so the
-  // flush does not queue behind recursive snapshot directory deletions.
+  // Concurrent-mode token used to dispatch the best-effort prepare-time flush of snapshot
+  // creation. Lives on an unstarvable pool, not the bounded snapshot cleanup pool, so the flush
+  // cannot queue behind recursive snapshot directory deletions from any tablet.
   std::unique_ptr<ThreadPoolToken> preflush_token_ GUARDED_BY(cleanup_mutex_);
   std::unordered_map<std::string, PendingSnapshotDeletion> pending_deletions_
       GUARDED_BY(cleanup_mutex_);

--- a/src/yb/tablet/tablet_snapshots.h
+++ b/src/yb/tablet/tablet_snapshots.h
@@ -192,6 +192,7 @@ class TabletSnapshots : public TabletComponent {
   void ScanDeletedSnapshotDirs();
   void ScheduleCleanup(PendingSnapshotDeletion deletion);
   void SubmitCleanup();
+  void SubmitPreflush();
   void RunCleanup();
   void ScheduleRetry();
   void PublishPendingDeletionState(const PendingSnapshotDeletion& deletion);
@@ -207,6 +208,10 @@ class TabletSnapshots : public TabletComponent {
   // without this mutex, and only the serial token may call RunCleanup.
   std::mutex cleanup_mutex_;
   std::unique_ptr<ThreadPoolToken> cleanup_token_ GUARDED_BY(cleanup_mutex_);
+  // Concurrent-mode token on the same pool as cleanup_token_, used to dispatch the best-effort
+  // prepare-time flush of snapshot creation. Kept separate from the serial cleanup token so the
+  // flush does not queue behind recursive snapshot directory deletions.
+  std::unique_ptr<ThreadPoolToken> preflush_token_ GUARDED_BY(cleanup_mutex_);
   std::unordered_map<std::string, PendingSnapshotDeletion> pending_deletions_
       GUARDED_BY(cleanup_mutex_);
   rpc::ScheduledTaskTracker retry_task_tracker_;

--- a/src/yb/tablet/tablet_snapshots.h
+++ b/src/yb/tablet/tablet_snapshots.h
@@ -71,12 +71,7 @@ class TabletSnapshots : public TabletComponent {
 
   Status Open();
 
-  // preflush_pool must not be starvable by long-running tasks (e.g. an unbounded pool): the
-  // prepare-time snapshot preflush is only useful if it starts before the operation is applied,
-  // and its token shutdown waits for queued tasks. May be null; then the preflush is scheduled
-  // inline from Prepare.
-  void SetCleanupPool(
-      ThreadPool* thread_pool, rpc::Scheduler* scheduler, ThreadPool* preflush_pool);
+  void SetCleanupPool(ThreadPool* thread_pool, rpc::Scheduler* scheduler);
   void StartShutdown();
   void CompleteShutdown();
 
@@ -93,9 +88,6 @@ class TabletSnapshots : public TabletComponent {
   Status Delete(const SnapshotOperation& operation);
 
   Status RestoreFinished(SnapshotOperation* operation);
-
-  // Prepares the operation context for a snapshot operation.
-  Status Prepare(SnapshotOperation* operation);
 
   Result<std::string> RestoreToTemporary(const TxnSnapshotId& snapshot_id, HybridTime restore_at);
 
@@ -197,7 +189,6 @@ class TabletSnapshots : public TabletComponent {
   void ScanDeletedSnapshotDirs();
   void ScheduleCleanup(PendingSnapshotDeletion deletion);
   void SubmitCleanup();
-  void SubmitPreflush();
   void RunCleanup();
   void ScheduleRetry();
   void PublishPendingDeletionState(const PendingSnapshotDeletion& deletion);
@@ -213,10 +204,6 @@ class TabletSnapshots : public TabletComponent {
   // without this mutex, and only the serial token may call RunCleanup.
   std::mutex cleanup_mutex_;
   std::unique_ptr<ThreadPoolToken> cleanup_token_ GUARDED_BY(cleanup_mutex_);
-  // Concurrent-mode token used to dispatch the best-effort prepare-time flush of snapshot
-  // creation. Lives on an unstarvable pool, not the bounded snapshot cleanup pool, so the flush
-  // cannot queue behind recursive snapshot directory deletions from any tablet.
-  std::unique_ptr<ThreadPoolToken> preflush_token_ GUARDED_BY(cleanup_mutex_);
   std::unordered_map<std::string, PendingSnapshotDeletion> pending_deletions_
       GUARDED_BY(cleanup_mutex_);
   rpc::ScheduledTaskTracker retry_task_tracker_;

--- a/src/yb/tablet/tablet_vector_indexes.cc
+++ b/src/yb/tablet/tablet_vector_indexes.cc
@@ -916,11 +916,15 @@ Status VectorIndexList::WaitForFlush() {
     return Status::OK();
   }
 
+  Status result;
   for (const auto& index : *list_) {
-    RETURN_NOT_OK(index->WaitForFlush());
+    auto status = index->WaitForFlush();
+    if (result.ok()) {
+      result = status;
+    }
   }
 
-  return Status::OK();
+  return result;
 }
 
 void VectorIndexList::Flush() {

--- a/src/yb/tserver/CMakeLists.txt
+++ b/src/yb/tserver/CMakeLists.txt
@@ -286,6 +286,8 @@ set(TSERVER_SRCS
   remote_snapshot_transfer_client.cc
   service_util.cc
   session_registry.cc
+  snapshot_preflush.cc
+  tablet_flusher.cc
   tablet_limits.cc
   tablet_memory_manager.cc
   tablet_server.cc

--- a/src/yb/tserver/backup_service-test.cc
+++ b/src/yb/tserver/backup_service-test.cc
@@ -10,29 +10,59 @@
 // or implied.  See the License for the specific language governing permissions and limitations
 // under the License.
 
+#include <future>
+
 #include "yb/common/wire_protocol.h"
 #include "yb/common/wire_protocol-test-util.h"
 
+#include "yb/consensus/consensus.h"
+#include "yb/consensus/consensus.pb.h"
+
+#include "yb/rocksdb/db.h"
+
 #include "yb/rpc/messenger.h"
+#include "yb/rpc/outbound_call.h"
 #include "yb/rpc/rpc_controller.h"
 
 #include "yb/tablet/tablet.h"
 #include "yb/tablet/tablet_metadata.h"
 #include "yb/tablet/tablet_peer.h"
+#include "yb/tablet/tablet_retention_policy.h"
 #include "yb/tablet/tablet_snapshots.h"
 
 #include "yb/tserver/backup.proxy.h"
 #include "yb/tserver/mini_tablet_server.h"
+#include "yb/tserver/tablet_flusher.h"
 #include "yb/tserver/tablet_server.h"
 #include "yb/tserver/tablet_server-test-base.h"
 #include "yb/tserver/ts_tablet_manager.h"
 #include "yb/tserver/tserver.pb.h"
+#include "yb/tserver/tserver_admin.pb.h"
+#include "yb/tserver/tserver_admin.proxy.h"
 #include "yb/tserver/tserver_service.proxy.h"
+
+#include "yb/util/backoff_waiter.h"
+#include "yb/util/countdown_latch.h"
+#include "yb/util/scope_exit.h"
+#include "yb/util/sync_point.h"
+#include "yb/util/test_thread_holder.h"
+
+DECLARE_bool(TEST_enable_sync_points);
+DECLARE_bool(TEST_fail_flush_mem_table);
+DECLARE_bool(enable_history_cutoff_propagation);
+DECLARE_bool(snapshot_create_flush_before_submit);
+DECLARE_int32(snapshot_preflush_concurrency);
+DECLARE_int32(snapshot_preflush_timeout_ms);
+DECLARE_int32(tablet_flush_concurrency);
+DECLARE_int32(timestamp_history_retention_interval_sec);
+METRIC_DECLARE_gauge_uint64(snapshot_preflush_active);
+METRIC_DECLARE_gauge_uint64(tablet_flush_active);
 
 namespace yb {
 namespace tserver {
 
 using std::string;
+using namespace std::literals;
 
 using yb::rpc::RpcController;
 
@@ -43,7 +73,9 @@ class BackupServiceTest : public TabletServerTestBase {
   Status WriteSingleRow(
       const std::string& tablet_id, int32_t key, int32_t int_val, const std::string& string_val);
 
-  Status CreateSnapshot(const std::string& tablet_id, const TxnSnapshotId& snapshot_id);
+  Status CreateSnapshot(
+      const std::string& tablet_id, const TxnSnapshotId& snapshot_id,
+      HybridTime snapshot_time = HybridTime::kInvalid);
 
   Status RestoreSnapshot(
       const std::string& tablet_id, const TxnSnapshotId& snapshot_id,
@@ -55,6 +87,557 @@ class BackupServiceTest : public TabletServerTestBase {
     StartTabletServer();
   }
 };
+
+class SnapshotPreflushServiceTest : public BackupServiceTest {
+ protected:
+  void SetUp() override {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_create_flush_before_submit) = true;
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_enable_sync_points) = true;
+    BackupServiceTest::SetUp();
+  }
+
+  void PauseFlush(
+      CountDownLatch& flushed, CountDownLatch& release, std::atomic<bool>* submitted = nullptr) {
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("TabletFlusher::Flushed", [&flushed, &release](void*) {
+      flushed.CountDown();
+      release.Wait();
+    });
+    if (submitted) {
+      sync->SetCallBack("SnapshotPreflush::BeforeSubmit", [submitted](void*) {
+        submitted->store(true, std::memory_order_release);
+      });
+    }
+    sync->EnableProcessing();
+  }
+
+  Result<tablet::TabletPtr> AddTablet(const TabletId& id) {
+    RETURN_NOT_OK(mini_server_->AddTestTablet(
+        "test-namespace", "test-table", id, schema_, table_type_));
+    RETURN_NOT_OK(WaitForTabletRunning(id.c_str()));
+    return VERIFY_RESULT(mini_server_->server()->tablet_manager()->GetTablet(id))->shared_tablet();
+  }
+
+  void InitializeRetention(const tablet::TabletPtr& tablet) {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_history_cutoff_propagation) = false;
+    ASSERT_OK(tablet->metadata()->set_namespace_id("test-namespace"));
+    ASSERT_OK(mini_server_->server()->XClusterHandleMasterHeartbeatResponse({}));
+  }
+
+  HybridTime HistoryCutoff(const tablet::TabletPtr& tablet) {
+    return tablet->RetentionPolicy()->GetRetentionDirective().history_cutoff.primary_cutoff_ht;
+  }
+
+  uint64_t ActiveFlushes() {
+    return mini_server_->server()->metric_entity()
+        ->FindOrNull<AtomicGauge<uint64_t>>(METRIC_tablet_flush_active)->value();
+  }
+
+  void TestPartialFlushFailure(bool fail_wait) {
+    auto first = ASSERT_RESULT(tablet_peer_->shared_tablet());
+    auto second = ASSERT_RESULT(AddTablet("second-tablet"));
+    ASSERT_OK(WriteSingleRow(first->tablet_id(), 1, 11, "value"));
+    ASSERT_OK(WriteSingleRow(second->tablet_id(), 1, 11, "value"));
+    auto* blocked_db = (fail_wait ? second : first)->regular_db();
+    auto* failing_tablet = (fail_wait ? first : second).get();
+    CountDownLatch started(1), injected(1), release(1);
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("DBImpl::BackgroundCallFlush:Start", [&](void* arg) {
+      if (arg == blocked_db) {
+        started.CountDown();
+        release.Wait();
+      }
+    });
+    sync->SetCallBack(fail_wait ? "TabletFlusher::BeforeWait" : "TabletFlusher::BeforeSuperblock",
+        [&](void* arg) {
+      auto& hook = *static_cast<std::pair<tablet::Tablet*, Status>*>(arg);
+      if (hook.first == failing_tablet) {
+        hook.second = STATUS(IOError, "injected flush failure");
+        injected.CountDown();
+      }
+    });
+    sync->EnableProcessing();
+    auto result = std::make_shared<std::promise<std::pair<Status, TabletId>>>();
+    auto future = result->get_future();
+    bool accepted = false;
+    auto cleanup = ScopeExit([&] {
+      release.CountDown();
+      if (accepted && future.valid()) {
+        future.wait();
+      }
+      sync->DisableProcessing();
+      sync->ClearAllCallBacks();
+    });
+    auto& flusher = mini_server_->server()->tablet_manager()->tablet_flusher();
+    FlushTabletsRequestPB request;
+    request.set_operation(FlushTabletsRequestPB::FLUSH);
+    const auto deadline = CoarseMonoClock::Now() + 10s;
+    ASSERT_OK(flusher.Submit({first, second}, request, deadline,
+        [result](const Status& status, const TabletId& id) { result->set_value({status, id}); }));
+    accepted = true;
+    ASSERT_TRUE(started.WaitFor(5s));
+    ASSERT_TRUE(injected.WaitFor(5s));
+    ASSERT_EQ(ActiveFlushes(), 1);
+    ASSERT_EQ(future.wait_for(20ms), std::future_status::timeout);
+    ASSERT_TRUE(flusher.Submit({first}, request, deadline,
+        [](const Status&, const TabletId&) {}).IsServiceUnavailable());
+    release.CountDown();
+    ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
+    const auto [status, id] = future.get();
+    ASSERT_TRUE(status.IsIOError()) << status;
+    ASSERT_STR_CONTAINS(status.ToString(), "injected flush failure");
+    ASSERT_EQ(id, failing_tablet->tablet_id());
+    ASSERT_EQ(ActiveFlushes(), 0);
+  }
+
+  void WaitForRetiredPreflight() {
+    ASSERT_OK(WaitFor([this] {
+      return mini_server_->server()->metric_entity()
+          ->FindOrNull<AtomicGauge<uint64_t>>(METRIC_snapshot_preflush_active)->value() == 0;
+    }, 5s, "Retire preflight callbacks"));
+  }
+};
+
+TEST_F(SnapshotPreflushServiceTest, WritesContinueUntilPreflushCompletes) {
+  CountDownLatch flushed(1), release(1);
+  std::atomic<bool> submitted{false};
+  auto* sync = SyncPoint::GetInstance();
+  PauseFlush(flushed, release, &submitted);
+  TestThreadHolder threads;
+  auto cleanup = ScopeExit([&] {
+    release.CountDown();
+    threads.JoinAll();
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  ASSERT_OK(WriteSingleRow(kTabletId, 1, 11, "value"));
+  Status status;
+  threads.AddThreadFunctor([&] {
+    status = CreateSnapshot(kTabletId, TxnSnapshotId::GenerateRandom());
+  });
+  ASSERT_TRUE(flushed.WaitFor(5s));
+  ASSERT_FALSE(submitted.load(std::memory_order_acquire));
+  ASSERT_OK(WriteSingleRow(kTabletId, 2, 22, "value"));
+  // Reject overlapping preflights rather than incorrectly reusing an earlier flush barrier.
+  ASSERT_NOK(CreateSnapshot(kTabletId, TxnSnapshotId::GenerateRandom()));
+  release.CountDown();
+  threads.JoinAll();
+  ASSERT_OK(status);
+  ASSERT_TRUE(submitted.load(std::memory_order_acquire));
+  ASSERT_NO_FATALS(WaitForRetiredPreflight());
+}
+
+TEST_F(SnapshotPreflushServiceTest, TimeoutDoesNotSubmitOnLateCompletion) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_preflush_timeout_ms) = 250;
+  CountDownLatch flushed(1), release(1), completed(1);
+  std::atomic<bool> submitted{false};
+  auto* sync = SyncPoint::GetInstance();
+  PauseFlush(flushed, release, &submitted);
+  TestThreadHolder threads;
+  auto cleanup = ScopeExit([&] {
+    release.CountDown();
+    threads.JoinAll();
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  Status status;
+  threads.AddThreadFunctor([&] {
+    status = CreateSnapshot(kTabletId, TxnSnapshotId::GenerateRandom());
+    completed.CountDown();
+  });
+  ASSERT_TRUE(flushed.WaitFor(5s));
+  ASSERT_TRUE(completed.WaitFor(5s));
+  ASSERT_TRUE(status.IsTimedOut()) << status;
+  ASSERT_OK(WriteSingleRow(kTabletId, 1, 11, "value"));
+  ASSERT_EQ(mini_server_->server()->metric_entity()
+      ->FindOrNull<AtomicGauge<uint64_t>>(METRIC_snapshot_preflush_active)->value(), 1);
+  release.CountDown();
+  threads.JoinAll();
+  ASSERT_NO_FATALS(WaitForRetiredPreflight());
+  ASSERT_FALSE(submitted.load(std::memory_order_acquire));
+}
+
+TEST_F(SnapshotPreflushServiceTest, ShutdownAbortsPendingPreflight) {
+  CountDownLatch flushed(1), release(1), completed(1);
+  auto* sync = SyncPoint::GetInstance();
+  PauseFlush(flushed, release);
+  TestThreadHolder threads;
+  auto cleanup = ScopeExit([&] {
+    release.CountDown();
+    threads.JoinAll();
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  Status status;
+  threads.AddThreadFunctor([&] {
+    status = CreateSnapshot(kTabletId, TxnSnapshotId::GenerateRandom());
+    completed.CountDown();
+  });
+  ASSERT_TRUE(flushed.WaitFor(5s));
+  threads.AddThreadFunctor([&] { mini_server_->Shutdown(); });
+  ASSERT_TRUE(completed.WaitFor(5s));
+  ASSERT_NOK(status);
+  release.CountDown();
+  threads.JoinAll();
+}
+
+TEST_F(SnapshotPreflushServiceTest, SnapshotDataIncludesWritesAfterPreflush) {
+  ASSERT_OK(WriteSingleRow(kTabletId, 1, 11, "value"));
+  auto* sync = SyncPoint::GetInstance();
+  Status write_status;
+  CountDownLatch write_completed(1);
+  sync->SetCallBack("SnapshotPreflush::BeforeSubmit", [&](void*) {
+    write_status = WriteSingleRow(kTabletId, 2, 22, "value");
+    write_completed.CountDown();
+  });
+  sync->EnableProcessing();
+  auto cleanup = ScopeExit([&] {
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  auto snapshot_id = TxnSnapshotId::GenerateRandom();
+  ASSERT_OK(CreateSnapshot(kTabletId, snapshot_id));
+  ASSERT_TRUE(write_completed.WaitFor(5s));
+  ASSERT_OK(write_status);
+  ASSERT_OK(WriteSingleRow(kTabletId, 3, 33, "value"));
+  ASSERT_OK(RestoreSnapshot(kTabletId, snapshot_id, TxnSnapshotRestorationId::GenerateRandom()));
+  VerifyRows(schema_, {KeyValue(1, 11), KeyValue(2, 22)});
+}
+
+TEST_F(SnapshotPreflushServiceTest, HistoryRemainsPinnedThroughPreflight) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_history_cutoff_propagation) = false;
+  ASSERT_OK(WriteSingleRow(kTabletId, 1, 11, "value"));
+  auto peer = ASSERT_RESULT(mini_server_->server()->tablet_manager()->GetTablet(kTabletId));
+  auto tablet = ASSERT_RESULT(peer->shared_tablet());
+  ASSERT_NO_FATALS(InitializeRetention(tablet));
+  const auto snapshot_time = peer->clock().Now();
+  std::atomic<bool> history_pinned{false};
+  auto* sync = SyncPoint::GetInstance();
+  sync->SetCallBack("SnapshotPreflush::BeforeSubmit", [&](void*) {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_timestamp_history_retention_interval_sec) = 0;
+    history_pinned.store(tablet->RetentionPolicy()->GetRetentionDirective()
+        .history_cutoff.primary_cutoff_ht <= snapshot_time, std::memory_order_release);
+  });
+  sync->EnableProcessing();
+  auto cleanup = ScopeExit([&] {
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  ASSERT_OK(CreateSnapshot(kTabletId, TxnSnapshotId::GenerateRandom(), snapshot_time));
+  ASSERT_TRUE(history_pinned.load(std::memory_order_acquire));
+  ASSERT_OK(WaitFor([&] {
+    return tablet->RetentionPolicy()->GetRetentionDirective().history_cutoff.primary_cutoff_ht >
+        snapshot_time;
+  }, 5s, "Snapshot history guard released after submission"));
+}
+
+TEST_F(SnapshotPreflushServiceTest, EqualTimestampReadersUnregisterIndependently) {
+  auto tablet = ASSERT_RESULT(tablet_peer_->shared_tablet());
+  ASSERT_NO_FATALS(InitializeRetention(tablet));
+  const auto time = tablet_peer_->clock().Now();
+  auto first = ASSERT_RESULT(tablet::ScopedReadOperation::Create(
+      tablet.get(), tablet::RequireLease::kTrue, ReadHybridTime::SingleTime(time)));
+  auto second = ASSERT_RESULT(tablet::ScopedReadOperation::Create(
+      tablet.get(), tablet::RequireLease::kTrue, ReadHybridTime::SingleTime(time)));
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_timestamp_history_retention_interval_sec) = 0;
+  ASSERT_EQ(HistoryCutoff(tablet), time);
+  first.Reset();
+  ASSERT_EQ(HistoryCutoff(tablet), time);
+  second.Reset();
+  ASSERT_GT(HistoryCutoff(tablet), time);
+}
+
+TEST_F(SnapshotPreflushServiceTest, RejectedOverlapKeepsOriginalHistoryPin) {
+  Status status;
+  auto tablet = ASSERT_RESULT(tablet_peer_->shared_tablet());
+  ASSERT_NO_FATALS(InitializeRetention(tablet));
+  ASSERT_OK(WriteSingleRow(kTabletId, 1, 11, "value"));
+  const auto time = tablet_peer_->clock().Now();
+  CountDownLatch flushed(1), release(1);
+  auto* sync = SyncPoint::GetInstance();
+  PauseFlush(flushed, release);
+  TestThreadHolder threads;
+  auto cleanup = ScopeExit([&] {
+    release.CountDown();
+    threads.JoinAll();
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  threads.AddThreadFunctor([&] {
+    status = CreateSnapshot(kTabletId, TxnSnapshotId::GenerateRandom(), time);
+  });
+  ASSERT_TRUE(flushed.WaitFor(5s));
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_timestamp_history_retention_interval_sec) = 0;
+  ASSERT_EQ(HistoryCutoff(tablet), time);
+  auto rejected = CreateSnapshot(kTabletId, TxnSnapshotId::GenerateRandom(), time);
+  ASSERT_EQ(rpc::RpcError(rejected), rpc::ErrorStatusPB::ERROR_SERVER_TOO_BUSY) << rejected;
+  // Rejection releases its guard before responding, so this checks the surviving registration.
+  ASSERT_EQ(HistoryCutoff(tablet), time);
+  release.CountDown();
+  threads.JoinAll();
+  ASSERT_OK(status);
+  ASSERT_OK(WaitFor([&] { return HistoryCutoff(tablet) > time; }, 5s, "Release history pin"));
+}
+
+TEST_F(SnapshotPreflushServiceTest, StepdownAfterFlushPreventsSubmission) {
+  auto peer = ASSERT_RESULT(mini_server_->server()->tablet_manager()->GetTablet(kTabletId));
+  auto consensus = ASSERT_RESULT(peer->GetConsensus());
+  auto* sync = SyncPoint::GetInstance();
+  Status stepdown_status;
+  CountDownLatch stepped_down(1);
+  sync->SetCallBack("SnapshotPreflush::BeforeSubmit", [&](void*) {
+    consensus::LeaderStepDownRequestPB request;
+    consensus::LeaderStepDownResponsePB response;
+    request.set_tablet_id(kTabletId);
+    request.set_disable_graceful_transition(true);
+    stepdown_status = consensus->StepDown(&request, &response);
+    if (stepdown_status.ok() && response.has_error()) {
+      stepdown_status = StatusFromPB(response.error().status());
+    }
+    stepped_down.CountDown();
+  });
+  sync->EnableProcessing();
+  auto cleanup = ScopeExit([&] {
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  const auto snapshot_id = TxnSnapshotId::GenerateRandom();
+  ASSERT_NOK(CreateSnapshot(kTabletId, snapshot_id));
+  ASSERT_TRUE(stepped_down.WaitFor(5s));
+  ASSERT_OK(stepdown_status);
+  ASSERT_NO_FATALS(WaitForRetiredPreflight());
+  ASSERT_FALSE(peer->tablet_metadata()->fs_manager()->env()->FileExists(JoinPathSegments(
+      peer->tablet_metadata()->snapshots_dir(), snapshot_id.ToString())));
+}
+
+TEST_F(SnapshotPreflushServiceTest, ReceiverRejectsOverlapAndInvalidFlags) {
+  auto peer = ASSERT_RESULT(mini_server_->server()->tablet_manager()->GetTablet(kTabletId));
+  auto tablet = ASSERT_RESULT(peer->shared_tablet());
+  auto& flusher = mini_server_->server()->tablet_manager()->tablet_flusher();
+  FlushTabletsRequestPB request;
+  request.set_operation(FlushTabletsRequestPB::FLUSH);
+  request.set_flags(tablet::FLUSH_COMPACT_VECTOR_INDEX_EXCLUDED);
+  const auto deadline = CoarseMonoClock::Now() + 5s;
+  const auto ignored = [](const Status&, const TabletId&) {};
+  ASSERT_TRUE(flusher.Submit({tablet}, request, deadline, ignored).IsInvalidArgument());
+  request.set_flags(tablet::FLUSH_COMPACT_ALL);
+  ASSERT_TRUE(flusher.Submit({tablet}, request, CoarseMonoClock::Now(), ignored).IsTimedOut());
+
+  CountDownLatch flushed(1), release(1);
+  auto* sync = SyncPoint::GetInstance();
+  PauseFlush(flushed, release);
+  auto cleanup = ScopeExit([&] {
+    release.CountDown();
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  auto result = std::make_shared<std::promise<Status>>();
+  auto future = result->get_future();
+  ASSERT_OK(flusher.Submit({tablet, tablet}, request, deadline,
+      [result](const Status& status, const TabletId&) { result->set_value(status); }));
+  ASSERT_TRUE(flushed.WaitFor(5s));
+  ASSERT_TRUE(flusher.Submit({tablet}, request, deadline, ignored).IsServiceUnavailable());
+  release.CountDown();
+  ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
+  ASSERT_OK(future.get());
+}
+
+TEST_F(SnapshotPreflushServiceTest, GuardFailureDoesNotLaunchEarlierFlush) {
+  auto first = ASSERT_RESULT(tablet_peer_->shared_tablet());
+  auto second = ASSERT_RESULT(AddTablet("second-tablet"));
+  ASSERT_OK(WriteSingleRow(first->tablet_id(), 1, 11, "value"));
+  auto second_peer = ASSERT_RESULT(
+      mini_server_->server()->tablet_manager()->GetTablet(second->tablet_id()));
+  ASSERT_OK(second_peer->TEST_Shutdown(
+      tablet::ShouldAbortActiveTransactions::kFalse, tablet::DisableFlushOnShutdown::kTrue));
+  auto started = std::make_shared<std::atomic<bool>>(false);
+  auto* sync = SyncPoint::GetInstance();
+  sync->SetCallBack("DBImpl::BackgroundCallFlush:Start",
+      [started, db = first->regular_db()](void* arg) {
+    if (arg == db) {
+      started->store(true, std::memory_order_release);
+    }
+  });
+  sync->EnableProcessing();
+  auto cleanup = ScopeExit([&] {
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  auto result = std::make_shared<std::promise<std::pair<Status, TabletId>>>();
+  auto future = result->get_future();
+  FlushTabletsRequestPB request;
+  ASSERT_OK(mini_server_->server()->tablet_manager()->tablet_flusher().Submit(
+      {first, second}, request, CoarseMonoClock::Now() + 5s,
+      [result](const Status& status, const TabletId& id) { result->set_value({status, id}); }));
+  ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
+  const auto [status, id] = future.get();
+  ASSERT_TRUE(status.IsShutdownInProgress()) << status;
+  ASSERT_EQ(id, second->tablet_id());
+  ASSERT_OK(first->regular_db()->WaitForFlush());
+  first->regular_db()->WaitForFlushJobs();
+  ASSERT_FALSE(started->load(std::memory_order_acquire));
+  ASSERT_EQ(ActiveFlushes(), 0);
+}
+
+TEST_F(SnapshotPreflushServiceTest, SuperblockFailureDrainsEarlierFlush) {
+  TestPartialFlushFailure(false);
+}
+
+TEST_F(SnapshotPreflushServiceTest, WaitFailureDrainsLaterFlush) {
+  TestPartialFlushFailure(true);
+}
+
+TEST_F(SnapshotPreflushServiceTest, BackgroundErrorRetainsAdmissionUntilCleanup) {
+  auto tablet = ASSERT_RESULT(tablet_peer_->shared_tablet());
+  ASSERT_OK(WriteSingleRow(kTabletId, 1, 11, "value"));
+  CountDownLatch failed(1), release(1);
+  auto* sync = SyncPoint::GetInstance();
+  sync->SetCallBack("DBImpl::WaitAfterBackgroundError", [&](void* arg) {
+    if (arg == tablet->regular_db()) {
+      failed.CountDown();
+      release.Wait();
+    }
+  });
+  sync->EnableProcessing();
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_flush_mem_table) = true;
+  auto result = std::make_shared<std::promise<Status>>();
+  auto future = result->get_future();
+  bool accepted = false;
+  auto cleanup = ScopeExit([&] {
+    release.CountDown();
+    if (accepted && future.valid()) {
+      future.wait();
+    }
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_flush_mem_table) = false;
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  auto& flusher = mini_server_->server()->tablet_manager()->tablet_flusher();
+  FlushTabletsRequestPB request;
+  request.set_operation(FlushTabletsRequestPB::FLUSH);
+  ASSERT_OK(flusher.Submit({tablet}, request, CoarseMonoClock::Now() + 5s,
+      [result](const Status& status, const TabletId&) { result->set_value(status); }));
+  accepted = true;
+  ASSERT_TRUE(failed.WaitFor(5s));
+  ASSERT_NOK(tablet->regular_db()->WaitForFlush());
+  ASSERT_EQ(ActiveFlushes(), 1);
+  ASSERT_EQ(future.wait_for(20ms), std::future_status::timeout);
+  ASSERT_TRUE(flusher.Submit({tablet}, request, CoarseMonoClock::Now() + 5s,
+      [](const Status&, const TabletId&) {}).IsServiceUnavailable());
+  release.CountDown();
+  ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
+  ASSERT_TRUE(future.get().IsIOError());
+  ASSERT_EQ(ActiveFlushes(), 0);
+}
+
+TEST_F(SnapshotPreflushServiceTest, ReceiverRpcTimeoutRetainsAdmission) {
+  auto tablet = ASSERT_RESULT(tablet_peer_->shared_tablet());
+  ASSERT_OK(WriteSingleRow(kTabletId, 1, 11, "value"));
+  CountDownLatch started(1), release(1);
+  auto* sync = SyncPoint::GetInstance();
+  sync->SetCallBack("DBImpl::BackgroundCallFlush:Start", [&](void* arg) {
+    if (arg == tablet->regular_db()) {
+      started.CountDown();
+      release.Wait();
+    }
+  });
+  sync->EnableProcessing();
+  FlushTabletsRequestPB request;
+  request.set_dest_uuid(mini_server_->server()->permanent_uuid());
+  request.add_tablet_ids(kTabletId);
+  FlushTabletsResponsePB response;
+  RpcController controller;
+  controller.set_timeout(250ms);
+  CountDownLatch replied(1);
+  auto cleanup = ScopeExit([&] {
+    release.CountDown();
+    replied.Wait();
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+    ASSERT_OK(WaitFor([&] { return ActiveFlushes() == 0; }, 5s, "Receiver flush retired"));
+  });
+  admin_proxy_->FlushTabletsAsync(request, &response, &controller, [&] { replied.CountDown(); });
+  ASSERT_TRUE(started.WaitFor(5s));
+  ASSERT_TRUE(replied.WaitFor(5s));
+  ASSERT_TRUE(controller.status().IsTimedOut()) << controller.status();
+  ASSERT_EQ(ActiveFlushes(), 1);
+  RpcController retry_controller;
+  retry_controller.set_timeout(5s);
+  FlushTabletsResponsePB retry_response;
+  const auto rejected = admin_proxy_->FlushTablets(request, &retry_response, &retry_controller);
+  ASSERT_EQ(rpc::RpcError(rejected), rpc::ErrorStatusPB::ERROR_SERVER_TOO_BUSY) << rejected;
+  release.CountDown();
+  ASSERT_OK(WaitFor([&] { return ActiveFlushes() == 0; }, 5s, "Receiver flush retired"));
+  retry_controller.Reset();
+  retry_controller.set_timeout(5s);
+  retry_response.Clear();
+  ASSERT_OK(admin_proxy_->FlushTablets(request, &retry_response, &retry_controller));
+  ASSERT_FALSE(retry_response.has_error()) << retry_response.DebugString();
+}
+
+TEST_F(SnapshotPreflushServiceTest, LocalFlushFailureDoesNotSubmit) {
+  mini_server_->server()->tablet_manager()->tablet_flusher().StartShutdown();
+  auto status = CreateSnapshot(kTabletId, TxnSnapshotId::GenerateRandom());
+  ASSERT_TRUE(status.IsShutdownInProgress()) << status;
+  ASSERT_NO_FATALS(WaitForRetiredPreflight());
+  ASSERT_OK(WriteSingleRow(kTabletId, 1, 11, "value"));
+}
+
+class SnapshotPreflushLimitServiceTest : public SnapshotPreflushServiceTest {
+ protected:
+  void SetUp() override {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_preflush_concurrency) = 1;
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_tablet_flush_concurrency) = 1;
+    SnapshotPreflushServiceTest::SetUp();
+  }
+
+  void TestCapacity(bool snapshot) {
+    Status first_status;
+    auto second = ASSERT_RESULT(AddTablet("second-tablet"));
+    auto send = [&](const TabletId& id) -> Status {
+      if (snapshot) {
+        return CreateSnapshot(id, TxnSnapshotId::GenerateRandom());
+      }
+      FlushTabletsRequestPB request;
+      request.set_dest_uuid(mini_server_->server()->permanent_uuid());
+      request.add_tablet_ids(id);
+      FlushTabletsResponsePB response;
+      RpcController controller;
+      controller.set_timeout(10s);
+      RETURN_NOT_OK(admin_proxy_->FlushTablets(request, &response, &controller));
+      return response.has_error() ? StatusFromPB(response.error().status()) : Status::OK();
+    };
+    CountDownLatch flushed(1), release(1);
+    auto* sync = SyncPoint::GetInstance();
+    PauseFlush(flushed, release);
+    TestThreadHolder threads;
+    auto cleanup = ScopeExit([&] {
+      release.CountDown();
+      threads.JoinAll();
+      sync->DisableProcessing();
+      sync->ClearAllCallBacks();
+    });
+    threads.AddThreadFunctor([&] { first_status = send(kTabletId); });
+    ASSERT_TRUE(flushed.WaitFor(5s));
+    auto rejected = send(second->tablet_id());
+    ASSERT_EQ(rpc::RpcError(rejected), rpc::ErrorStatusPB::ERROR_SERVER_TOO_BUSY) << rejected;
+    ASSERT_STR_CONTAINS(rejected.ToString(), snapshot ? "Snapshot preflight capacity exhausted" :
+                                                       "Tablet flush capacity exhausted");
+    release.CountDown();
+    threads.JoinAll();
+    ASSERT_OK(first_status);
+    ASSERT_NO_FATALS(WaitForRetiredPreflight());
+    ASSERT_OK(send(second->tablet_id()));
+  }
+};
+
+TEST_F(SnapshotPreflushLimitServiceTest, OriginLimitAcrossDistinctTablets) {
+  TestCapacity(true);
+}
+
+TEST_F(SnapshotPreflushLimitServiceTest, ReceiverLimitAcrossDistinctTablets) {
+  TestCapacity(false);
+}
 
 TEST_F(BackupServiceTest, TestCreateTabletSnapshot) {
   // Verify that the tablet exists.
@@ -184,12 +767,13 @@ Status BackupServiceTest::WriteSingleRow(
 }
 
 Status BackupServiceTest::CreateSnapshot(
-    const std::string& tablet_id, const TxnSnapshotId& snapshot_id) {
+    const std::string& tablet_id, const TxnSnapshotId& snapshot_id, HybridTime snapshot_time) {
   TabletSnapshotOpRequestPB req;
   TabletSnapshotOpResponsePB resp;
   req.set_operation(TabletSnapshotOpRequestPB::CREATE_ON_TABLET);
   req.set_dest_uuid(mini_server_->server()->fs_manager()->uuid());
   req.set_snapshot_id(snapshot_id.data(), snapshot_id.size());
+  req.set_snapshot_hybrid_time(snapshot_time.ToUint64());
   req.add_tablet_id(tablet_id);
   RpcController rpc;
   SCOPED_TRACE(req.DebugString());

--- a/src/yb/tserver/backup_service.cc
+++ b/src/yb/tserver/backup_service.cc
@@ -22,6 +22,7 @@
 #include "yb/tablet/operations/snapshot_operation.h"
 
 #include "yb/tserver/service_util.h"
+#include "yb/tserver/snapshot_preflush.h"
 #include "yb/tserver/tablet_server.h"
 #include "yb/tserver/ts_tablet_manager.h"
 
@@ -34,6 +35,8 @@ using namespace std::literals;
 
 DEFINE_test_flag(bool, fail_tserver_snapshot_op, false, "Fail to delete snapshot");
 
+DECLARE_bool(snapshot_create_flush_before_submit);
+
 namespace yb {
 namespace tserver {
 
@@ -44,7 +47,15 @@ using tablet::OperationCompletionCallback;
 TabletServiceBackupImpl::TabletServiceBackupImpl(TSTabletManager* tablet_manager,
                                                  const scoped_refptr<MetricEntity>& metric_entity)
     : TabletServerBackupServiceIf(metric_entity),
-      tablet_manager_(tablet_manager) {
+      tablet_manager_(tablet_manager),
+      preflush_(std::make_unique<SnapshotPreflush>(tablet_manager->server())) {
+}
+
+TabletServiceBackupImpl::~TabletServiceBackupImpl() = default;
+
+void TabletServiceBackupImpl::Shutdown() {
+  preflush_->StartShutdown();
+  preflush_->CompleteShutdown();
 }
 
 void TabletServiceBackupImpl::TabletSnapshotOp(const TabletSnapshotOpRequestPB* req,
@@ -115,6 +126,9 @@ void TabletServiceBackupImpl::TabletSnapshotOp(const TabletSnapshotOpRequestPB* 
     }
   }
 
+  const auto deadline = context.GetClientDeadline();
+  const bool preflush = FLAGS_snapshot_create_flush_before_submit &&
+      req->operation() == TabletSnapshotOpRequestPB::CREATE_ON_TABLET;
   auto operation = std::make_unique<SnapshotOperation>(tablet.tablet);
   operation->AllocateRequest()->CopyFrom(*req);
 
@@ -126,9 +140,11 @@ void TabletServiceBackupImpl::TabletSnapshotOp(const TabletSnapshotOpRequestPB* 
     return;
   }
 
-  // TODO(txn_snapshot) Avoid duplicate snapshots.
-  // Submit the create snapshot op. The RPC will be responded to asynchronously.
-  tablet.peer->Submit(std::move(operation), tablet.leader_term);
+  if (preflush) {
+    preflush_->Submit(std::move(tablet), std::move(operation), std::move(read_operation), deadline);
+  } else {
+    tablet.peer->Submit(std::move(operation), tablet.leader_term);
+  }
 }
 
 }  // namespace tserver

--- a/src/yb/tserver/backup_service.h
+++ b/src/yb/tserver/backup_service.h
@@ -17,18 +17,22 @@
 namespace yb {
 namespace tserver {
 
+class SnapshotPreflush;
 class TSTabletManager;
 
 class TabletServiceBackupImpl : public TabletServerBackupServiceIf {
  public:
   TabletServiceBackupImpl(TSTabletManager* tablet_manager,
                           const scoped_refptr<MetricEntity>& metric_entity);
+  ~TabletServiceBackupImpl() override;
+  void Shutdown() override;
 
   virtual void TabletSnapshotOp(const TabletSnapshotOpRequestPB* req,
                                 TabletSnapshotOpResponsePB* resp,
                                 rpc::RpcContext context) override;
  private:
   TSTabletManager* tablet_manager_;
+  std::unique_ptr<SnapshotPreflush> preflush_;
 };
 
 }  // namespace tserver

--- a/src/yb/tserver/snapshot_preflush.cc
+++ b/src/yb/tserver/snapshot_preflush.cc
@@ -1,0 +1,348 @@
+// Copyright (c) YugabyteDB, Inc.
+
+#include "yb/tserver/snapshot_preflush.h"
+
+#include <condition_variable>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+
+#include "yb/common/wire_protocol.h"
+#include "yb/consensus/consensus.h"
+#include "yb/consensus/metadata.pb.h"
+#include "yb/rpc/rpc_controller.h"
+#include "yb/tablet/operations/snapshot_operation.h"
+#include "yb/tablet/tablet.h"
+#include "yb/tablet/tablet_peer.h"
+#include "yb/tserver/service_util.h"
+#include "yb/tserver/tablet_flusher.h"
+#include "yb/tserver/tablet_server.h"
+#include "yb/tserver/ts_tablet_manager.h"
+#include "yb/tserver/tserver_admin.proxy.h"
+#include "yb/util/flag_validators.h"
+#include "yb/util/flags.h"
+#include "yb/util/metrics.h"
+#include "yb/util/status_format.h"
+#include "yb/util/sync_point.h"
+#include "yb/util/threadpool.h"
+
+using namespace std::literals;
+
+DEFINE_RUNTIME_bool(snapshot_create_flush_before_submit, false,
+    "Wait for separate flush RPCs to all captured replicas before submitting snapshot creation. "
+    "An unavailable replica prevents snapshot submission; normal replication continues.");
+TAG_FLAG(snapshot_create_flush_before_submit, advanced);
+DEFINE_RUNTIME_int32(snapshot_preflush_timeout_ms, 10000,
+    "Preflight flush budget, capped by the snapshot RPC deadline.");
+DEFINE_validator(snapshot_preflush_timeout_ms, FLAG_GT_VALUE_VALIDATOR(0));
+TAG_FLAG(snapshot_preflush_timeout_ms, advanced);
+DEFINE_NON_RUNTIME_int32(snapshot_preflush_concurrency, 4,
+    "Maximum outstanding snapshot preflights per tablet server, including retiring flush work.");
+DEFINE_validator(snapshot_preflush_concurrency, FLAG_GT_VALUE_VALIDATOR(0));
+TAG_FLAG(snapshot_preflush_concurrency, advanced);
+
+METRIC_DEFINE_event_stats(server, snapshot_preflush_duration_us, "Snapshot preflight duration",
+    yb::MetricUnit::kMicroseconds, "Time spent preflushing before snapshot submission");
+METRIC_DEFINE_gauge_uint64(server, snapshot_preflush_active, "Active snapshot preflights",
+    yb::MetricUnit::kOperations, "Admitted preflights including retiring work", 0);
+METRIC_DEFINE_counter(server, snapshot_preflush_failures, "Snapshot preflight failures",
+    yb::MetricUnit::kOperations, "Failed snapshot preflight attempts");
+METRIC_DEFINE_counter(server, snapshot_preflush_timeouts, "Snapshot preflight timeouts",
+    yb::MetricUnit::kOperations, "Snapshot preflight attempts that exhausted their deadline");
+METRIC_DEFINE_counter(server, snapshot_preflush_rejections, "Snapshot preflight rejections",
+    yb::MetricUnit::kOperations, "Snapshot preflight attempts rejected by admission control");
+
+namespace yb::tserver {
+namespace {
+
+struct FlushResults;
+
+struct Admission {
+  // Weak entries let late RPC/local completions retain admission without retaining the service.
+  std::mutex mutex;
+  bool closing GUARDED_BY(mutex) = false;
+  std::unordered_map<TabletId, std::weak_ptr<FlushResults>> active GUARDED_BY(mutex);
+  scoped_refptr<AtomicGauge<uint64_t>> metric;
+};
+
+struct FlushResults {
+  std::shared_ptr<Admission> admission;
+  TabletId tablet_id;
+  bool admitted = false;
+  std::mutex mutex;
+  std::condition_variable changed;
+  size_t remaining GUARDED_BY(mutex) = 0;
+  Status status GUARDED_BY(mutex);
+
+  ~FlushResults() {
+    if (admitted) {
+      std::lock_guard lock(admission->mutex);
+      admission->active.erase(tablet_id);
+      admission->metric->Decrement();
+    }
+  }
+
+  void Complete(const Status& result) {
+    std::lock_guard lock(mutex);
+    --remaining;
+    if (status.ok() && !result.ok()) {
+      status = result;
+    }
+    changed.notify_all();
+  }
+
+  void Stop() {
+    std::lock_guard lock(mutex);
+    status = STATUS(ShutdownInProgress, "Snapshot preflight is shutting down");
+    changed.notify_all();
+  }
+
+  // Clang does not track std::unique_lock across condition-variable waits.
+  Status Wait(CoarseTimePoint deadline) NO_THREAD_SAFETY_ANALYSIS {
+    std::unique_lock lock(mutex);
+    if (!changed.wait_until(lock, deadline, [this]() REQUIRES(mutex) {
+          return !status.ok() || remaining == 0;
+        })) {
+      return STATUS(TimedOut, "Snapshot preflight flush deadline expired");
+    }
+    return status;
+  }
+};
+
+struct RemoteFlush {
+  RemoteFlush(rpc::ProxyCache* cache, const HostPort& address)
+      : proxy(cache, address) {}
+  TabletServerAdminServiceProxy proxy;
+  FlushTabletsRequestPB request;
+  FlushTabletsResponsePB response;
+  rpc::RpcController controller;
+};
+
+// The operation's RPC callback owns its response storage. Release history before tablet refs.
+struct Attempt {
+  LeaderTabletPeer tablet;
+  std::unique_ptr<tablet::SnapshotOperation> operation;
+  tablet::ScopedReadOperation read_operation;
+  std::shared_ptr<FlushResults> results;
+  CoarseTimePoint deadline;
+  std::optional<consensus::ConsensusStatePB> configuration;
+};
+
+using Membership = std::map<std::string, consensus::PeerMemberType>;
+
+Membership Members(const consensus::RaftConfigPB& config) {
+  Membership result;
+  for (const auto& peer : config.peers()) {
+    result.emplace(peer.permanent_uuid(), peer.member_type());
+  }
+  return result;
+}
+
+}  // namespace
+
+class SnapshotPreflush::Impl {
+ public:
+  explicit Impl(TabletServer* server)
+      : server_(*server), limit_(FLAGS_snapshot_preflush_concurrency),
+        admission_(std::make_shared<Admission>()),
+        duration_(METRIC_snapshot_preflush_duration_us.Instantiate(server->metric_entity())),
+        failures_(METRIC_snapshot_preflush_failures.Instantiate(server->metric_entity())),
+        timeouts_(METRIC_snapshot_preflush_timeouts.Instantiate(server->metric_entity())),
+        rejections_(METRIC_snapshot_preflush_rejections.Instantiate(server->metric_entity())) {
+    admission_->metric = METRIC_snapshot_preflush_active.Instantiate(server->metric_entity(), 0);
+    CHECK_OK(ThreadPoolBuilder("snapshot-preflight").set_max_threads(static_cast<int>(limit_))
+        .Build(&pool_));
+  }
+
+  void Submit(std::shared_ptr<Attempt> attempt) {
+    auto results = std::make_shared<FlushResults>();
+    results->admission = admission_;
+    results->tablet_id = attempt->tablet.tablet->tablet_id();
+    attempt->results = results;
+    auto status = AdmitAndSubmit(attempt);
+    if (!status.ok()) {
+      rejections_->Increment();
+      attempt->read_operation.Reset();
+      attempt->operation->Aborted(status, false);
+    }
+  }
+
+  void StartShutdown() {
+    std::vector<std::shared_ptr<FlushResults>> active;
+    {
+      std::lock_guard lock(admission_->mutex);
+      admission_->closing = true;
+      for (const auto& [id, weak] : admission_->active) {
+        if (auto results = weak.lock()) {
+          active.push_back(std::move(results));
+        }
+      }
+    }
+    for (const auto& results : active) {
+      results->Stop();
+    }
+  }
+
+  void CompleteShutdown() {
+    pool_->Wait();
+    pool_->Shutdown();
+  }
+
+ private:
+  Status AdmitAndSubmit(const std::shared_ptr<Attempt>& attempt) {
+    const auto& results = attempt->results;
+    std::lock_guard lock(admission_->mutex);
+    SCHECK(!admission_->closing, ShutdownInProgress, "Snapshot preflight is shutting down");
+    SCHECK_LT(admission_->active.size(), limit_, ServiceUnavailable,
+              "Snapshot preflight capacity exhausted");
+    SCHECK(!admission_->active.contains(results->tablet_id), ServiceUnavailable,
+            "Snapshot preflight already in progress for tablet");
+    admission_->active.emplace(results->tablet_id, results);
+    results->admitted = true;
+    admission_->metric->Increment();
+    // Enqueue before StartShutdown can begin draining the pool.
+    return pool_->SubmitFunc([this, attempt] { Run(attempt); });
+  }
+
+  void Run(const std::shared_ptr<Attempt>& attempt) {
+    const auto start = CoarseMonoClock::Now();
+    auto status = Preflush(attempt);
+    if (status.ok()) {
+      TEST_SYNC_POINT_CALLBACK("SnapshotPreflush::BeforeSubmit", attempt->tablet.tablet.get());
+      // Recheck after hooks and all metadata reads, not only before the flush.
+      status = CheckActive(*attempt);
+    }
+    duration_->Increment(ToMicroseconds(CoarseMonoClock::Now() - start));
+    if (!status.ok()) {
+      failures_->Increment();
+      if (status.IsTimedOut()) {
+        timeouts_->Increment();
+      }
+      LOG(WARNING) << "Snapshot preflight for " << attempt->results->tablet_id << ": " << status;
+      attempt->operation->Aborted(status, false);
+      return;
+    }
+    attempt->tablet.peer->Submit(std::move(attempt->operation), attempt->tablet.leader_term);
+  }
+
+  Status CheckActive(const Attempt& attempt) {
+    {
+      std::lock_guard lock(admission_->mutex);
+      SCHECK(!admission_->closing, ShutdownInProgress, "Snapshot preflight is shutting down");
+    }
+    SCHECK_EQ(VERIFY_RESULT(LeaderTerm(*attempt.tablet.peer)), attempt.tablet.leader_term,
+              IllegalState, "Snapshot preflight leader term changed");
+    if (attempt.configuration) {
+      auto consensus = VERIFY_RESULT(attempt.tablet.peer->GetConsensus());
+      const auto current = consensus->ConsensusState(consensus::CONSENSUS_CONFIG_ACTIVE);
+      SCHECK(current.current_term() == attempt.configuration->current_term() &&
+             Members(current.config()) == Members(attempt.configuration->config()), TryAgain,
+             "Snapshot preflight configuration changed");
+    }
+    SCHECK(CoarseMonoClock::Now() < attempt.deadline, TimedOut,
+            "Snapshot preflight deadline expired before submission");
+    return Status::OK();
+  }
+
+  Result<std::vector<std::shared_ptr<RemoteFlush>>> PrepareCalls(
+      const Attempt& attempt, const consensus::RaftConfigPB& config) {
+    std::vector<std::shared_ptr<RemoteFlush>> calls;
+    calls.reserve(config.peers_size());
+    std::unordered_set<std::string> seen;
+    for (const auto& peer : config.peers()) {
+      SCHECK(!peer.permanent_uuid().empty(), IllegalState, "Replica has no UUID");
+      if (peer.permanent_uuid() == server_.permanent_uuid() ||
+          !seen.insert(peer.permanent_uuid()).second) {
+        continue;
+      }
+      SCHECK(!peer.last_known_private_addr().empty() || !peer.last_known_broadcast_addr().empty(),
+              IllegalState, "Replica has no address");
+      auto call = std::make_shared<RemoteFlush>(
+          &server_.proxy_cache(), HostPortFromPB(DesiredHostPort(peer, server_.MakeCloudInfoPB())));
+      call->request.set_dest_uuid(peer.permanent_uuid());
+      call->request.add_tablet_ids(attempt.results->tablet_id);
+      call->request.set_operation(FlushTabletsRequestPB::FLUSH);
+      call->request.set_flags(tablet::FLUSH_COMPACT_ALL);
+      call->request.set_propagated_hybrid_time(server_.Clock()->Now().ToUint64());
+      call->controller.set_deadline(attempt.deadline);
+      calls.push_back(std::move(call));
+    }
+    return calls;
+  }
+
+  Status Preflush(const std::shared_ptr<Attempt>& attempt) {
+    RETURN_NOT_OK(CheckActive(*attempt));
+    auto consensus = VERIFY_RESULT(attempt->tablet.peer->GetConsensus());
+    attempt->configuration = consensus->ConsensusState(consensus::CONSENSUS_CONFIG_ACTIVE);
+    const auto& state = *attempt->configuration;
+    const auto membership = Members(state.config());
+    SCHECK(membership.contains(server_.permanent_uuid()), IllegalState,
+            "Snapshot preflight configuration omits the leader");
+    auto calls = VERIFY_RESULT(PrepareCalls(*attempt, state.config()));
+    auto results = attempt->results;
+    {
+      std::lock_guard lock(results->mutex);
+      results->remaining = calls.size() + 1;
+    }
+    for (const auto& call : calls) {
+      call->proxy.FlushTabletsAsync(call->request, &call->response, &call->controller,
+          [call, results] {
+            auto status = call->controller.status();
+            if (status.ok() && call->response.has_error()) {
+              status = StatusFromPB(call->response.error().status());
+            }
+            // A missing follower is not a missing leader tablet (terminal at the master).
+            if (!status.ok()) {
+              auto message = Format("Snapshot preflush on replica $0 failed: $1",
+                                    call->request.dest_uuid(), status);
+              status = status.IsTimedOut() ? STATUS(TimedOut, message) : STATUS(TryAgain, message);
+            }
+            results->Complete(status);
+          });
+    }
+    FlushTabletsRequestPB request;
+    request.set_operation(FlushTabletsRequestPB::FLUSH);
+    request.set_flags(tablet::FLUSH_COMPACT_ALL);
+    auto status = server_.tablet_manager()->tablet_flusher().Submit(
+        {attempt->tablet.tablet}, request, attempt->deadline,
+        [results](const Status& status, const TabletId&) { results->Complete(status); });
+    if (!status.ok()) {
+      results->Complete(status);
+    }
+    return results->Wait(attempt->deadline);
+  }
+
+  TabletServer& server_;
+  const size_t limit_;
+  std::shared_ptr<Admission> admission_;
+  std::unique_ptr<ThreadPool> pool_;
+  scoped_refptr<EventStats> duration_;
+  scoped_refptr<Counter> failures_;
+  scoped_refptr<Counter> timeouts_;
+  scoped_refptr<Counter> rejections_;
+};
+
+SnapshotPreflush::SnapshotPreflush(TabletServer* server) : impl_(std::make_unique<Impl>(server)) {}
+
+SnapshotPreflush::~SnapshotPreflush() {
+  StartShutdown();
+  CompleteShutdown();
+}
+
+void SnapshotPreflush::Submit(
+    LeaderTabletPeer tablet, std::unique_ptr<tablet::SnapshotOperation> operation,
+    tablet::ScopedReadOperation read_operation, CoarseTimePoint deadline) {
+  auto attempt = std::make_shared<Attempt>();
+  attempt->tablet = std::move(tablet);
+  attempt->operation = std::move(operation);
+  attempt->read_operation = std::move(read_operation);
+  attempt->deadline = std::min(
+      deadline, CoarseMonoClock::Now() + FLAGS_snapshot_preflush_timeout_ms * 1ms);
+  impl_->Submit(std::move(attempt));
+}
+
+void SnapshotPreflush::StartShutdown() { impl_->StartShutdown(); }
+void SnapshotPreflush::CompleteShutdown() { impl_->CompleteShutdown(); }
+
+}  // namespace yb::tserver

--- a/src/yb/tserver/snapshot_preflush.h
+++ b/src/yb/tserver/snapshot_preflush.h
@@ -1,0 +1,38 @@
+// Copyright (c) YugabyteDB, Inc.
+
+#pragma once
+
+#include <memory>
+
+#include "yb/util/monotime.h"
+
+namespace yb {
+namespace tablet {
+class ScopedReadOperation;
+class SnapshotOperation;
+}  // namespace tablet
+namespace tserver {
+struct LeaderTabletPeer;
+class TabletServer;
+
+// Orchestration waits on its own bounded workers, never on RPC/reactor or preparer threads.
+// Flush I/O uses TabletFlusher's separate executor, so a full preflight pool cannot starve it.
+class SnapshotPreflush {
+ public:
+  explicit SnapshotPreflush(TabletServer* server);
+  ~SnapshotPreflush();
+
+  // Always takes ownership and completes/aborts the operation on admission failure.
+  void Submit(
+      LeaderTabletPeer tablet, std::unique_ptr<tablet::SnapshotOperation> operation,
+      tablet::ScopedReadOperation read_operation, CoarseTimePoint deadline);
+  void StartShutdown();
+  void CompleteShutdown();
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace tserver
+}  // namespace yb

--- a/src/yb/tserver/tablet_flusher.cc
+++ b/src/yb/tserver/tablet_flusher.cc
@@ -1,0 +1,217 @@
+// Copyright (c) YugabyteDB, Inc.
+
+#include "yb/tserver/tablet_flusher.h"
+
+#include <array>
+
+#include "yb/docdb/doc_vector_index.h"
+#include "yb/rocksdb/db.h"
+#include "yb/tablet/tablet.h"
+#include "yb/tablet/tablet_vector_indexes.h"
+#include "yb/tserver/tserver_admin.pb.h"
+#include "yb/util/flag_validators.h"
+#include "yb/util/flags.h"
+#include "yb/util/metrics.h"
+#include "yb/util/status_format.h"
+#include "yb/util/sync_point.h"
+#include "yb/util/threadpool.h"
+
+DEFINE_NON_RUNTIME_int32(tablet_flush_concurrency, 4,
+    "Maximum admitted admin/local preflight flush jobs per tablet server.");
+DEFINE_validator(tablet_flush_concurrency, FLAG_GT_VALUE_VALIDATOR(0));
+TAG_FLAG(tablet_flush_concurrency, advanced);
+
+DECLARE_bool(TEST_skip_force_superblock_flush);
+
+THREAD_POOL_METRICS_DEFINE(server, tablet_flush_pool, "Admin tablet flush workers");
+METRIC_DEFINE_gauge_uint64(server, tablet_flush_active, "Admitted tablet flush jobs",
+    yb::MetricUnit::kOperations, "Flush jobs including error cleanup and retiring work", 0);
+
+namespace yb::tserver {
+namespace {
+
+class FlushBatch {
+ public:
+  FlushBatch(const std::vector<tablet::TabletPtr>& tablets, const FlushTabletsRequestPB& request)
+      : tablets_(tablets),
+        vector_only_(request.flags() == tablet::FLUSH_COMPACT_VECTOR_INDEX_ONLY ||
+            (request.flags() == tablet::FLUSH_COMPACT_DEFAULT &&
+             !request.vector_index_ids().empty())),
+        regular_only_(request.flags() == tablet::FLUSH_COMPACT_REGULAR_FOR_TEST_ONLY),
+        vector_ids_(request.vector_index_ids().begin(), request.vector_index_ids().end()),
+        dbs_(tablets.size()) {}
+
+  Status Run(CoarseTimePoint deadline, TabletId* failed_tablet_id) {
+    SCHECK(CoarseMonoClock::Now() < deadline, TimedOut, "Tablet flush deadline expired");
+    std::vector<ScopedRWOperation> guards;
+    guards.reserve(tablets_.size());
+    // Guard acquisition must not fail after another tablet's flush has already started.
+    for (size_t i = 0; i != tablets_.size(); ++i) {
+      auto guard = tablets_[i]->CreateScopedRWOperationBlockingRocksDbShutdownStart();
+      if (!guard.ok()) {
+        *failed_tablet_id = tablets_[i]->tablet_id();
+        return guard.CreateStatus();
+      }
+      guards.push_back(std::move(guard));
+    }
+    indexes_.reserve(tablets_.size());
+    for (const auto& tablet : tablets_) {
+      indexes_.push_back(regular_only_ ? tablet::VectorIndexList() :
+          vector_only_ ? tablet->vector_indexes().Collect(vector_ids_) :
+                         tablet->vector_indexes().List());
+    }
+    size_t launched = 0;
+    for (; launched != tablets_.size();) {
+      const auto i = launched++;
+      Record(Start(i), i, failed_tablet_id);
+      if (!status_.ok()) {
+        break;
+      }
+    }
+    // Even a failed Start/Wait can leave other DBs or indexes running. Keep the batch's
+    // reservations and guards until all possibly launched work, including cleanup, retires.
+    for (size_t i = 0; i != launched; ++i) {
+      std::pair<tablet::Tablet*, Status> hook{tablets_[i].get(), Status::OK()};
+      TEST_SYNC_POINT_CALLBACK("TabletFlusher::BeforeWait", &hook);
+      Record(hook.second, i, failed_tablet_id);
+      Record(indexes_[i].WaitForFlush(), i, failed_tablet_id);
+      for (auto* db : dbs_[i]) {
+        if (db) {
+          Record(db->WaitForFlush(), i, failed_tablet_id);
+          db->WaitForFlushJobs();
+        }
+      }
+      TEST_SYNC_POINT_CALLBACK("TabletFlusher::Flushed", tablets_[i].get());
+    }
+    return status_;
+  }
+
+ private:
+  Status Start(size_t i) {
+    if (indexes_[i]) {
+      for (const auto& index : *indexes_[i]) {
+        RETURN_NOT_OK(index->Flush());
+      }
+    }
+    if (!vector_only_) {
+      rocksdb::FlushOptions options(rocksdb::FlushReason::kAdminFlush);
+      options.wait = false;
+      const std::array candidates{
+          regular_only_ ? nullptr : tablets_[i]->intents_db(), tablets_[i]->regular_db()};
+      for (size_t j = 0; j != candidates.size(); ++j) {
+        if (auto* db = candidates[j]) {
+          // Flush can schedule work and still fail; record the DB before calling it.
+          dbs_[i][j] = db;
+          RETURN_NOT_OK(db->Flush(options));
+        }
+      }
+    }
+    std::pair<tablet::Tablet*, Status> hook{tablets_[i].get(), Status::OK()};
+    TEST_SYNC_POINT_CALLBACK("TabletFlusher::BeforeSuperblock", &hook);
+    RETURN_NOT_OK(hook.second);
+    // Persist dirty metadata too: https://github.com/yugabyte/yugabyte-db/issues/16116.
+    return FLAGS_TEST_skip_force_superblock_flush ? Status::OK() :
+        tablets_[i]->FlushSuperblock(tablet::OnlyIfDirty::kTrue);
+  }
+
+  void Record(const Status& status, size_t i, TabletId* failed_tablet_id) {
+    if (status_.ok() && !status.ok()) {
+      status_ = status;
+      *failed_tablet_id = tablets_[i]->tablet_id();
+    }
+  }
+
+  const std::vector<tablet::TabletPtr>& tablets_;
+  const bool vector_only_;
+  const bool regular_only_;
+  const TableIds vector_ids_;
+  std::vector<tablet::VectorIndexList> indexes_;
+  std::vector<std::array<rocksdb::DB*, 2>> dbs_;
+  Status status_;
+};
+
+}  // namespace
+
+TabletFlusher::TabletFlusher(const scoped_refptr<MetricEntity>& metrics)
+    : limit_(FLAGS_tablet_flush_concurrency),
+      active_metric_(METRIC_tablet_flush_active.Instantiate(metrics, 0)) {
+  CHECK_OK(ThreadPoolBuilder("tablet-flush")
+      .set_max_threads(static_cast<int>(limit_))
+      .set_metrics(THREAD_POOL_METRICS_INSTANCE(metrics, tablet_flush_pool))
+      .Build(&pool_));
+}
+
+TabletFlusher::~TabletFlusher() {
+  StartShutdown();
+  CompleteShutdown();
+}
+
+Status TabletFlusher::Submit(
+    std::vector<tablet::TabletPtr> tablets, const FlushTabletsRequestPB& request,
+    CoarseTimePoint deadline, Callback callback) {
+  SCHECK_EQ(request.operation(), FlushTabletsRequestPB::FLUSH, InvalidArgument,
+            "Expected a flush request");
+  SCHECK_NE(request.flags(), tablet::FLUSH_COMPACT_VECTOR_INDEX_EXCLUDED, InvalidArgument,
+            "Vector index excluded flag is not supported for flush");
+  SCHECK(CoarseMonoClock::Now() < deadline, TimedOut, "Tablet flush deadline expired");
+  std::unordered_set<TabletId> ids;
+  std::erase_if(tablets, [&ids](const auto& tablet) {
+    return !ids.insert(tablet->tablet_id()).second;
+  });
+  std::lock_guard lock(mutex_);
+  SCHECK(!closing_, ShutdownInProgress, "Tablet flusher is shutting down");
+  SCHECK_LT(active_, limit_, ServiceUnavailable, "Tablet flush capacity exhausted");
+  for (const auto& id : ids) {
+    SCHECK(!tablets_.contains(id), ServiceUnavailable, "Tablet flush already in progress");
+  }
+  ++active_;
+  active_metric_->Increment();
+  tablets_.insert(ids.begin(), ids.end());
+  // Serialize enqueue with StartShutdown so its subsequent pool drain includes every admitted
+  // job. SubmitFunc only enqueues; neither the job nor its callback runs inline under this lock.
+  auto status = pool_->SubmitFunc(
+      [this, tablets, request, deadline, callback = std::move(callback)] {
+    TabletId failed_tablet_id;
+    Status status;
+    {
+      std::lock_guard lock(mutex_);
+      if (closing_) {
+        status = STATUS(ShutdownInProgress, "Tablet flusher is shutting down");
+      }
+    }
+    if (status.ok()) {
+      status = FlushBatch(tablets, request).Run(deadline, &failed_tablet_id);
+    }
+    Release(tablets);
+    callback(status, failed_tablet_id);
+  });
+  if (!status.ok()) {
+    --active_;
+    active_metric_->Decrement();
+    for (const auto& id : ids) {
+      tablets_.erase(id);
+    }
+  }
+  return status;
+}
+
+void TabletFlusher::Release(const std::vector<tablet::TabletPtr>& tablets) {
+  std::lock_guard lock(mutex_);
+  --active_;
+  active_metric_->Decrement();
+  for (const auto& tablet : tablets) {
+    tablets_.erase(tablet->tablet_id());
+  }
+}
+
+void TabletFlusher::StartShutdown() {
+  std::lock_guard lock(mutex_);
+  closing_ = true;
+}
+
+void TabletFlusher::CompleteShutdown() {
+  pool_->Wait();
+  pool_->Shutdown();
+}
+
+}  // namespace yb::tserver

--- a/src/yb/tserver/tablet_flusher.h
+++ b/src/yb/tserver/tablet_flusher.h
@@ -1,0 +1,53 @@
+// Copyright (c) YugabyteDB, Inc.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_set>
+#include <vector>
+
+#include "yb/common/entity_ids_types.h"
+#include "yb/tablet/tablet_fwd.h"
+#include "yb/tserver/tserver_admin.fwd.h"
+#include "yb/util/metrics_fwd.h"
+#include "yb/util/monotime.h"
+#include "yb/util/status.h"
+
+namespace yb {
+class MetricEntity;
+class ThreadPool;
+
+namespace tserver {
+
+// Shared by local snapshot preflights and the admin FlushTablets RPC. Admission bounds both
+// worker usage and outstanding work; a caller timeout does not release a running job's slot.
+class TabletFlusher {
+ public:
+  using Callback = std::function<void(const Status&, const TabletId&)>;
+
+  explicit TabletFlusher(const scoped_refptr<MetricEntity>& metrics);
+  ~TabletFlusher();
+
+  Status Submit(
+      std::vector<tablet::TabletPtr> tablets, const FlushTabletsRequestPB& request,
+      CoarseTimePoint deadline, Callback callback);
+  void StartShutdown();
+  void CompleteShutdown();
+
+ private:
+  void Release(const std::vector<tablet::TabletPtr>& tablets);
+
+  const size_t limit_;
+  std::unique_ptr<ThreadPool> pool_;
+  // Admission and shutdown are serialized here; callbacks and I/O run without this mutex.
+  std::mutex mutex_;
+  bool closing_ GUARDED_BY(mutex_) = false;
+  size_t active_ GUARDED_BY(mutex_) = 0;
+  std::unordered_set<TabletId> tablets_ GUARDED_BY(mutex_);
+  scoped_refptr<AtomicGauge<uint64_t>> active_metric_;
+};
+
+}  // namespace tserver
+}  // namespace yb

--- a/src/yb/tserver/tablet_server.cc
+++ b/src/yb/tserver/tablet_server.cc
@@ -819,9 +819,10 @@ Status TabletServer::RegisterServices() {
       std::make_unique<CDCServiceContextImpl>(this), metric_entity(), metric_registry(),
       client_future(), []() { return FLAGS_update_min_cdc_indices_interval_secs; });
 
-  RETURN_NOT_OK(RegisterService(
-      FLAGS_ts_backup_svc_queue_length,
-      std::make_shared<TabletServiceBackupImpl>(tablet_manager_.get(), metric_entity())));
+  auto backup_service =
+      std::make_shared<TabletServiceBackupImpl>(tablet_manager_.get(), metric_entity());
+  backup_service_ = backup_service;
+  RETURN_NOT_OK(RegisterService(FLAGS_ts_backup_svc_queue_length, std::move(backup_service)));
 
   RETURN_NOT_OK(RegisterService(FLAGS_xcluster_svc_queue_length, cdc_service_));
 
@@ -1029,6 +1030,11 @@ void TabletServer::Shutdown() {
     remote_bootstrap_service->StartShutdown();
   }
 
+  // Release pending snapshot history guards before tablet storage teardown. Outstanding flush
+  // callbacks retain only their result/admission state, not the backup service or snapshot RPC.
+  if (auto backup_service = backup_service_.lock()) {
+    backup_service->Shutdown();
+  }
   tablet_manager_->StartShutdown();
   WARN_NOT_OK(relinquish_lease_future.get(), "Couldn't relinquish ysql lease");
 

--- a/src/yb/tserver/tablet_server.h
+++ b/src/yb/tserver/tablet_server.h
@@ -122,6 +122,7 @@ namespace tserver {
 
 class GetYSQLLeaseInfoResponsePB;
 class PgClientServiceImpl;
+class TabletServiceBackupImpl;
 class TServerCgroupManager;
 class TserverAutoFlagsManager;
 class TserverXClusterContext;
@@ -663,6 +664,7 @@ class TabletServer : public DbServerBase, public TabletServerIf {
   // An instance to remote bootstrap service. This pointer is no longer valid after
   // RpcAndWebServerBase is shut down.
   std::weak_ptr<RemoteBootstrapServiceImpl> remote_bootstrap_service_;
+  std::weak_ptr<TabletServiceBackupImpl> backup_service_;
 
   struct PgClientServiceHolder;
 

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -105,6 +105,7 @@
 #include "yb/tserver/pg_txn_snapshot_manager.h"
 #include "yb/tserver/read_query.h"
 #include "yb/tserver/service_util.h"
+#include "yb/tserver/tablet_flusher.h"
 #include "yb/tserver/tablet_server.h"
 #include "yb/tserver/ts_local_lock_manager.h"
 #include "yb/tserver/ts_tablet_manager.h"
@@ -1912,169 +1913,9 @@ void TabletServiceAdminImpl::DeleteTablet(const DeleteTabletRequestPB* req,
 
 namespace {
 
-class TabletsFlusherBase {
- public:
-  explicit TabletsFlusherBase(
-      const TabletServiceAdminImpl& service,
-      const TSTabletManager::TabletPtrs& tablets,
-      FlushTabletsResponsePB& resp)
-    : service_(service), tablets_(tablets), resp_(resp)
-  {}
-
-  virtual ~TabletsFlusherBase() = default;
-
-  Status Run();
-
-  auto LogPrefix() const {
-    return service_.LogPrefix();
-  }
-
- private:
-  virtual Status Flush(const tablet::TabletPtr& tablet) = 0;
-  virtual Status WaitForFlush(const tablet::TabletPtr& tablet) = 0;
-
-  const TabletServiceAdminImpl& service_;
-  const TSTabletManager::TabletPtrs& tablets_;
-  FlushTabletsResponsePB& resp_;
-};
-
-Status TabletsFlusherBase::Run() {
-  for (const auto& tablet : tablets_) {
-    resp_.set_failed_tablet_id(tablet->tablet_id());
-    RETURN_NOT_OK(Flush(tablet));
-
-    // Refer to https://github.com/yugabyte/yugabyte-db/issues/16116.
-    if (!FLAGS_TEST_skip_force_superblock_flush) {
-      RETURN_NOT_OK(tablet->FlushSuperblock(tablet::OnlyIfDirty::kTrue));
-    }
-    resp_.clear_failed_tablet_id();
-  }
-
-  // Wait for end of all flush operations.
-  for (const auto& tablet : tablets_) {
-    resp_.set_failed_tablet_id(tablet->tablet_id());
-    RETURN_NOT_OK(WaitForFlush(tablet));
-    resp_.clear_failed_tablet_id();
-  }
-
-  return Status::OK();
-}
-
-class TabletsFlusher final : public TabletsFlusherBase {
- public:
-  explicit TabletsFlusher(
-    const TabletServiceAdminImpl& service,
-      const TSTabletManager::TabletPtrs& tablets,
-      const tablet::FlushFlags flush_flags,
-      FlushTabletsResponsePB& resp)
-      : TabletsFlusherBase(service, tablets, resp),
-        flush_flags_(flush_flags) {
-    VLOG_WITH_PREFIX(1) << "TabletsFlusher: flush_flags: " << std::to_underlying(flush_flags_);
-  }
-
- private:
-  Status Flush(const tablet::TabletPtr& tablet) override {
-    return tablet->Flush(
-        tablet::FlushMode::kAsync, flush_flags_, rocksdb::FlushReason::kAdminFlush);
-  }
-
-  Status WaitForFlush(const tablet::TabletPtr& tablet) override {
-    return tablet->WaitForFlush();
-  }
-
-  const tablet::FlushFlags flush_flags_;
-};
-
-class VectorIndexFlusher : public TabletsFlusherBase {
- public:
-  explicit VectorIndexFlusher(
-      const TabletServiceAdminImpl& service,
-      const TSTabletManager::TabletPtrs& tablets,
-      TableIds&& vector_index_ids,
-      FlushTabletsResponsePB& resp)
-      : TabletsFlusherBase(service, tablets, resp),
-        vector_index_ids_(std::move(vector_index_ids)) {
-    VLOG_WITH_PREFIX(1) << "VectorIndexFlusher: vector index ids: "
-                        << (vector_index_ids_.size() ? AsString(vector_index_ids_) : "all");
-  }
-
- private:
-  Status Flush(const tablet::TabletPtr& tablet) override {
-    auto [it, inserted] = tablet_vector_indexes_.try_emplace(
-      tablet->tablet_id(),
-      tablet->vector_indexes().Collect(vector_index_ids_)
-    );
-
-    if (!inserted) {
-      LOG_WITH_PREFIX(DFATAL)
-          << "Flush of vector indexes is already running for tablet " << tablet->tablet_id();
-      return Status::OK();
-    }
-
-    it->second.Flush();
-    return Status::OK();
-  }
-
-  Status WaitForFlush(const tablet::TabletPtr& tablet) override {
-    auto it = tablet_vector_indexes_.find(tablet->tablet_id());
-    if (it == tablet_vector_indexes_.end()) {
-      LOG_WITH_PREFIX(DFATAL) << "Vector indexes are not found for tablet " << tablet->tablet_id();
-      return Status::OK();
-    }
-
-    return it->second.WaitForFlush();
-  }
-
-  TableIds vector_index_ids_;
-  std::unordered_map<TabletId, tablet::VectorIndexList> tablet_vector_indexes_;
-};
-
-bool IsRegularOnly(const FlushTabletsRequestPB& req) {
-  return req.flags() == tablet::FLUSH_COMPACT_REGULAR_FOR_TEST_ONLY;
-}
-
 bool IsVectorIndexOnly(const FlushTabletsRequestPB& req) {
   return (req.flags() == tablet::FLUSH_COMPACT_VECTOR_INDEX_ONLY) ||
          (req.flags() == tablet::FLUSH_COMPACT_DEFAULT && req.vector_index_ids_size());
-}
-
-auto CopyVectorIndexIds(const FlushTabletsRequestPB& req) {
-  return TableIds{ req.vector_index_ids().begin(), req.vector_index_ids().end() };
-}
-
-Status TriggerFlush(
-    const TabletServiceAdminImpl& service,
-    const TSTabletManager::TabletPtrs& tablets,
-    const FlushTabletsRequestPB& req,
-    FlushTabletsResponsePB& resp) {
-  // FlushCompactFlags for FLUSH operation:
-  // 1. FLUSH_COMPACT_DEFAULT
-  //    Flush regular + intents + vector indexes. If vector_index_ids field is not empty,
-  //    the value is treated as FLUSH_COMPACT_VECTOR_INDEX_ONLY.
-  //
-  // 2. FLUSH_COMPACT_REGULAR_FOR_TEST_ONLY
-  //    Flush only regular db, used in tests only.
-  //
-  // 3. FLUSH_COMPACT_VECTOR_INDEX_EXCLUDED
-  //    Not applicable for FLUSH operation.
-  //
-  // 4. FLUSH_COMPACT_VECTOR_INDEX_ONLY
-  //    Flush only vector indexes. Empty vector_index_ids means all vector indexes.
-  //
-  // 5. FLUSH_COMPACT_ALL
-  //    Flush regular + intents + vector indexes. Empty vector_index_ids means all vector indexes.
-  DCHECK_EQ(req.operation(), FlushTabletsRequestPB::FLUSH);
-  SCHECK_FORMAT(
-    req.flags() != tablet::FLUSH_COMPACT_VECTOR_INDEX_EXCLUDED, InvalidArgument,
-    "Flag [$0] is not supported for FLUSH operation", req.flags());
-
-  if (IsVectorIndexOnly(req)) {
-    return VectorIndexFlusher{ service, tablets, CopyVectorIndexIds(req), resp }.Run();
-  }
-
-  const tablet::FlushFlags flush_flags =
-      IsRegularOnly(req) ? tablet::FlushFlags::kRegular : tablet::FlushFlags::kAllDbs;
-  return TabletsFlusher{ service, tablets, flush_flags, resp }.Run();
 }
 
 Result<TableIdsPtr> CollectVectorIndexesForCompaction(const FlushTabletsRequestPB& req) {
@@ -2084,7 +1925,7 @@ Result<TableIdsPtr> CollectVectorIndexesForCompaction(const FlushTabletsRequestP
     return nullptr;
   }
 
-  return std::make_shared<TableIds>(CopyVectorIndexIds(req));
+  return std::make_shared<TableIds>(req.vector_index_ids().begin(), req.vector_index_ids().end());
 }
 
 Status TriggerCompact(
@@ -2169,10 +2010,22 @@ void TabletServiceAdminImpl::FlushTablets(const FlushTabletsRequestPB* req,
   }
   switch (req->operation()) {
     case FlushTabletsRequestPB::FLUSH: {
-      RETURN_UNKNOWN_ERROR_IF_NOT_OK(
-          TriggerFlush(*this, tablet_ptrs, *req, *resp),
-          resp, &context);
-      break;
+      auto deadline = context.GetClientDeadline();
+      auto shared_context = std::make_shared<rpc::RpcContext>(std::move(context));
+      auto status = server_->tablet_manager()->tablet_flusher().Submit(
+          std::move(tablet_ptrs), *req, deadline,
+          [shared_context, resp](const Status& status, const TabletId& failed_tablet_id) {
+            if (!status.ok()) {
+              resp->set_failed_tablet_id(failed_tablet_id);
+              SetupErrorAndRespond(resp->mutable_error(), status, shared_context.get());
+            } else {
+              shared_context->RespondSuccess();
+            }
+          });
+      if (!status.ok()) {
+        SetupErrorAndRespond(resp->mutable_error(), status, shared_context.get());
+      }
+      return;
     }
     case FlushTabletsRequestPB::COMPACT: {
       RETURN_UNKNOWN_ERROR_IF_NOT_OK(

--- a/src/yb/tserver/ts_tablet_manager.cc
+++ b/src/yb/tserver/ts_tablet_manager.cc
@@ -106,6 +106,7 @@
 #include "yb/tserver/remote_bootstrap_client.h"
 #include "yb/tserver/remote_bootstrap_session.h"
 #include "yb/tserver/remote_snapshot_transfer_client.h"
+#include "yb/tserver/tablet_flusher.h"
 #include "yb/tserver/tablet_limits.h"
 #include "yb/tserver/tablet_server.h"
 #include "yb/tserver/tserver_cgroup_manager.h"
@@ -564,6 +565,7 @@ TSTabletManager::TSTabletManager(FsManager* fs_manager,
     .max_workers = rpc::ThreadPoolOptions::kUnlimitedWorkers
   });
 
+  tablet_flusher_ = std::make_unique<TabletFlusher>(server_->metric_entity());
   CHECK_GT(FLAGS_snapshot_cleanup_pool_size, 0);
   CHECK_OK(ThreadPoolBuilder("snapshot-cleanup")
                .set_min_threads(1)
@@ -2639,6 +2641,8 @@ void TSTabletManager::StartShutdown() {
     }
   }
 
+  tablet_flusher_->StartShutdown();
+
   TEST_PAUSE_IF_FLAG(TEST_pause_after_ts_manager_started_quiescing);
 
   for (auto& callback : flag_callbacks_) {
@@ -2709,6 +2713,7 @@ void TSTabletManager::StartShutdown() {
 }
 
 void TSTabletManager::CompleteShutdown() {
+  tablet_flusher_->CompleteShutdown();
   tablet_metadata_validator_->CompleteShutdown();
 
   for (const TabletPeerPtr& peer : shutting_down_peers_) {

--- a/src/yb/tserver/ts_tablet_manager.h
+++ b/src/yb/tserver/ts_tablet_manager.h
@@ -110,6 +110,7 @@ typedef std::vector<TabletCreationMetadata> SplitTabletsCreationMetadata;
 
 typedef Callback<void(tablet::TabletPeerPtr)> ConsensusChangeCallback;
 
+class TabletFlusher;
 class TabletMetadataValidator;
 
 // If 'expr' fails, log a message, tombstone the given tablet, and return the
@@ -195,6 +196,7 @@ class TSTabletManager : public tserver::TabletPeerLookupIf, public tablet::Table
   ThreadPool* tablet_prepare_pool() const { return tablet_prepare_pool_.get(); }
   ThreadPool* raft_pool() const { return raft_pool_.get(); }
   ThreadPool* snapshot_cleanup_pool() const { return snapshot_cleanup_pool_.get(); }
+  TabletFlusher& tablet_flusher() const { return *tablet_flusher_; }
   rpc::ThreadPool* raft_notifications_pool() const {
     return raft_notifications_pool_.get();
   }
@@ -820,6 +822,7 @@ class TSTabletManager : public tserver::TabletPeerLookupIf, public tablet::Table
 
   // Bounded process-wide pool for physical tablet snapshot directory cleanup.
   std::unique_ptr<ThreadPool> snapshot_cleanup_pool_;
+  std::unique_ptr<TabletFlusher> tablet_flusher_;
 
   // Thread pool for appender threads, shared between all tablets.
   std::unique_ptr<ThreadPool> append_pool_;

--- a/src/yb/vector_index/vector_lsm.cc
+++ b/src/yb/vector_index/vector_lsm.cc
@@ -633,7 +633,6 @@ struct VectorLSM<Vector, DistanceResult>::MutableChunk {
   storage::UserFrontiersPtr user_frontiers;
 
   // Used to indicates this chunk insertion failed and hence save_callback should not be called.
-  std::atomic<bool> insertion_failed { false };
 
   // Returns true if registration was successful. Otherwise, new mutable chunk should be allocated.
   // Invoked when owning VectorLSM holds the mutex.
@@ -655,9 +654,8 @@ struct VectorLSM<Vector, DistanceResult>::MutableChunk {
     auto new_tasks = --num_tasks;
     if (new_tasks == 0) {
       DCHECK(save_callback);
-      if (!insertion_failed.load(std::memory_order::acquire)) {
-        save_callback();
-      }
+      // SaveChunk also retires a flush whose inserts failed, without writing the failed index.
+      save_callback();
       save_callback = {};
     }
   }
@@ -983,7 +981,7 @@ class VectorLSM<Vector, DistanceResult>::CompactionTask : public PriorityThreadP
     if (status.ok() || status.IsShutdownInProgress()) {
       LOG_WITH_PREFIX(INFO) << "Done: " << status;
     } else {
-      LOG_WITH_PREFIX(DFATAL) << "Failed: " << status;
+      LOG_WITH_PREFIX(ERROR) << "Failed: " << status;
       lsm_.CheckFailure(status);
     }
     Completed(status, last_serial_no);
@@ -1014,6 +1012,7 @@ class VectorLSM<Vector, DistanceResult>::CompactionTask : public PriorityThreadP
   }
 
   Status DoRun(PriorityThreadPoolSuspender* suspender) {
+    RETURN_NOT_OK(lsm_.GetFlushStatus());
     auto scope = lsm_.PickChunksForCompaction(compaction_type_);
 
     if (scope.empty()) {
@@ -1126,10 +1125,10 @@ void VectorLSM<Vector, DistanceResult>::CompleteShutdown() {
     size_t chunks_left;
     {
       std::lock_guard lock(mutex_);
-      chunks_left = updates_queue_.size();
-      if (chunks_left == 0) {
+      if (FlushesRetiredUnlocked()) {
         break;
       }
+      chunks_left = std::max(updates_queue_.size(), pending_save_tasks_);
     }
     auto now = CoarseMonoClock::now();
     if (now > last_warning_time + report_interval) {
@@ -1186,7 +1185,7 @@ inline void VectorLSM<Vector, DistanceResult>::CheckFailure(const Status& status
   {
     std::lock_guard lock(mutex_);
     if (failed_status_.ok()) {
-      failed_status_ = status;
+      RecordFailureUnlocked(status);
       return;
     }
     existing_status = failed_status_;
@@ -1194,6 +1193,20 @@ inline void VectorLSM<Vector, DistanceResult>::CheckFailure(const Status& status
   YB_LOG_WITH_PREFIX_EVERY_N_SECS(WARNING, 1)
       << "Vector LSM already in failed state: " << existing_status
       << ", while trying to set new failed state: " << status;
+}
+
+template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
+void VectorLSM<Vector, DistanceResult>::RecordFailureUnlocked(const Status& status) {
+  DCHECK(!status.ok());
+  if (failed_status_.ok()) {
+    failed_status_ = status;
+  }
+  // A later chunk may have retired its save task while waiting for an earlier manifest entry.
+  for (auto& [_, chunk] : updates_queue_) {
+    chunk->Flushed(failed_status_);
+  }
+  updates_queue_empty_cv_.notify_all();
+  writing_manifest_done_cv_.notify_all();
 }
 
 template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
@@ -1258,8 +1271,8 @@ Status VectorLSM<Vector, DistanceResult>::Open(Options options) {
   }
   for (auto& promise : promises) {
     auto status = promise.get_future().get();
-    if (!status.ok() && failed_status_.ok()) {
-      failed_status_ = status;
+    if (!status.ok()) {
+      RecordFailureUnlocked(status);
     }
   }
 
@@ -1331,7 +1344,9 @@ Status VectorLSM<Vector, DistanceResult>::Insert(
   size_t num_tasks = ceil_div<size_t>(entries.size(), FLAGS_vector_index_task_size);
   {
     std::lock_guard lock(mutex_);
-    RETURN_NOT_OK(failed_status_);
+    if (!failed_status_.ok()) {
+      return failed_status_;
+    }
 
     size_t chunk_size = std::max(entries.size(), context.chunk_size);
     if (!mutable_chunk_) {
@@ -1360,7 +1375,6 @@ Status VectorLSM<Vector, DistanceResult>::Insert(
           auto failure = status.CloneAndPrepend("VectorLSM insertion failed");
           LOG(ERROR) << LogPrefix() << failure;
           CheckFailure(failure);
-          chunk->insertion_failed.store(false, std::memory_order::release);
         }
         chunk->InsertTaskDone();
       }));
@@ -1619,15 +1633,18 @@ bool VectorLSM<Vector, DistanceResult>::ManifestAcquired() {
 }
 
 template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
-void VectorLSM<Vector, DistanceResult>::AcquireManifest() {
+Status VectorLSM<Vector, DistanceResult>::AcquireManifest() {
   UniqueLock lock(mutex_);
-
-  // Wait for all current writes to manifest file are done.
-  writing_manifest_done_cv_.wait(
-      lock, [this]() NO_THREAD_SAFETY_ANALYSIS { return !writing_manifest_; });
-
-  // Take the ownership of the writing state.
+  TEST_SYNC_POINT_CALLBACK("VectorLSM::AcquireManifest:Waiting", this);
+  // A failed writer may leave the manifest unusable. Waiters must retire without acquiring it.
+  writing_manifest_done_cv_.wait(lock, [this]() NO_THREAD_SAFETY_ANALYSIS {
+    return !writing_manifest_ || !failed_status_.ok();
+  });
+  if (!failed_status_.ok()) {
+    return failed_status_;
+  }
   writing_manifest_ = true;
+  return Status::OK();
 }
 
 template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
@@ -1674,6 +1691,9 @@ template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
 Status VectorLSM<Vector, DistanceResult>::DoSaveChunk(const ImmutableChunkPtr& chunk) {
   VLOG_WITH_PREFIX_AND_FUNC(3) << AsString(*chunk);
 
+  Status injected;
+  TEST_SYNC_POINT_CALLBACK("VectorLSM::DoSaveChunk:Status", &injected);
+  RETURN_NOT_OK(injected);
   SaveIndexToFileResult saved;
   if (chunk->index) {
     LOG_IF(DFATAL, chunk->file.get())
@@ -1761,6 +1781,9 @@ Status VectorLSM<Vector, DistanceResult>::AddChunkToManifest(
   chunk.AddToUpdate(update);
   VLOG_WITH_PREFIX_AND_FUNC(3) << update.ShortDebugString();
 
+  Status injected;
+  TEST_SYNC_POINT_CALLBACK("VectorLSM::AddChunkToManifest:Status", &injected);
+  RETURN_NOT_OK(injected);
   RETURN_NOT_OK(VectorLSMMetadataAppendUpdate(manifest_file, update));
 
   // TODO(vector_index): print chunk number as well, could be covered within #27098.
@@ -1777,9 +1800,7 @@ Status VectorLSM<Vector, DistanceResult>::UpdateManifest(
     if (!status.ok()) {
       // Manifest stays acquired on failure, so queued chunks would never flush.
       std::lock_guard lock(mutex_);
-      for (auto& [_, queued_chunk] : updates_queue_) {
-        queued_chunk->Flushed(status);
-      }
+      RecordFailureUnlocked(status);
       return status;
     }
 
@@ -1814,18 +1835,28 @@ Status VectorLSM<Vector, DistanceResult>::UpdateManifest(
 
 template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
 void VectorLSM<Vector, DistanceResult>::SaveChunk(const ImmutableChunkPtr& chunk) {
+  auto retire = ScopeExit([this] {
+    TEST_SYNC_POINT_CALLBACK("VectorLSM::SaveChunk:BeforeRetirement", this);
+    std::lock_guard lock(mutex_);
+    --pending_save_tasks_;
+    updates_queue_empty_cv_.notify_all();
+  });
   if (TEST_sleep_during_flush && chunk->order_no) {
     SleepFor(TEST_sleep_during_flush);
   }
 
-  auto status = DoSaveChunk(chunk);
-  if (status.ok()) {
-    return;
+  Status status;
+  {
+    std::lock_guard lock(mutex_);
+    status = failed_status_;
   }
-
-  chunk->Flushed(status);
-  LOG_WITH_PREFIX(DFATAL) << "Save chunk failed: " << status;
-  CheckFailure(status);
+  if (status.ok()) {
+    status = DoSaveChunk(chunk);
+  }
+  if (!status.ok()) {
+    CheckFailure(status);
+    LOG_WITH_PREFIX(ERROR) << "Save chunk failed: " << status;
+  }
 }
 
 template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
@@ -1841,12 +1872,16 @@ Status VectorLSM<Vector, DistanceResult>::DoFlush(std::promise<Status>* promise)
 
   auto tasks = mutable_chunk_->num_tasks -= kRunningMark;
   RSTATUS_DCHECK_LT(tasks, kRunningMark, RuntimeError, "Wrong value for num_tasks");
+  ++pending_save_tasks_;
   if (tasks == 0) {
-    if (!mutable_chunk_->insertion_failed.load(std::memory_order::acquire)) {
-      options_.insert_thread_pool->EnqueueFunctor(mutable_chunk_->save_callback);
-    }
-    // TODO(vector_index): Optimize memory allocation related to save callback
+    const bool queued = options_.insert_thread_pool->EnqueueFunctor(mutable_chunk_->save_callback);
     mutable_chunk_->save_callback = {};
+    if (!queued) {
+      --pending_save_tasks_;
+      RecordFailureUnlocked(
+          STATUS(ShutdownInProgress, "Vector flush executor is shutting down"));
+      return failed_status_;
+    }
   }
   return Status::OK();
 }
@@ -1934,6 +1969,9 @@ Status VectorLSM<Vector, DistanceResult>::Flush(bool wait) {
   std::promise<Status> promise;
   {
     std::lock_guard lock(mutex_);
+    if (!failed_status_.ok()) {
+      return failed_status_;
+    }
     if (!mutable_chunk_) {
       LOG_WITH_PREFIX_AND_FUNC(INFO) << "Noting to flush";
       return Status::OK();
@@ -2019,6 +2057,18 @@ storage::FlushAbility VectorLSM<Vector, DistanceResult>::GetFlushAbility() {
 }
 
 template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
+Status VectorLSM<Vector, DistanceResult>::GetFlushStatus() const {
+  SharedLock lock(mutex_);
+  return failed_status_;
+}
+
+template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
+size_t VectorLSM<Vector, DistanceResult>::TEST_PendingSaveTasks() const {
+  SharedLock lock(mutex_);
+  return pending_save_tasks_;
+}
+
+template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
 size_t VectorLSM<Vector, DistanceResult>::NumImmutableChunks() const {
   SharedLock lock(mutex_);
   return immutable_chunks_.size();
@@ -2091,14 +2141,20 @@ DistanceResult VectorLSM<Vector, DistanceResult>::Distance(
 }
 
 template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
+bool VectorLSM<Vector, DistanceResult>::FlushesRetiredUnlocked() const {
+  return pending_save_tasks_ == 0 && (updates_queue_.empty() || !failed_status_.ok());
+}
+
+template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
 Status VectorLSM<Vector, DistanceResult>::WaitForFlush() {
   UniqueLock lock(mutex_);
 
   // TODO(vector_index) Don't wait flushes that started after this call.
-  updates_queue_empty_cv_.wait(
-      lock, [this]() NO_THREAD_SAFETY_ANALYSIS { return updates_queue_.empty(); });
+  updates_queue_empty_cv_.wait(lock, [this]() NO_THREAD_SAFETY_ANALYSIS {
+    return FlushesRetiredUnlocked();
+  });
 
-  return Status::OK();
+  return failed_status_;
 }
 
 template<IndexableVectorType Vector, ValidDistanceResultType DistanceResult>
@@ -2883,7 +2939,7 @@ Status VectorLSM<Vector, DistanceResult>::DoCompact(
       "VectorLSM::DoCompact:Merged", const_cast<CompactionType*>(&context.type));
 
   // Lock manifest file for writes to be able to not miss any upcoming chunk.
-  AcquireManifest();
+  RETURN_NOT_OK(AcquireManifest());
   TEST_SYNC_POINT("VectorLSM::DoCompact:ManifestAcquired");
   // Prepare manifest file update taking into account specified policy.
   VectorLSMUpdatePB update;

--- a/src/yb/vector_index/vector_lsm.h
+++ b/src/yb/vector_index/vector_lsm.h
@@ -148,6 +148,9 @@ class VectorLSM {
   storage::UserFrontierRange GetInMemoryFrontiers();
   storage::FlushAbility GetFlushAbility();
 
+  // Returns terminal failure without waiting for in-flight saves.
+  Status GetFlushStatus() const;
+
   Status Insert(std::vector<InsertEntry> entries, const VectorLSMInsertContext& context);
 
   // Returns an estimate, derived from the underlying vector index implementation, of the number
@@ -182,6 +185,7 @@ class VectorLSM {
 
   Env* TEST_GetEnv() const;
   bool TEST_HasBackgroundInserts() const;
+  size_t TEST_PendingSaveTasks() const;
   bool TEST_HasCompactions() const EXCLUDES(mutex_);
   bool TEST_ObsoleteFilesCleanupInProgress() const;
   size_t TEST_NextManifestFileNo() const EXCLUDES(mutex_);
@@ -234,10 +238,12 @@ class VectorLSM {
   Status RollChunk(
       size_t min_vectors, rocksdb::Cache::ReservationMode reservation_mode) REQUIRES(mutex_);
   Status DoFlush(std::promise<Status>* promise) REQUIRES(mutex_);
+  bool FlushesRetiredUnlocked() const REQUIRES(mutex_);
 
   // Use var arg to avoid specifying arguments twice in SaveChunk and DoSaveChunk.
   void SaveChunk(const ImmutableChunkPtr& chunk) EXCLUDES(mutex_);
   void CheckFailure(const Status& status) EXCLUDES(mutex_);
+  void RecordFailureUnlocked(const Status& status) REQUIRES(mutex_);
 
   // Actual implementation for SaveChunk, to have ability simply return Status in case of failure.
   Status DoSaveChunk(const ImmutableChunkPtr& chunk) EXCLUDES(mutex_);
@@ -251,7 +257,7 @@ class VectorLSM {
   Status AddChunkToManifest(WritableFile& manifest_file, ImmutableChunk& chunk);
 
   bool ManifestAcquired() EXCLUDES(mutex_);
-  void AcquireManifest() EXCLUDES(mutex_);
+  Status AcquireManifest() EXCLUDES(mutex_);
   void ReleaseManifest() EXCLUDES(mutex_);
   void ReleaseManifestUnlocked() REQUIRES(mutex_);
   Result<WritableFile*> RollManifest() REQUIRES(mutex_);
@@ -367,6 +373,9 @@ class VectorLSM {
   // invariant must be kept. The value of order_no is used as key in this map.
   std::map<size_t, ImmutableChunkPtr> updates_queue_ GUARDED_BY(mutex_);
   std::condition_variable_any updates_queue_empty_cv_;
+  // Includes queued saves and saves waiting for inserts. Manifest failure can leave entries in
+  // updates_queue_ permanently, so error-path retirement cannot use queue emptiness alone.
+  size_t pending_save_tasks_ GUARDED_BY(mutex_) = 0;
 
   mutable rw_spinlock compaction_tasks_mutex_;
   std::condition_variable_any compaction_tasks_cv_;
@@ -383,6 +392,8 @@ class VectorLSM {
   std::vector<std::unique_ptr<VectorLSMFileMetaData>> obsolete_files_ GUARDED_BY(cleanup_mutex_);
   std::atomic<bool> obsolete_files_cleanup_in_progress_ = false;
 
+  // Set via RecordFailureUnlocked to complete synchronous waiters. Must be copied, not moved,
+  // when returned: retirement and subsequent calls rely on this error.
   Status failed_status_ GUARDED_BY(mutex_);
 
   std::unique_ptr<VectorLSMMetrics> metrics_;

--- a/src/yb/yql/pgwrapper/pg_vector_index-test.cc
+++ b/src/yb/yql/pgwrapper/pg_vector_index-test.cc
@@ -11,6 +11,7 @@
 // under the License.
 //
 
+#include <future>
 #include <queue>
 
 #include "yb/client/client_error.h"
@@ -47,6 +48,9 @@
 
 #include "yb/tserver/mini_tablet_server.h"
 #include "yb/tserver/tablet_server.h"
+#include "yb/tserver/tablet_flusher.h"
+#include "yb/tserver/ts_tablet_manager.h"
+#include "yb/tserver/tserver_admin.pb.h"
 
 #include "yb/util/backoff_waiter.h"
 #include "yb/util/countdown_latch.h"
@@ -108,6 +112,7 @@ DECLARE_uint64(vector_index_max_merge_tasks);
 DECLARE_uint64(vector_index_task_size);
 
 METRIC_DECLARE_histogram(handler_latency_yb_tserver_TabletServerService_Read);
+METRIC_DECLARE_gauge_uint64(tablet_flush_active);
 
 namespace yb::docdb {
 
@@ -3129,6 +3134,114 @@ TEST_P(PgVectorIndexSingleServerTest, ShutdownDuringIntentsWriteStall) {
   // fixed code Tablet::StartShutdown signals RocksDB shutdown before the strand drain, releasing
   // the stalled write, so the drop completes.
   ASSERT_OK(conn.Execute("DROP TABLE test"));
+}
+
+TEST_P(PgVectorIndexSingleServerTest, FailedVectorFlushRetiresIntentsAndAdmission) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_enable_compactions) = false;
+  auto conn = ASSERT_RESULT(MakeIndex());
+  auto peers = ListTabletPeersWithVectorIndexes(cluster_.get());
+  ASSERT_EQ(peers.size(), 1);
+  auto tablet = ASSERT_RESULT(peers.front()->shared_tablet());
+  ASSERT_OK(tablet->Flush(tablet::FlushMode::kSync, tablet::FlushFlags::kAllDbs,
+                          rocksdb::FlushReason::kTestOnly));
+  ASSERT_OK(conn.StartTransaction(IsolationLevel::SNAPSHOT_ISOLATION));
+  ASSERT_OK(InsertBatch(conn, 1, 16));
+  ASSERT_OK(conn.CommitTransaction());
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kTrue, 30s * kTimeMultiplier));
+  // Remove regular RocksDB from the dependency so the filter can only be waiting for vector data.
+  ASSERT_OK(tablet->Flush(tablet::FlushMode::kSync, tablet::FlushFlags::kRegular,
+                          rocksdb::FlushReason::kTestOnly));
+  auto indexes = tablet->vector_indexes().List();
+  ASSERT_EQ(indexes->size(), 1);
+  auto index = indexes->front();
+  auto* intents_db = tablet->intents_db();
+  ASSERT_NE(intents_db, nullptr);
+  auto flushed_frontier = [](auto* storage) {
+    auto frontier = storage->GetFlushedFrontier();
+    return frontier ? frontier->ToString() : std::string();
+  };
+  const auto intents_frontier = flushed_frontier(intents_db);
+  const auto vector_frontier = flushed_frontier(index.get());
+
+  CountDownLatch saving(1), release_save(1), intents_blocked(1), shutdown_done(1);
+  CountDownLatch vector_retiring(1), release_vector(1), intents_failed(1), release_intents(1);
+  auto* sync = SyncPoint::GetInstance();
+  sync->SetCallBack("VectorLSM::DoSaveChunk:Status", [&](void* arg) {
+    saving.CountDown();
+    release_save.Wait();
+    *static_cast<Status*>(arg) = STATUS(IOError, "injected vector dependency failure");
+  });
+  sync->SetCallBack("Tablet::IntentsDbFlushFilter:Blocked", [&](void* arg) {
+    if (arg == tablet.get()) {
+      intents_blocked.CountDown();
+    }
+  });
+  sync->SetCallBack("VectorLSM::SaveChunk:BeforeRetirement", [&](void*) {
+    vector_retiring.CountDown();
+    release_vector.Wait();
+  });
+  sync->SetCallBack("DBImpl::WaitAfterBackgroundError", [&](void* arg) {
+    if (arg == intents_db) {
+      intents_failed.CountDown();
+      release_intents.Wait();
+    }
+  });
+  sync->EnableProcessing();
+  auto* server = cluster_->mini_tablet_server(0)->server();
+  auto active = server->metric_entity()->FindOrNull<AtomicGauge<uint64_t>>(
+      METRIC_tablet_flush_active);
+  auto& flusher = server->tablet_manager()->tablet_flusher();
+  auto result = std::make_shared<std::promise<std::pair<Status, TabletId>>>();
+  auto future = result->get_future();
+  bool admitted = false;
+  TestThreadHolder threads;
+  auto cleanup = ScopeExit([&] {
+    release_save.CountDown();
+    release_vector.CountDown();
+    release_intents.CountDown();
+    if (admitted && future.valid()) {
+      future.wait();
+    }
+    threads.JoinAll();
+    sync->DisableProcessing();
+    sync->ClearAllCallBacks();
+  });
+  tserver::FlushTabletsRequestPB request;
+  request.set_operation(tserver::FlushTabletsRequestPB::FLUSH);
+  ASSERT_OK(flusher.Submit({tablet}, request, CoarseMonoClock::Now() + 30s * kTimeMultiplier,
+      [result](const Status& status, const TabletId& id) { result->set_value({status, id}); }));
+  admitted = true;
+  ASSERT_TRUE(saving.WaitFor(30s * kTimeMultiplier));
+  ASSERT_TRUE(intents_blocked.WaitFor(30s * kTimeMultiplier));
+  ASSERT_EQ(flushed_frontier(intents_db), intents_frontier);
+  release_save.CountDown();
+  ASSERT_TRUE(vector_retiring.WaitFor(30s * kTimeMultiplier));
+  ASSERT_TRUE(intents_failed.WaitFor(30s * kTimeMultiplier));
+  ASSERT_TRUE(intents_db->WaitForFlush().IsIOError());
+  ASSERT_EQ(active->value(), 1);
+  ASSERT_EQ(future.wait_for(20ms), std::future_status::timeout);
+  ASSERT_TRUE(flusher.Submit({tablet}, request, CoarseMonoClock::Now() + 5s,
+      [](const Status&, const TabletId&) {}).IsServiceUnavailable());
+
+  release_vector.CountDown();
+  ASSERT_TRUE(index->WaitForFlush().IsIOError());
+  ASSERT_EQ(active->value(), 1);
+  ASSERT_EQ(future.wait_for(20ms), std::future_status::timeout);
+  release_intents.CountDown();
+  ASSERT_EQ(future.wait_for(30s * kTimeMultiplier), std::future_status::ready);
+  auto [status, failed_tablet_id] = future.get();
+  ASSERT_TRUE(status.IsIOError()) << status;
+  ASSERT_EQ(failed_tablet_id, tablet->tablet_id());
+  ASSERT_EQ(active->value(), 0);
+  ASSERT_EQ(flushed_frontier(intents_db), intents_frontier);
+  ASSERT_EQ(flushed_frontier(index.get()), vector_frontier);
+
+  threads.AddThreadFunctor([&] {
+    cluster_->mini_tablet_server(0)->Shutdown();
+    shutdown_done.CountDown();
+  });
+  ASSERT_TRUE(shutdown_done.WaitFor(30s * kTimeMultiplier));
+  threads.JoinAll();
 }
 
 TEST_P(PgVectorIndexSingleServerTest, ReverseMappingCleanup) {


### PR DESCRIPTION
## Summary

Snapshot creation flushes while applying a Raft operation, holding the tablet's ReplicaState mutex
and potentially stalling writes, lease-checked reads, and follower replication. Prepare-time
flushing can be overtaken by apply; waiting for it there would block consensus.

Replace prepare-time flushing with an optional leader preflight before submitting `CREATE_ON_TABLET`:

- Pin history, resolve intents, capture the active configuration, and flush every captured replica
  using separate `FlushTablets` RPCs and local flushing. Recheck leadership, term, membership, and
  deadline before submission; failures prevent submission, with no best-effort fallback.
- Use separate bounded orchestration and receiver executors, excluding overlapping work per tablet.
  Caller timeouts do not release admission before physical flush work and error cleanup retire.
- Retain the synchronous all-DB apply-time flush. Preflight does not establish a common flushed OpId
  or exclude later writes, so apply-time work can remain substantial.
- Keep equal-timestamp history registrations independent. Propagate terminal vector/storage failures
  to dependent intents flushes and synchronous/manifest waiters rather than strand shutdown.

Preflight is **default-off**: requiring every captured replica reduces snapshot availability even
when a healthy quorum can still commit writes. Neither the preparer nor `UpdateConsensus` waits for
preflight; ordinary storage contention and write stalls still apply.

| Flag | Default | Scope |
| --- | --- | --- |
| `snapshot_create_flush_before_submit` | `false` | Runtime; enables leader preflight |
| `snapshot_preflush_timeout_ms` | `10000` | Runtime; capped by the incoming RPC deadline |
| `snapshot_preflush_concurrency` | `4` | Startup; outstanding leader preflights per server |
| `tablet_flush_concurrency` | `4` | Startup; admitted admin/local flush batches per server |

## Upgrade/Rollback safety

No wire-format, on-disk-format, or catalog changes. Supported older followers use the existing
`FlushTablets` API; only upgraded, enabled leaders orchestrate preflight. Mixed versions do not
provide a cluster-wide latency guarantee.

Disable `snapshot_create_flush_before_submit` to restore direct submission plus the final synchronous
flush. The branch-only `snapshot_create_flush_on_prepare` flag is removed without a compatibility
shim; remove it from any configuration used to test earlier revisions of this PR.

Shared admin-flush admission and storage error handling apply even with preflight disabled. Storage
filter errors fail closed and make the affected RocksDB read-only, including when paranoid checks
are disabled; disabling preflight does not clear a cached storage failure.

## Test plan

Local validation on the development base, before the publication rebase (release, clang21, arm64;
one exact test filter per invocation):

- [x] 48 targeted tests covering snapshot data, RF=3 write progress, missing/unavailable followers,
  leadership/configuration changes, timeouts, history pins, admission limits, and flush retirement.
- [x] New failure regressions: out-of-order synchronous vector promises, manifest-waiter shutdown,
  memtable-selection rollback, and integrated vector/intents failure with unchanged durable frontiers
  and admission held through cleanup. Vector cases include usearch and hnswlib; the integrated case
  also passed with the YbHnsw usearch backend.
- [x] Three additional repetitions each of `EarlierFailureCompletesSynchronousFlush`,
  `ManifestFailureReleasesCompactionWaiter`, `FailedVectorFlushRetiresIntentsAndAdmission`, and
  `SnapshotTest.PreflushDoesNotBlockReplication`.
- [x] Release daemon build.
- [x] C++ lint and `git diff --check`; branch-wide lint also passed after rebasing onto current master.

The build/test matrix has not been rerun on the rebased PR head. Sanitizers and load benchmarks
were not run.

