### PR TITLE
[#33567] DocDB: Escape non-ASCII bytes in Slice::ToDebugString regardless of locale

### DIFF
--- a/src/yb/util/slice-test.cc
+++ b/src/yb/util/slice-test.cc
@@ -224,7 +224,12 @@ TEST(SliceTest, OrderConsistency) {
   LOG(INFO) << "made_checks: " << made_checks;
 }
 
-TEST(SliceTest, DebugStringLength) {
+TEST(SliceTest, DebugStringLengthAndLocale) {
+  // On macOS in a UTF-8 locale isgraph() accepts bytes >= 0xA1, so ToDebugString leaked them
+  // into logs unescaped. Run under a UTF-8 locale to verify rendering is locale-independent.
+  const std::string saved_locale = setlocale(LC_ALL, nullptr);
+  setlocale(LC_ALL, "en_US.UTF-8");
+
   constexpr auto kNumIters = 1000;
   constexpr auto kSize = 1024;
   for (auto i = 0; i < kNumIters; ++i) {
@@ -236,10 +241,24 @@ TEST(SliceTest, DebugStringLength) {
     ASSERT_LE(debug_str.size(), max_len * 2 + 40)
         << " max_len: " << max_len << " debug_str: " << debug_str;
 
+    // Mostly-graph data stays under the hex-rendering threshold, so non-graph bytes are
+    // escaped individually.
+    std::string mixed(kSize, 'a');
+    for (auto j = 0; j < kSize / 20; ++j) {
+      mixed[RandomUniformInt(0, kSize - 1)] = static_cast<char>(RandomUniformInt(0, 255));
+    }
+    for (const auto& str : {debug_str, Slice(mixed).ToDebugString(0)}) {
+      for (const char c : str) {
+        ASSERT_TRUE(c >= ' ' && c < 0x7f) << "garbage in: " << str;
+      }
+    }
+
     if (max_len < 100) {
       YB_LOG_EVERY_N(INFO, 10) << debug_str;
     }
   }
+
+  setlocale(LC_ALL, saved_locale.c_str());
 }
 
 } // namespace yb

--- a/src/yb/util/slice.cc
+++ b/src/yb/util/slice.cc
@@ -83,7 +83,9 @@ std::string Slice::ToDebugString(size_t max_len) const {
 
   size_t num_not_graph = 0;
   for (size_t i = 0; i < bytes_to_print; i++) {
-    if (!isgraph(begin_[i])) {
+    // C locale explicitly: in UTF-8 locales macOS's isgraph() accepts bytes >= 0xA1,
+    // letting raw binary through into logs.
+    if (!std::isgraph(static_cast<char>(begin_[i]), std::locale::classic())) {
       ++num_not_graph;
     }
   }
@@ -106,7 +108,7 @@ std::string Slice::ToDebugString(size_t max_len) const {
   } else {
     for (size_t i = 0; i < bytes_to_print; i++) {
       auto ch = begin_[i];
-      if (!isgraph(ch)) {
+      if (!std::isgraph(static_cast<char>(ch), std::locale::classic())) {
         if (ch == '\r') {
           ret += "\\r";
         } else if (ch == '\n') {


### PR DESCRIPTION
## Summary

`isgraph()` is locale-dependent: on macOS in a UTF-8 locale it accepts bytes >= 0xA1, so binary fields rendered via `Slice::ToDebugString` (e.g. transaction ids in lightweight-protobuf debug output) went into logs as raw unescaped bytes, and the non-graph count often stayed under the `--non_graph_characters_percentage_to_use_hexadecimal_rendering` threshold. glibc rejects these bytes, so Linux was unaffected.

Evaluate `isgraph()` in the classic C locale at both call sites so rendering is locale-independent; non-ASCII bytes are always escaped. Linux output is unchanged.

The existing `SliceTest.DebugStringLength` is extended (and renamed to `DebugStringLengthAndLocale`) to run under a UTF-8 locale and assert the rendered output contains only printable ASCII — tests run in the default C locale, so without pinning the locale the regression check would pass against the unfixed code.

Fixes #33567

## Test plan

- [x] `SliceTest.DebugStringLengthAndLocale` fails against the unfixed code on macOS (raw bytes in output) and passes with the fix, on both macOS (arm64) and Linux (x86_64).
- [x] Verified `RemoteBootstrapITest` logs on macOS contain no raw binary after the fix (`LC_ALL=C grep -rl '[^[:print:][:space:]]'` finds nothing); Linux log output unchanged.
