### PR TITLE
[#33522] Docs: Build a Netlify preview only when a pull request changes docs

### DIFF
--- a/docs/netlify-ignore.sh
+++ b/docs/netlify-ignore.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Netlify runs this from the site's base directory (docs/) before every build.
+# Exit 0 cancels the build; any non-zero status lets it proceed.
+#
+# When we cannot establish what a build would cover we let it run: a redundant
+# preview is cheaper than a missing one.
+
+set -uo pipefail
+
+REPO=${DOCS_REPO_SLUG:-yugabyte/yugabyte-db}
+# GitHub caps this endpoint at 3000 files, so a full 30th page means the list
+# was truncated and we can no longer rule out docs edits.
+MAX_PAGES=30
+
+build() { echo "netlify-ignore: $1; building."; exit 1; }
+skip()  { echo "netlify-ignore: $1; skipping build."; exit 0; }
+
+if [[ ${PULL_REQUEST:-false} == true ]]; then
+  # CACHED_COMMIT_REF is the last commit built for this context, which for a
+  # deploy preview is an unrelated commit on the production branch. Diffing
+  # against it reports every docs commit that landed between that commit and
+  # this branch's base, so it flags PRs that never touched docs. Ask GitHub what
+  # the PR itself changed instead.
+  [[ -n ${REVIEW_ID:-} ]] || build "deploy preview with no REVIEW_ID"
+
+  curl_args=(--silent --show-error --fail --max-time 30
+             -H 'Accept: application/vnd.github+json')
+  [[ -n ${GITHUB_TOKEN:-} ]] && curl_args+=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
+  for ((page = 1; page <= MAX_PAGES; page++)); do
+    payload=$(curl "${curl_args[@]}" \
+      "https://api.github.com/repos/$REPO/pulls/$REVIEW_ID/files?per_page=100&page=$page") \
+      || build "could not list the files in PR #$REVIEW_ID"
+
+    # previous_filename too, so renaming a page out of docs/ still rebuilds.
+    paths=$(grep -oE '"(previous_)?filename"[[:space:]]*:[[:space:]]*"[^"]*"' <<<"$payload" |
+              sed 's/.*"\(.*\)"$/\1/')
+    grep -q '^docs/' <<<"$paths" && build "PR #$REVIEW_ID edits docs/"
+
+    (( $(grep -o '"filename"' <<<"$payload" | wc -l) < 100 )) &&
+      skip "PR #$REVIEW_ID does not touch docs/"
+  done
+  build "PR #$REVIEW_ID has a truncated file list ($((MAX_PAGES * 100))+ files)"
+fi
+
+# Production and branch deploys advance along a single branch, so the cached
+# commit is an ancestor of this one and diffing the two is accurate.
+[[ -n ${CACHED_COMMIT_REF:-} ]] || build "no CACHED_COMMIT_REF to compare against"
+[[ ${CACHED_COMMIT_REF} != ${COMMIT_REF:-} ]] ||
+  build "$COMMIT_REF was already the last build, so this is a rebuild"
+git cat-file -e "${CACHED_COMMIT_REF}^{commit}" 2>/dev/null ||
+  build "CACHED_COMMIT_REF $CACHED_COMMIT_REF is not in this clone"
+git diff --quiet "$CACHED_COMMIT_REF" "$COMMIT_REF" -- . ||
+  build "docs/ changed since $CACHED_COMMIT_REF"
+skip "no docs/ changes since $CACHED_COMMIT_REF"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -4,7 +4,7 @@
   # Default build command.
   command = "npm run build"
   # Skip builds unless this directory has changes.
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- . && [ -n \"$CACHED_COMMIT_REF\" ] && [ \"$CACHED_COMMIT_REF\" != \"$COMMIT_REF\" ]"
+  ignore = "bash ./netlify-ignore.sh"
 
 # Deploy contexts
 # Environment variables here override variables set in the web UI.


### PR DESCRIPTION
## Summary

Netlify built a docs deploy preview for almost every pull request. It also
built a preview for pull requests that do not change a file in `docs/`.
Pull request #33508 is an example. That pull request changes only
`.cursor/Dockerfile`, `.devcontainer/Dockerfile`, and `AGENTS.md`.

### Cause

Two conditions of the Netlify environment are important:

- Exit code 0 from the `ignore` command cancels the build. A different exit
  code lets the build start.
- Netlify runs the command from the base directory of the site. That directory
  is `docs/`. The path `.` is thus `docs/`. The path `docs/` is `docs/docs/`,
  and no file has that path.

The rule compared the current commit with `CACHED_COMMIT_REF`:

```
git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- .
```

`CACHED_COMMIT_REF` is the last commit that Netlify built. For a deploy
preview, that commit is a commit on master. It has no relation to the point
where the branch started. The `git diff` command compares two trees. It
reports each docs commit that came to master after the branch started. The
branch does not contain these commits, and the command shows them as
differences.

Docs commits came to master on 18 of the last 30 days. Almost all branches
are older than the most recent docs commit. Netlify thus built a preview for
almost all pull requests.

### The four previous versions of the rule

Four pull requests changed this rule. Each one kept the comparison with
`CACHED_COMMIT_REF`. I ran all four commands in a small test repository with
the same directory layout. This table shows the result of each command. The
results in bold are incorrect.

| Test case | #30983 | #31416 | #31719 | #31808 | Correct result |
|---|---|---|---|---|---|
| The commit changes docs | BUILD | BUILD | **SKIP** | BUILD | BUILD |
| The commit does not change docs | SKIP | **BUILD** | SKIP | SKIP | SKIP |
| `CACHED_COMMIT_REF` is empty | **SKIP** | BUILD | BUILD | BUILD | BUILD |
| The cached commit is the current commit | **SKIP** | BUILD | BUILD | BUILD | BUILD |

**#30983** used `git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- .`. The
exit code and the path were correct. But the command did not protect against
an empty variable. If `CACHED_COMMIT_REF` is empty, the shell removes it. The
command becomes `git diff --quiet $COMMIT_REF -- .`, which compares the commit
with the work tree. The work tree is a clean copy of that commit. The exit
code is thus 0, and Netlify cancelled the build. The same problem applied to a
second build of the same commit.

**#31416** used `git diff --name-only ... -- docs/ | grep -q .`. This version
has two errors, and each error hides the other one. First, `grep -q .` gives
exit code 0 when the diff finds a change in docs. Exit code 0 cancels the
build, thus this command cancelled the build when docs changed. Second, the
path `docs/` finds no file, because the command runs in `docs/`. The output is
always empty, and `grep` always fails. Netlify thus built a preview for every
pull request. The second error hid the first error.

**#31719** used `--quiet` again, and added two tests of `CACHED_COMMIT_REF`.
These changes corrected the exit code and the two problems of #30983. But this
version kept the incorrect `docs/` path, and `--quiet` no longer hid that
error. The command found no change in any condition, and gave exit code 0.
Netlify cancelled all builds, also the builds for commits that change docs. The
next pull request, #31808, has the title "Tweak netlify build command that
wasn't working".

**#31808** changed the path from `docs/` to `.`. All four results in the table
are now correct. But the comparison with `CACHED_COMMIT_REF` is still
incorrect for a deploy preview. The "Cause" section above gives this defect.

### The change

The new script `docs/netlify-ignore.sh` replaces the rule, and
`docs/netlify.toml` calls the script.

For a deploy preview, the script asks the GitHub API which files the pull
request changes. It starts a build only when a path starts with `docs/`. The
script also reads the `previous_filename` field. A pull request that moves a
page out of `docs/` thus starts a build.

For a production build or a branch build, the script keeps the comparison with
`CACHED_COMMIT_REF`. That comparison is correct for these builds, because the
cached commit is an ancestor of the current commit.

If the script cannot find which files changed, it starts a build. This applies
when `REVIEW_ID` is not set, when the API gives an error, when the cached
commit is not in the clone, and when the list of files is too long. An
unnecessary preview is better than an absent preview.

### One request for the Netlify configuration

The GitHub API permits 60 requests each hour from one address if the request
has no token. Netlify build machines share addresses. If this limit stops the
request, the script starts a build, which is the current behavior. Thus this
limit cannot break the docs previews, but it can prevent the decrease in
builds.

A `GITHUB_TOKEN` environment variable in the Netlify configuration increases
the limit to 5000 requests each hour. The script uses this variable if it is
present. Read access to public repositories is sufficient. Please add this
variable.

## Test plan

I ran `docs/netlify-ignore.sh` against the GitHub API and against the commits
of this repository. The script gave the correct result in each test.

Deploy previews, real pull requests:

- [x] Pull requests #33502, #33473, and #33436 change docs. The script started
      a build.
- [x] Pull requests #33508, #33483, and #33474 do not change docs. The script
      cancelled the build.
- [x] Pull request #33206 changes 8458 files, and its first docs file is on
      page 2 of the API results. The script read page 2 and started a build.
- [x] The same tests without a `GITHUB_TOKEN` value gave the same results.

Deploy previews, conditions with no data:

- [x] An unknown pull request number gives HTTP 404. The script started a
      build.
- [x] `REVIEW_ID` is not set. The script started a build.
- [x] An unknown repository gives an error. The script started a build.
- [x] The list of files is too long. The script started a build, and did not
      cancel it. GitHub gives a maximum of 3000 files for this API, thus the
      script must not trust a full last page.

Production builds and branch builds, commits from this repository:

- [x] A commit that changes docs. The script started a build.
- [x] Two sequential commits that do not change docs. The script cancelled the
      build.
- [x] `CACHED_COMMIT_REF` is empty. The script started a build.
- [x] `CACHED_COMMIT_REF` is the current commit. The script started a build.
- [x] `CACHED_COMMIT_REF` is not in the clone. The script started a build.

Other:

- [x] `bash -n docs/netlify-ignore.sh` found no error.

I could not test the Netlify environment itself. The base directory and the
`bash` and `curl` commands are necessary for the script. Pull request #31808
shows that the base directory is `docs/`. The Ubuntu image of Netlify contains
`bash` and `curl`. The first deploy preview of this pull request will show if
these conditions are correct.
