### PR TITLE
[#33516] DocDB: Fix session-level advisory lock txn start time units

### DIFF
--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -3598,11 +3598,12 @@ class PgClientSession::Impl {
       txn = transaction_provider_.Take<kSessionKind>(deadline);
       txn->SetLogPrefixTag(kTxnLogPrefixTag, id_);
       txn->InitPgSessionRequestVersion();
-      // Set the start time before initializing the transaction to allow start time to be
-      // propagated to txn coordinator.
+      // Set the start time (epoch microseconds, like pg_txn_start_us) before initializing the
+      // transaction to allow start time to be propagated to txn coordinator.
       // Session level txns is only used for advisory locks. These would not touch regular tables.
-      RETURN_NOT_OK(
-          txn->SetPgTxnStart(MonoTime::Now().ToUint64(), IsTxnUsingTableLocks::kFalse));
+      RETURN_NOT_OK(txn->SetPgTxnStart(
+          static_cast<int64_t>(clock()->Now().GetPhysicalValueMicros()),
+          IsTxnUsingTableLocks::kFalse));
       // Isolation level doesn't matter but we need to set it for conflict resolution to not treat
       // it as a single shard/fast-path transaction.
       RETURN_NOT_OK(txn->Init(IsolationLevel::READ_COMMITTED));

--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -3990,7 +3990,8 @@ class PgClientSession::Impl {
           ? IsolationLevel::SERIALIZABLE_ISOLATION : IsolationLevel::SNAPSHOT_ISOLATION;
       txn = transaction_provider_.Take<PgClientSessionKind::kAutonomousDdl>(deadline);
       RETURN_NOT_OK(txn->SetPgTxnStart(
-          pg_txn_start_us ? pg_txn_start_us : MonoTime::Now().ToUint64(),
+          pg_txn_start_us ? pg_txn_start_us
+                          : static_cast<int64_t>(clock()->Now().GetPhysicalValueMicros()),
           is_txn_using_table_locks));
       RETURN_NOT_OK(txn->Init(isolation));
       txn->SetPriority(priority);


### PR DESCRIPTION
## Summary

`BeginPgSessionLevelTxnIfNecessary` stamped the session-level (advisory lock) transaction's start time with `MonoTime::Now().ToUint64()` — monotonic nanoseconds since boot — while every consumer treats `pg_txn_start_us` as microseconds since the Unix epoch. On hosts up longer than ~20.7 days that value exceeds current epoch-microseconds, so the txn looks like it starts in the far future: the coordinator's `GetOldTransactions` scan can exclude it (`pg_locks` then shows none of the session's advisory locks), the `pg_locks` `max_num_txns` priority queue evicts it first, and wait-queue fairness mis-orders it. On fresh hosts the same value is smaller than any epoch timestamp, so the txn just looks infinitely old and everything works — which is why CI never catches this.

Fix: send the hybrid clock's physical time (epoch microseconds), matching what the plain-txn path sends.

## Test plan

- [x] `PgObjectLocksTest.ConsecutiveCreateIndexDontDeadlock` on a release build on a host with 82 days of uptime: failed before the fix (advisory lock count 0, expected 3), passes with it.
