### PR TITLE
[#33577] YSQL: Deflake PgAnalyzeReadBufferLimitTest.AnalyzeWithBigResponse

### DIFF
--- a/src/yb/yql/pgwrapper/pg_auto_analyze-test.cc
+++ b/src/yb/yql/pgwrapper/pg_auto_analyze-test.cc
@@ -2080,6 +2080,8 @@ TEST_F(PgAnalyzeReadBufferLimitTest, AnalyzeWithBigResponse) {
       .port = ts1->ysql_port(),
     }).Connect());
     ASSERT_OK(conn1.Execute("CREATE TABLE test (k INT PRIMARY KEY, v TEXT)"));
+    // Keep setup INSERT batches well under the 4MB read buffer limit this test sets.
+    ASSERT_OK(conn1.Execute("SET ysql_session_max_batch_size = 512"));
     ASSERT_OK(conn1.Execute("INSERT INTO test SELECT s, repeat('abcdefg', 100) || '-' || s::TEXT "
                             "FROM generate_series(1, 10000) AS s"));
     ASSERT_OK(conn1.Execute("ANALYZE test"));


### PR DESCRIPTION
## Summary

The test sets `--read_buffer_memory_limit=4000000` to verify ANALYZE respects fetch limits, but the setup INSERT batches rows at the default `ysql_session_max_batch_size` (3072), producing ~2.4MB write RPCs. When the read buffer is partly consumed, the tserver drops the call ("Unable to allocate read buffer because of limit ... Call will be ignored"), the INSERT never completes, and the test hangs to the 600s timeout. Cap the setup INSERT's batch size at 512 rows so its RPCs always fit.

Fixes #33577

## Test plan

- [x] Without the fix: `./yb_build.sh release --cxx-test pg_auto_analyze-test --gtest_filter PgAnalyzeReadBufferLimitTest.AnalyzeWithBigResponse -n 50 --tp 12` on Linux (x86_64, release): 1/50 iterations hang to the 600s timeout on the dropped-RPC INSERT.
- [x] With the fix, `-n 100 --tp 24`: 100/100 pass.
