### PR TITLE
[DEVOPS-3901] build: Add selector keywords to jenkins_jobs.yml

### DIFF
--- a/jenkins_jobs.yml
+++ b/jenkins_jobs.yml
@@ -5,11 +5,6 @@
 #   change - run by default for DB changes
 #   full - run for full official build
 #
-# To request optional build/test on PR, include Jenkins: directives
-# in the description.
-# Examples:
-#   Jenkins: build type: tsan
-#   Jenkins: jobs: full
 
 jobs:
   - os: alma9

--- a/jenkins_jobs.yml
+++ b/jenkins_jobs.yml
@@ -50,6 +50,7 @@ jobs:
     build_opts: YB_LINKING_TYPE=full-lto YB_PGO_BOLT=1
     release_artifact: true
     when:
+     - change
      - full
 
   - os: mac14

--- a/jenkins_jobs.yml
+++ b/jenkins_jobs.yml
@@ -3,11 +3,13 @@
 #
 # when selectors:
 #   change - run by default for DB changes
-#   sanitize - optional addition for DB changes
 #   full - run for full official build
 #
-# To request optional build/test on PR, include "Jenkins: jobs: <selector-keyword>"
+# To request optional build/test on PR, include Jenkins: directives
 # in the description.
+# Examples:
+#   Jenkins: build type: tsan
+#   Jenkins: jobs: full
 
 jobs:
   - os: alma9
@@ -15,7 +17,7 @@ jobs:
     build_type: asan
     release_artifact: false
     when:
-     - sanitize
+     - change
      - full
 
   - os: alma8
@@ -23,7 +25,6 @@ jobs:
     build_type: tsan
     release_artifact: false
     when:
-     - sanitize
      - full
 
   - os: alma8
@@ -41,6 +42,7 @@ jobs:
     build_opts: YB_LINKING_TYPE=full-lto YB_PGO_BOLT=1
     release_artifact: true
     when:
+     - change
      - full
 
   - os: alma8
@@ -50,7 +52,6 @@ jobs:
     build_opts: YB_LINKING_TYPE=full-lto YB_PGO_BOLT=1
     release_artifact: true
     when:
-     - change
      - full
 
   - os: mac14

--- a/jenkins_jobs.yml
+++ b/jenkins_jobs.yml
@@ -1,27 +1,47 @@
 # This file determines the jobs that we run in this branch on Jenkins.
 # Default architecture is x86_64
+#
+# when selectors:
+#   change - run by default for DB changes
+#   sanitize - optional addition for DB changes
+#   full - run for full official build
+#
+# To request optional build/test on PR, include "Jenkins: jobs: <selector-keyword>"
+# in the description.
+
 jobs:
   - os: alma9
     compiler: clang21
     build_type: asan
     release_artifact: false
+    when:
+     - sanitize
+     - full
 
   - os: alma8
     compiler: clang21
     build_type: tsan
     release_artifact: false
+    when:
+     - sanitize
+     - full
 
   - os: alma8
     compiler: gcc15
     build_type: fastdebug
     test_opts: YB_TEST_YB_CONTROLLER=0 YB_ENABLE_YSQL_CONN_MGR_IN_JAVA_TESTS=true
     release_artifact: false
+    when:
+     - change
+     - full
 
   - os: alma8
     compiler: clang21
     build_type: release
     build_opts: YB_LINKING_TYPE=full-lto YB_PGO_BOLT=1
     release_artifact: true
+    when:
+     - full
 
   - os: alma8
     compiler: clang21
@@ -29,6 +49,8 @@ jobs:
     architecture: aarch64
     build_opts: YB_LINKING_TYPE=full-lto YB_PGO_BOLT=1
     release_artifact: true
+    when:
+     - full
 
   - os: mac14
     compiler: clang21
@@ -36,6 +58,8 @@ jobs:
     architecture: arm64
     test_opts: YB_TEST_YB_CONTROLLER=0
     release_artifact: true
+    when:
+     - full
 
   - os: mac14
     compiler: clang21
@@ -43,9 +67,13 @@ jobs:
     architecture: x86_64
     test_opts: YB_COMPILE_ONLY=1
     release_artifact: true
+    when:
+     - full
 
   - os: ubuntu22.04
     compiler: clang21
     build_type: debug
     release_artifact: false
     test_opts: YB_COMPILE_ONLY=1
+    when:
+     - full


### PR DESCRIPTION
Build list can by differentiated for full official builds and change testing.

Future use may include some build/test combinations that only apply to changes and not full builds, such as smoke/subset testing by combining when keywords with test_opts.

For comment-only change:
Jenkins: skip