### PR TITLE
fix: guard xcluster parser against empty bracket and bracket-less output

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -11598,9 +11598,9 @@ class YBAdminProxy(object):
             return None
 
         matches = re.findall(r'\[(.*?)\]', out)
-        replication_ids = [replication_id.strip() for replication_id in matches[0].split(',')]
-
-        return replication_ids
+        if not matches:
+            return []
+        return [replication_id.strip() for replication_id in matches[0].split(',') if replication_id.strip()]
 
     @staticmethod
     def get_source_xcluster_databases(master_addrs, replication_id, timeout=10):


### PR DESCRIPTION
Fixes #33514

`get_source_xcluster_replication_ids` uses `re.findall(r'\[(.*?)\]', out)` to parse yb-admin output. Two failure modes:

1. **Zero groups** — `[]` matches as `['']`, `''.split(',')` = `['']`, phantom empty replication ID. `does_replication_id_exists('')` returns `True`.
2. **Bracket-less output** — `matches[0]` raises `IndexError` instead of a clean exit.

Fix: guard empty matches and filter empty entries from the split result.