### PR TITLE
[#33574] DocDB: Deflake RemoteBootstrapITest.TestRBSWithLazySuperblockFlush

### DIFF
--- a/src/yb/integration-tests/remote_bootstrap-itest.cc
+++ b/src/yb/integration-tests/remote_bootstrap-itest.cc
@@ -2301,7 +2301,9 @@ void RemoteBootstrapITest::RBSWithLazySuperblockFlush(int num_tables) {
         }
         return leader.get() == ts_idx_to_bootstrap;
       },
-      timeout, "Waiting for ts_idx_to_bootstrap to become leader"));
+      // Leader transfer away from a blacklisted tserver can exceed 10s on a loaded host.
+      MonoDelta::FromSeconds(kTimeMultiplier * 60),
+      "Waiting for ts_idx_to_bootstrap to become leader"));
 
   // Check persistence of previously inserted data.
   auto new_conn = ASSERT_RESULT(ConnectToDB(database));


### PR DESCRIPTION
## Summary

`TestRBSWithLazySuperblockFlush` waits for leadership to move to the tserver being remote-bootstrapped using the shared 10s `timeout`. On a loaded machine the leader transfer away from the blacklisted tserver can take longer, failing the test with "Waiting for ts_idx_to_bootstrap to become leader didn't complete within 10001ms". Raise that one wait to 60s × kTimeMultiplier.

Fixes #33574

## Test plan

- [x] Without the fix: `./yb_build.sh release --cxx-test remote_bootstrap-itest --gtest_filter RemoteBootstrapITest.TestRBSWithLazySuperblockFlush -n 50 --tp 12` on Linux (x86_64, release): 1/50 iterations fail on the leader-transfer wait.
- [x] With the fix, same command at `--tp 24`: 50/50 pass.
