### PR TITLE
[#33510] Tools: Drop sudo mkdir of /opt/yb-build from Cloud Agent Dockerfiles

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,3 +1,1 @@
 FROM yugabyteci/yb_build_infra_almalinux9_x86_64:latest
-
-RUN sudo mkdir -p /opt/yb-build && sudo chown yugabyteci:yugabyteci /opt/yb-build

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,1 @@
 FROM yugabyteci/yb_build_infra_almalinux9_x86_64:latest
-
-RUN sudo mkdir -p /opt/yb-build && sudo chown yugabyteci:yugabyteci /opt/yb-build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ When working on DB code (`src/`), refer to `src/AGENTS.md` for build and test gu
 
 ### Environment
 
-The VM image is `yugabyteci/yb_build_infra_almalinux9_x86_64` which ships with: Clang, JDK 17, Go, Python 3.11, CMake, Ninja, SBT, Node.js 22, Rust, and all C++ build dependencies. The `/opt/yb-build` directory is pre-created for thirdparty downloads and toolchain caching.
+The VM image is `yugabyteci/yb_build_infra_almalinux9_x86_64` which ships with: Clang, JDK 17, Go, Python 3.11, CMake, Ninja, SBT, Node.js 22, Rust, and all C++ build dependencies.
 
 ### Building from source
 


### PR DESCRIPTION
## Summary

The Cloud Agent image build fails because `.cursor/Dockerfile` runs `sudo mkdir /opt/yb-build` as `yugabyteci`, whose sudo needs a password and a TTY. Docker `RUN` has neither.

Remove that `RUN` from both Dockerfiles. `/opt/yb-build` is not required to start the environment.

## Test plan

- [x] Confirmed both Dockerfiles are a single `FROM` line with no `sudo` `RUN`
- [ ] Re-run a Cursor Cloud Agent environment build after merge (builds use the default branch)
