### PR TITLE
[#33540] DocDB: Bind outbound loopback connections to 127.0.0.1 on macOS

### DIFF
--- a/src/yb/rpc/reactor.cc
+++ b/src/yb/rpc/reactor.cc
@@ -789,6 +789,15 @@ Status Reactor::FindOrStartConnection(const ConnectionId &conn_id,
     auto outbound_address = conn_id.remote().address().is_v6()
         ? messenger_.outbound_address_v6()
         : messenger_.outbound_address_v4();
+#if defined(__APPLE__)
+    // macOS picks the destination as the source for unbound loopback sockets (src == dst);
+    // bind to the loopback address like Linux does.
+    if (outbound_address.is_unspecified() && conn_id.remote().address().is_loopback()) {
+      outbound_address = conn_id.remote().address().is_v6()
+          ? IpAddress(boost::asio::ip::address_v6::loopback())
+          : IpAddress(boost::asio::ip::address_v4::loopback());
+    }
+#endif
     if (!outbound_address.is_unspecified()) {
       auto status = sock.SetReuseAddr(true);
       if (status.ok()) {


### PR DESCRIPTION
## Summary

On macOS, an unbound socket that connects to a loopback alias gets the destination address itself as its source address (src == dst); Linux picks 127.0.0.1.

The MiniCluster connectivity simulation filters incoming connections by source address. A client dialing a server's broadcast address therefore appears to connect from that blacklisted address and is reset. Since the fix for issue #28539 made yb-admin prefer broadcast addresses over private ones, several xCluster bootstrap / admin-cli tests and AreLeadersOnPreferredOnlyTest fail on macOS with "Connection reset by peer" (see #33540 for the full list).

Bind the outbound socket to 127.0.0.1 / ::1 when no source address is configured and the remote is loopback, macOS only — Linux behavior is unchanged. Server messengers in MiniCluster set an explicit outbound base address and are unaffected, so the simulated connectivity breaking still works.

## Test plan

On macOS arm64 (release build), all previously failing with "Connection reset by peer", now passing:

- [x] `./yb_build.sh release --cxx-test tools_yb-admin-xcluster-test --gtest_filter '*Bootstrap*'`
- [x] `./yb_build.sh release --cxx-test integration-tests_xcluster-tablet-split-itest --gtest_filter NotSupportedTabletSplitITest.SplittingWithBootstrappedStream`
- [x] `./yb_build.sh release --cxx-test integration-tests_are_leaders_on_preferred_only-itest`
