### PR TITLE
[#33511] YSQL: Raise relcache preload mem test RSS cap to 120 MB

### DIFF
--- a/src/yb/yql/pgwrapper/pg_relcache_preload_mem-test.cc
+++ b/src/yb/yql/pgwrapper/pg_relcache_preload_mem-test.cc
@@ -74,7 +74,9 @@ class PgRelcachePreloadMemNormalTest : public PgRelcachePreloadMemTest {
   bool UseMinimalCatalogCachesPreload() const override { return false; }
 };
 
-constexpr int64_t kSingleConnMaxRssMb = 100;
+// Backend peak RSS varies with host core count (tcmalloc per-CPU caches):
+// measured ~88 MB on 8 cores, ~103 MB on 192 cores for the same build.
+constexpr int64_t kSingleConnMaxRssMb = 120;
 constexpr int64_t kAllConnsMaxRssMb = 250;
 
 // Regression guard: a minimal-preload backend must preload the pg_rewrite


### PR DESCRIPTION
## Summary
The per-backend peak-RSS cap in pg_relcache_preload_mem-test fails on
many-core hosts: backend peak RSS includes tcmalloc per-CPU caches, which
scale with core count. Measured ~88 MB on 8 cores vs ~103 MB on 192 cores
for the same build. Raise the cap from 100 MB to 120 MB; the ~560 MB
regression the test guards against still exceeds it by a wide margin.

## Test plan
- [x] Ran PgRelcachePreloadMem tests on a 192-core Linux host (release):
      failed with the 100 MB cap (peak RSS 103/102 MB), pass with 120 MB.
- [x] Ran on an 8-core Linux host (release): peak RSS 88-89 MB, passes.
