### PR TITLE
[#33499] DocDB: Enforce a cap on intra-transaction write IDs

### DIFF
--- a/src/yb/common/doc_hybrid_time.h
+++ b/src/yb/common/doc_hybrid_time.h
@@ -32,6 +32,13 @@ constexpr IntraTxnWriteId kMinWriteId = 0;
 constexpr IntraTxnWriteId kDefaultWriteId = kMinWriteId;
 constexpr IntraTxnWriteId kMaxWriteId = std::numeric_limits<IntraTxnWriteId>::max();
 
+// Exclusive upper bound on intra-transaction write IDs (#33499). The counter previously
+// wrapped silently at 2^32, breaking the intra-transaction write-ID ordering that
+// commit-time intent application relies on. The write path enforces the limit before Raft
+// submission. Capping at half the space keeps every transaction far below the wrap point
+// while reserving [2^31, 2^32) for future write-ID domains.
+constexpr IntraTxnWriteId kIntraTxnWriteIdLimit = 0x80000000;
+
 // An aggressive upper bound on the length of a DocDB-encoded hybrid time with a write id.
 // This could happen in the degenerate case when all three VarInts in encoded representation of a
 // DocHybridTime take 10 bytes (the maximum length for a VarInt-encoded int64_t).

--- a/src/yb/docdb/non_transactional_batch_writer-test.cc
+++ b/src/yb/docdb/non_transactional_batch_writer-test.cc
@@ -127,6 +127,31 @@ class NonTransactionalBatchWriterTest : public DocDBTestBase {
     return Status::OK();
   }
 
+  // Runs a foreground transactional intent batch through TransactionalWriter with a seeded
+  // intra-transaction write ID counter, exactly like Tablet::WriteTransactionalBatch seeds it
+  // from the participant's next_write_id. Applies through a no-op handler rather than a real
+  // RocksDB write: a DirectWriter failure inside a DB write is cached as a background error
+  // that fails the fixture's DB destructor at teardown.
+  Status ApplyTransactionalBatch(
+      const docdb::LWKeyValueWriteBatchPB& put_batch, HybridTime hybrid_time,
+      const TransactionId& txn_id, IntraTxnWriteId start_write_id) {
+    class NoopDirectWriteHandler : public rocksdb::DirectWriteHandler {
+     public:
+      std::pair<Slice, Slice> Put(
+          const rocksdb::SliceParts& /* key */, const rocksdb::SliceParts& /* value */) override {
+        return {};
+      }
+      void SingleDelete(const Slice& /* key */) override {}
+    };
+
+    TransactionalWriter writer(
+        put_batch, hybrid_time, txn_id, IsolationLevel::SNAPSHOT_ISOLATION,
+        dockv::PartialRangeKeyIntents::kTrue, /* replicated_batches_state= */ Slice(),
+        start_write_id, /* applier= */ nullptr);
+    NoopDirectWriteHandler handler;
+    return writer.Apply(handler);
+  }
+
   std::string GetEncodedHashPartitionKey(uint16_t hash) {
     dockv::KeyBytes encoded_key;
     dockv::DocKeyEncoderAfterTableIdStep(&encoded_key).Hash(
@@ -165,6 +190,32 @@ class NonTransactionalBatchWriterTest : public DocDBTestBase {
  protected:
   ThreadSafeArena arena_;
 };
+
+TEST_F(NonTransactionalBatchWriterTest, ForegroundIntraTxnWriteIdCapRejectsAtLimit) {
+  // The always-on foreground cap: a transaction may never write an intent with an
+  // intra-transaction write ID at or above kIntraTxnWriteIdLimit -- that range is reserved.
+  // Without the cap the counter would cross into the reserved domain (and previously wrapped
+  // silently at 2^32).
+  const auto kWriteHT = 6000_usec_ht;
+  const auto txn_id = ASSERT_RESULT(FullyDecodeTransactionId(kTxnId));
+
+  docdb::LWKeyValueWriteBatchPB batch(&arena_);
+  for (const auto* key : {"row1", "row2"}) {
+    auto* write_pair = batch.add_write_pairs();
+    write_pair->dup_key(DocKey(0, MakeKeyEntryValues(key)).Encode().AsSlice());
+    write_pair->dup_value(EncodeValue(QLValue::Primitive("value")));
+  }
+
+  // Seeded fully below the limit, the batch is accepted.
+  ASSERT_OK(ApplyTransactionalBatch(batch, kWriteHT, txn_id, /* start_write_id= */ 0));
+
+  // The first pair consumes the last legal foreground write ID; the second must be rejected
+  // instead of entering the reserved marked domain.
+  const auto status = ApplyTransactionalBatch(
+      batch, kWriteHT, txn_id, /* start_write_id= */ kIntraTxnWriteIdLimit - 1);
+  ASSERT_TRUE(status.IsIllegalState()) << status;
+  ASSERT_STR_CONTAINS(status.message().ToBuffer(), "intra-transaction write ID limit");
+}
 
 TEST_F(NonTransactionalBatchWriterTest, SimpleTransaction) {
   // Simple test where we write two batches of external intents, then apply them.

--- a/src/yb/docdb/rocksdb_writer.cc
+++ b/src/yb/docdb/rocksdb_writer.cc
@@ -478,6 +478,16 @@ Status TransactionalWriter::operator()(
 
   }
 
+  // The write path rejects oversized transactions before Raft submission
+  // (WriteQuery::CheckIntraTxnWriteIdCap), so this is a fail-stop backstop against
+  // incompatible or corrupt replicated data: fail closed rather than crossing into the
+  // reserved range above kIntraTxnWriteIdLimit (previously the counter wrapped silently
+  // at 2^32).
+  SCHECK_LT(
+      intra_txn_write_id_, kIntraTxnWriteIdLimit, IllegalState,
+      "Transaction wrote too many intents to a single tablet: the intra-transaction write ID "
+      "limit is reached");
+
   const auto transaction_value_type = ValueEntryTypeAsChar::kTransactionId;
   const auto write_id_value_type = ValueEntryTypeAsChar::kWriteId;
   IntraTxnWriteId big_endian_write_id = BigEndian::FromHost32(intra_txn_write_id_);
@@ -872,6 +882,20 @@ Result<bool> ApplyIntentsContext::Entry(
           Corruption,
           Format("Unexpected write id. Expected: $0, found: $1, raw value: $2",
                  write_id_,
+                 decoded_value.write_id,
+                 intent_iter_.value().ToDebugHexString()));
+    }
+
+    // The write path enforces kIntraTxnWriteIdLimit before intents are written, so a
+    // violation here means corrupt data or an incompatible writer, and the resulting
+    // regular record would carry a write ID from the reserved range.
+    if (decoded_value.write_id >= kIntraTxnWriteIdLimit) {
+      DumpIntentsRecordForTransaction(intents_db_, transaction_id(), &schema_packing_provider());
+      RSTATUS_DCHECK(
+          false,
+          Corruption,
+          Format("Intent write id $0 is at or above the intra-transaction write ID limit, "
+                 "raw value: $1",
                  decoded_value.write_id,
                  intent_iter_.value().ToDebugHexString()));
     }

--- a/src/yb/tablet/transaction_participant.cc
+++ b/src/yb/tablet/transaction_participant.cc
@@ -129,6 +129,10 @@ DEFINE_test_flag(int32, stopactivetxns_sleep_in_abort_cb_ms, 0,
 DEFINE_test_flag(bool, no_schedule_remove_intents, false,
                  "Don't schedule remove intents when transaction is cleaned from memory.");
 
+DEFINE_test_flag(uint32, initial_intra_txn_write_id, 0,
+    "Initial intra-transaction write ID for newly added transactions. Lets tests exercise the "
+    "kIntraTxnWriteIdLimit cap without writing billions of intents.");
+
 DECLARE_int64(transaction_abort_check_timeout_ms);
 
 DECLARE_uint64(transaction_heartbeat_usec);
@@ -446,8 +450,12 @@ class TransactionParticipant::Impl
                         << " with begin_time: " << metadata.start_time.ToUint64()
                         << " (" << metadata.start_time << ")";
 
+    TransactionalBatchData initial_batch_data;
+    if (PREDICT_FALSE(FLAGS_TEST_initial_intra_txn_write_id != 0)) {
+      initial_batch_data.next_write_id = FLAGS_TEST_initial_intra_txn_write_id;
+    }
     auto txn = std::make_shared<RunningTransaction>(
-        metadata, TransactionalBatchData(), OneWayBitmap(), metadata.start_time, batch_write_ht,
+        metadata, initial_batch_data, OneWayBitmap(), metadata.start_time, batch_write_ht,
         this, metric_aborted_transactions_pending_cleanup_);
 
     {
@@ -464,6 +472,16 @@ class TransactionParticipant::Impl
     mem_tracker_->Consume(kRunningTransactionSize);
     TransactionsModifiedUnlocked(&min_running_notifier);
     return true;
+  }
+
+  Result<IntraTxnWriteId> NextIntraTxnWriteIdHint(const TransactionId& id) {
+    RETURN_NOT_OK(loader_.WaitLoaded(id));
+    std::lock_guard lock(mutex_);
+    auto it = transactions_.find(id);
+    if (it == transactions_.end()) {
+      return kMinWriteId;
+    }
+    return (**it).last_batch_data().next_write_id;
   }
 
   HybridTime LocalCommitTime(const TransactionId& id) {
@@ -3101,6 +3119,10 @@ TransactionParticipant::PrepareBatchData(
 void TransactionParticipant::BatchReplicated(
     const TransactionId& id, const TransactionalBatchData& data) {
   return impl_->BatchReplicated(id, data);
+}
+
+Result<IntraTxnWriteId> TransactionParticipant::NextIntraTxnWriteIdHint(const TransactionId& id) {
+  return impl_->NextIntraTxnWriteIdHint(id);
 }
 
 HybridTime TransactionParticipant::LocalCommitTime(const TransactionId& id) {

--- a/src/yb/tablet/transaction_participant.h
+++ b/src/yb/tablet/transaction_participant.h
@@ -146,6 +146,13 @@ class TransactionParticipant : public TransactionStatusManager {
 
   void BatchReplicated(const TransactionId& id, const TransactionalBatchData& data);
 
+  // The transaction's next intra-transaction write ID as of its last replicated batch.
+  // Returns kMinWriteId for an unknown transaction (its first batch starts there). The value
+  // only advances at Raft apply (BatchReplicated), so with batches in flight it lags the value
+  // the next apply will see -- callers using it to enforce kIntraTxnWriteIdLimit must keep a
+  // margin (see WriteQuery::DoCompleteExecute).
+  Result<IntraTxnWriteId> NextIntraTxnWriteIdHint(const TransactionId& id);
+
   HybridTime LocalCommitTime(const TransactionId& id) override;
 
   std::optional<TransactionLocalState> LocalTxnData(const TransactionId& id) override;

--- a/src/yb/tablet/write_query.cc
+++ b/src/yb/tablet/write_query.cc
@@ -27,6 +27,8 @@
 #include "yb/client/transaction.h"
 #include "yb/client/yb_op.h"
 
+#include "yb/common/doc_hybrid_time.h"
+#include "yb/common/pgsql_error.h"
 #include "yb/common/row_mark.h"
 #include "yb/common/schema.h"
 #include "yb/common/txn_error_injection.h"
@@ -233,6 +235,52 @@ Status CqlPopulateDocOps(
       doc_ops->emplace_back(std::move(write_op));
     }
     ++i;
+  }
+  return Status::OK();
+}
+
+// Always-on cap on the per-transaction-per-tablet intra-transaction write ID (#33499):
+// without the cap the uint32 counter wrapped silently at 2^32, and IDs at or above
+// kIntraTxnWriteIdLimit are reserved. Enforced here, before Raft submission, so an oversized
+// transaction gets a clean error with no WAL or intent side effects and no replica ever
+// evaluates the doomed batch. The participant's counter only advances at Raft apply, so
+// in-flight batches make this check approximate: kIntraTxnWriteIdSoftMargin absorbs any
+// realistic in-flight window, and TransactionalWriter's fail-stop check remains the backstop
+// against corrupt or incompatible replicated data.
+Status CheckIntraTxnWriteIdCap(
+    Tablet* tablet, const docdb::LWKeyValueWriteBatchPB& write_batch) {
+  // Covers the realistic in-flight (submitted but unapplied) intent count of one transaction
+  // on one tablet; consumes ~3% of the 2^31 foreground write-ID budget.
+  constexpr uint64_t kIntraTxnWriteIdSoftMargin = 1ULL << 26;
+
+  if (!write_batch.has_transaction()) {
+    return Status::OK();
+  }
+  auto txn_id = VERIFY_RESULT(FullyDecodeTransactionId(
+      write_batch.transaction().transaction_id()));
+  const auto next_write_id =
+      VERIFY_RESULT(tablet->transaction_participant()->NextIntraTxnWriteIdHint(txn_id));
+  // Approximately one strong intent per write pair, read pair, and lock pair (weak intents do
+  // not consume the intra-transaction counter). Under skip_prefix_locks with SERIALIZABLE
+  // isolation, ancestor top-level keys also take strong intents, so actual consumption can
+  // exceed this count; the soft margin absorbs the undercount and the writer-side check
+  // backstops it.
+  const uint64_t batch_records = write_batch.write_pairs_size() +
+      write_batch.read_pairs_size() + write_batch.lock_pairs_size();
+  if (next_write_id + batch_records + kIntraTxnWriteIdSoftMargin > kIntraTxnWriteIdLimit) {
+    // Not IllegalState: the client-side TabletInvoker retries IllegalState against other
+    // replicas as a leadership failure (tablet_rpc.cc); QLError propagates to the client as a
+    // hard error. SQLSTATE 54000 mirrors PG's per-transaction command-counter limit
+    // ("cannot have more than 2^32-2 commands in a transaction", xact.c) -- the same shape of
+    // per-transaction counter exhaustion.
+    return STATUS(
+        QLError,
+        Format("Transaction $0 exceeds the maximum number of writes to a single tablet "
+               "(intra-transaction write ID $1 + $2 new records would cross the cap of $3)",
+               txn_id, next_write_id, batch_records,
+               kIntraTxnWriteIdLimit - kIntraTxnWriteIdSoftMargin),
+        Slice(),
+        PgsqlError(YBPgErrorCode::YB_PG_PROGRAM_LIMIT_EXCEEDED));
   }
   return Status::OK();
 }
@@ -1210,7 +1258,8 @@ Status WriteQuery::DoCompleteExecute() {
       paths.clear();
     }
   }
-  return Status::OK();
+
+  return CheckIntraTxnWriteIdCap(tablet.get(), write_batch);
 }
 
 Result<TabletPtr> WriteQuery::tablet_safe() const {

--- a/src/yb/yql/pgwrapper/pg_txn-test.cc
+++ b/src/yb/yql/pgwrapper/pg_txn-test.cc
@@ -15,6 +15,8 @@
 
 #include <boost/algorithm/string/join.hpp>
 
+#include "yb/common/doc_hybrid_time.h"
+
 #include "yb/integration-tests/cdcsdk_ysql_test_base.h"
 #include "yb/rocksdb/db.h"
 
@@ -58,6 +60,7 @@ DECLARE_int32(txn_max_apply_batch_records);
 DECLARE_int64(db_filter_block_size_bytes);
 DECLARE_int64(db_write_buffer_size);
 DECLARE_string(time_source);
+DECLARE_uint32(TEST_initial_intra_txn_write_id);
 DECLARE_uint64(rocksdb_universal_compaction_always_include_size_threshold);
 
 METRIC_DECLARE_counter(docdb_column_tombstones_dropped_unmerged);
@@ -133,6 +136,43 @@ class PgTxnTest : public PgMiniTestBase {
     ASSERT_EQ(value_from_deprecated_guc, expected);
   }
 };
+
+// The always-on intra-transaction write-ID cap (kIntraTxnWriteIdLimit): a transaction whose
+// per-tablet counter is near the limit gets a clean, non-retryable error from the pre-Raft
+// check in WriteQuery::DoCompleteExecute -- no crash, and the transaction rolls back
+// normally. Seeds the counter via TEST_initial_intra_txn_write_id because writing ~2^31
+// real intents is infeasible in a test.
+TEST_F(PgTxnTest, IntraTxnWriteIdCapRejectsOversizedTransaction) {
+  auto conn = ASSERT_RESULT(Connect());
+  // Single tablet: the counter (and the seeded TEST value) is per-transaction-per-tablet, so
+  // both inserts must land on the same tablet's participant.
+  ASSERT_OK(conn.Execute(
+      "CREATE TABLE test (key INT PRIMARY KEY, value INT) SPLIT INTO 1 TABLETS"));
+
+  // Every transaction added to the participant from here starts just below the limit. The
+  // first small batch applies (the participant does not know the transaction until its first
+  // batch applies, and the batch stays far below the limit itself); the second statement is
+  // then rejected by the pre-Raft margin check. Keep the flag window tight: it applies to
+  // every new transaction on the (shared-process) cluster.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_initial_intra_txn_write_id) = kIntraTxnWriteIdLimit - 1000;
+  auto flag_resetter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_initial_intra_txn_write_id) = 0;
+  });
+
+  ASSERT_OK(conn.StartTransaction(IsolationLevel::SNAPSHOT_ISOLATION));
+  ASSERT_OK(conn.Execute("INSERT INTO test VALUES (1, 1)"));
+  auto status = conn.Execute("INSERT INTO test VALUES (2, 2)");
+  ASSERT_NOK(status);
+  ASSERT_STR_CONTAINS(status.message().ToBuffer(), "exceeds the maximum number of writes");
+  ASSERT_OK(conn.RollbackTransaction());
+
+  // With the seed removed, new transactions are unaffected.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_initial_intra_txn_write_id) = 0;
+  ASSERT_OK(conn.StartTransaction(IsolationLevel::SNAPSHOT_ISOLATION));
+  ASSERT_OK(conn.Execute("INSERT INTO test VALUES (3, 3)"));
+  ASSERT_OK(conn.CommitTransaction());
+  ASSERT_EQ(ASSERT_RESULT(conn.FetchRow<PGUint64>("SELECT COUNT(*) FROM test")), 1);
+}
 
 TEST_F(PgTxnTest, YB_DISABLE_TEST_IN_SANITIZERS(EmptyUpdate)) {
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_in_apply_if_no_metadata) = true;


### PR DESCRIPTION
## Summary

The per-transaction-per-tablet intra-transaction write ID (`intra_txn_write_id_`, consumed
once per strong intent in `TransactionalWriter`) is an unchecked `uint32`: at 2^32 it wraps
silently, restarting write IDs within the same commit hybrid time. That breaks the
intra-transaction write-ID ordering that commit-time intent application relies on (the
monotonicity check in `ApplyIntentsContext::Entry`) and can collide distinct provisional
records within one `(key, hybrid time)`.

This PR enforces an always-on exclusive limit, `kIntraTxnWriteIdLimit` (2^31), keeping every
transaction far below the wrap point and reserving `[2^31, 2^32)` for future write-ID
domains (see #33499 for the bound rationale). Three layers:

- **Pre-Raft** (`WriteQuery::DoCompleteExecute` -> `CheckIntraTxnWriteIdCap`): reject a
  transactional batch with a clean, non-retryable error (SQLSTATE 54000, mirroring PG's
  per-transaction command-counter limit in `xact.c`) when the transaction's counter plus the
  batch's strong-record count comes within `kIntraTxnWriteIdSoftMargin` (2^26) of the limit.
  The participant's counter only advances at Raft apply, so the margin absorbs in-flight
  batches; the check runs on the leader only, before any WAL or intent side effects, so no
  replica ever evaluates a doomed batch. The status is `QLError` rather than `IllegalState`
  because the client-side `TabletInvoker` retries `IllegalState` against other replicas as a
  leadership failure.
- **Apply-time** (`TransactionalWriter::operator()`): fail-stop `SCHECK` against crossing the
  limit -- unreachable for legitimate flows given the margin; guards corrupt or incompatible
  replicated data.
- **Commit-apply** (`ApplyIntentsContext::Entry`): fail-stop check that committed intents
  carry write IDs below the limit, alongside the existing monotonicity check.

New plumbing: `TransactionParticipant::NextIntraTxnWriteIdHint` (read-only view of the
counter for the pre-Raft check) and `TEST_initial_intra_txn_write_id` (seeds the counter for
tests -- writing ~2^31 real intents is infeasible).

Stacked on #33403, #33404, and #33484, based on
`feature-stack/Shopify/uniq-idx-1-backfill-job-mode` per the feature-stack workflow, so the
diff is exactly this PR's own commit. A failing pr-title check on stacked PRs is a known gap
in that check; the stack merges bottom-up and retargets as parents merge.

## Upgrade/Rollback safety

No proto, wire, or persisted-format changes. New nodes never emit write IDs at or above
2^31, so rollback is safe. The pre-Raft check is leader-local, so mixed-version clusters are
trivially safe: old followers never see a batch the new leader rejected. The only forward
risk is replaying pre-existing intents that legally held IDs in `[2^31, 2^32)` -- that
requires on the order of 100+ GB of intents from one transaction on one tablet, and such a
transaction was already doomed at the 2^32 silent wrap; the commit-apply check fail-stops
loudly instead of applying silently-corrupt ordering.

## Test plan

macOS arm64, release:

- [x] New: `NonTransactionalBatchWriterTest.ForegroundIntraTxnWriteIdCapRejectsAtLimit` --
      the exact boundary: last legal write ID accepted, next one rejected with a clean
      Status.
- [x] New: `PgTxnTest.IntraTxnWriteIdCapRejectsOversizedTransaction` -- seeded counter; the
      crossing statement fails with a clean SQLSTATE 54000 error (no crash, no client retry
      loop), ROLLBACK works, subsequent transactions unaffected.
- [x] Regressions: `PgTxnTest.MultiInsertUpdate`,
      `NonTransactionalBatchWriterTest.SimpleTransaction`.

AlmaLinux (x86_64, clang21), rebased onto master `c7253d204d`:

At this PR's own commit (`88bffba1de`), debug -- all green:

- [x] `non_transactional_batch_writer-test` (full), and
      `PgTxnTest.IntraTxnWriteIdCapRejectsOversizedTransaction`.

Integrated at the stack tip (`334a1deb3d`), all green. Exact suites per build type:

- [x] TSAN (6): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `non_transactional_batch_writer-test`,
      `keyed_fingerprint-test`, `raft_consensus-itest`.
- [x] ASAN (15): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `keyed_fingerprint-test`,
      `non_transactional_batch_writer-test`, `clone-tablet-itest`,
      `remote_bootstrap-itest`, `tablet_bootstrap-test`, `auto_flags-itest`,
      `docdb-test`, `compaction_file_filter-test`,
      `xcluster_external_apply_bootstrap-test`, `pg_txn-test`, `pg_ash-test`,
      full `pg_index_backfill-test`.
- [x] Debug (19): the ASAN list minus `compaction_file_filter-test`, plus
      `master_failover-itest`, `snapshot-test`, `tablet_snapshots-test`,
      `compaction-test`, `tablet-split-itest`.
- [x] Release (5): `keyed_fingerprint-test`, `auto_flags-itest`, full
      `pg_index_backfill-test`, java `TestIndexBackfill`, java
      `TestPgRegressBackfillIndex`.
- [x] All three full `pg_index_backfill-test` runs (ASAN, debug, release) pass with no
      test failures.

Two known-upstream issues surfaced by the tip matrix, both shown not attributable to this
stack:

- TSAN `tablet-split-itest` reports 3 data races in `yb::client::YBTable::~YBTable()`
  (table.cc:81) racing its partition-refresh callback, inside the upstream test
  `AutomaticTabletSplitITest.SizeRatio` (93 cases ran, 0 gtest failures). This stack has zero
  diff under `src/yb/client/`, and that test passes 3/3 isolated at the new master base.
- `wait_states-itest` hangs 9 cases at the 601s timeout (`AshCql`, the `kYCQL_*` group,
  `kBackfillIndex_*`, `kConsensusMeta_Flush`, `kCreatingNewTablet`,
  `kSaveRaftGroupMetadataToDisk`). Reproduced identically on plain master `c7253d204d`
  carrying none of this stack's code: 53 ran, the same 9 failed, same ~600.5s expiries.

Disposition change since the previous revision: the
`PgIndexBackfillBackendsManager.NoAbortTxn/1` flake cited earlier was fixed upstream. It
passes 3/3 at the new base and in all three full `pg_index_backfill-test` runs here, so it is
no longer carried as a known flake.

