### PR TITLE
[#33569] DocDB: Deflake LogCacheTest.ShouldNotEvictUnsyncedOpFromCache

### DIFF
--- a/src/yb/consensus/log_cache-test.cc
+++ b/src/yb/consensus/log_cache-test.cc
@@ -51,6 +51,7 @@
 
 #include "yb/server/hybrid_clock.h"
 
+#include "yb/util/logging_test_util.h"
 #include "yb/util/mem_tracker.h"
 #include "yb/util/metrics.h"
 #include "yb/util/monotime.h"
@@ -233,18 +234,29 @@ TEST_F(LogCacheTest, ShouldNotEvictUnsyncedOpFromCache) {
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_set_pause_before_wal_sync) = true;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_before_wal_sync) = true;
 
+  // Clear the flags on any exit, or a paused Appender hangs teardown.
+  auto se = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_set_pause_before_wal_sync) = false;
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_before_wal_sync) = false;
+  });
+
+  constexpr auto kPauseMessage = "Pausing due to flag TEST_pause_before_wal_sync";
+  const auto kPauseWaitTimeout = MonoDelta::FromSeconds(60 * kTimeMultiplier);
+
+  StringWaiterLogSink first_pause(kPauseMessage);
   // Append (1.2).
   ASSERT_OK(AppendReplicateMessageToCache(/* term = */ 1, /* index = */ 2));
+  // Wait for the pause before appending (2.1), so (2.1) doesn't join (1.2)'s sync batch.
+  ASSERT_OK(first_pause.WaitFor(kPauseWaitTimeout));
+
   // Append (2.1) and (1.2) should be erased from log cache.
   ASSERT_OK(AppendReplicateMessageToCache(/* term = */ 2, /* index = */ 1));
   ASSERT_EQ(cache_->num_cached_ops(), 1);
 
-  // Wait several seconds for actaully pausing at Log::Sync().
-  SleepFor(MonoDelta::FromSeconds(3 * kTimeMultiplier));
-
-  // Resume Log::Sync and set FLAGS_TEST_pause_before_wal_sync to true again.
+  // Resume Log::Sync and wait for the re-armed pause: (1.2) synced, (2.1) written but unsynced.
+  StringWaiterLogSink second_pause(kPauseMessage);
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_before_wal_sync) = false;
-  SleepFor(MonoDelta::FromSeconds(2 * kTimeMultiplier));
+  ASSERT_OK(second_pause.WaitFor(kPauseWaitTimeout));
 
   // Shouldn't evict (2.1).
   cache_->EvictThroughOp(1);
@@ -257,16 +269,14 @@ TEST_F(LogCacheTest, ShouldNotEvictUnsyncedOpFromCache) {
 
   ASSERT_OK(AppendReplicateMessageToCache(/* term = */ 3, /* index = */ 1));
   ASSERT_EQ(cache_->num_cached_ops(), 1);
+
+  StringWaiterLogSink third_pause(kPauseMessage);
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_before_wal_sync) = false;
-  SleepFor(MonoDelta::FromSeconds(2 * kTimeMultiplier));
+  ASSERT_OK(third_pause.WaitFor(kPauseWaitTimeout));
 
   // Shouldn't evict (3.1).
   cache_->EvictThroughOp(1);
   ASSERT_EQ(cache_->num_cached_ops(), 1);
-
-  // Let Appender continue doing Log::Sync and normally exit.
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_set_pause_before_wal_sync) = false;
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_before_wal_sync) = false;
 }
 
 // Ensure that the cache always yields at least one message,


### PR DESCRIPTION
## Summary

`ShouldNotEvictUnsyncedOpFromCache` waited for the Appender to pause at `Log::Sync()` with fixed sleeps. On a loaded machine the sleep elapses before the Appender reaches the pause point, the next append joins the previous append's sync batch, the op is treated as synced and evicted, and the test fails — then hangs to the 600s timeout because the pause flags are only cleared at the end of the test body.

Replace the sleeps with `StringWaiterLogSink` waits on the "Pausing due to flag TEST_pause_before_wal_sync" log message, and clear the pause flags via `ScopeExit` so a failed assertion can't hang teardown.

Fixes #33569

## Test plan

- [x] Without the fix: `./yb_build.sh release --cxx-test log_cache-test --gtest_filter LogCacheTest.ShouldNotEvictUnsyncedOpFromCache -n 200 --tp 24` on Linux (x86_64, release): 33/200 iterations fail and hang to the 600s timeout.
- [x] With the fix, same command: 200/200 pass, and each iteration finishes in seconds instead of sleeping through fixed delays.
