### PR TITLE
[#33444] DocDB: Add persisted index-backfill ordering-generation record and tablet fences

### DIFF
--- a/src/yb/integration-tests/fixed_hybrid_time_write_id-itest.cc
+++ b/src/yb/integration-tests/fixed_hybrid_time_write_id-itest.cc
@@ -31,6 +31,7 @@
 #include "yb/dockv/doc_key.h"
 #include "yb/dockv/key_bytes.h"
 #include "yb/dockv/key_entry_value.h"
+#include "yb/dockv/partition.h"
 #include "yb/dockv/primitive_value.h"
 
 #include "yb/gutil/casts.h"
@@ -41,10 +42,12 @@
 #include "yb/rpc/rpc_controller.h"
 
 #include "yb/tablet/tablet.h"
+#include "yb/tablet/tablet_metadata.h"
 #include "yb/tablet/tablet_peer.h"
 
 #include "yb/tserver/mini_tablet_server.h"
 #include "yb/tserver/tablet_server.h"
+#include "yb/tserver/ts_tablet_manager.h"
 #include "yb/tserver/tserver.messages.h"
 #include "yb/tserver/tserver.pb.h"
 #include "yb/tserver/tserver_service.proxy.h"
@@ -60,6 +63,7 @@
 
 using namespace std::chrono_literals;
 
+DECLARE_bool(TEST_bypass_index_backfill_ordering_generation_split_fence);
 DECLARE_bool(enable_load_balancing);
 
 namespace yb {
@@ -235,6 +239,38 @@ class FixedHybridTimeWriteIdITest : public YBMiniClusterTestBase<MiniCluster> {
     }
   }
 
+  // Sends one marked write batch whose keys are spread across the hash space, so the tablet has
+  // valid split points (unlike the hash-0 keys used for dump-literal comparisons).
+  Result<OpId> SendMarkedWriteSpreadHashes(
+      const TabletId& tablet_id, HybridTime write_ht, int num_keys) {
+    std::vector<MarkedWriteEntry> entries;
+    entries.reserve(num_keys);
+    for (int i = 0; i != num_keys; ++i) {
+      entries.emplace_back(
+          narrow_cast<uint16_t>((i * 65536) / num_keys), Format("key-$0", i),
+          Format("value-$0", i));
+    }
+    return SendMarkedWriteEntries(tablet_id, write_ht, entries);
+  }
+
+  // Sets (or clears) the ordering generation on every replica of the tablet.
+  Status SetOrderingGenerationOnAllReplicas(
+      const TabletId& tablet_id, const tablet::IndexBackfillOrderingGeneration& generation) {
+    auto peers = VERIFY_RESULT(ListTabletPeers(cluster_.get(), tablet_id));
+    SCHECK_EQ(peers.size(), 3U, IllegalState, "Expected all three replicas to be running");
+    for (const auto& peer : peers) {
+      RETURN_NOT_OK(peer->tablet_metadata()->set_index_backfill_ordering_generation(generation));
+    }
+    return Status::OK();
+  }
+
+  static tablet::IndexBackfillOrderingGeneration MakeActiveOrderingGeneration() {
+    tablet::IndexBackfillOrderingGeneration generation;
+    generation.active = true;
+    generation.base_op_index = 0;
+    return generation;
+  }
+
   // Fixed (arbitrary, past) hybrid time shared by every marked write in the test.
   static constexpr HybridTime kWriteHT = 1000_usec_ht;
 
@@ -299,6 +335,203 @@ TEST_F(FixedHybridTimeWriteIdITest, LeaderChangePreservesDistinctWriteIds) {
       ExpectedEntry("dup", w1_op_id.index, "first"),
       ExpectedEntry("stable", w1_op_id.index, "before")};
   ASSERT_NO_FATALS(AssertAllReplicasDumpTo(tablet_id, expected_after_w2));
+}
+
+TEST_F(FixedHybridTimeWriteIdITest, MasterSplitRefusedWhileOrderingGenerationActive) {
+  auto leaders = ASSERT_RESULT(WaitForTableActiveTabletLeadersPeers(
+      cluster_.get(), table_.table()->id(), /* num_active_leaders= */ 1));
+  const auto tablet_id = leaders.front()->tablet_id();
+  ASSERT_OK(WaitUntilTabletHasLeader(
+      cluster_.get(), tablet_id, CoarseMonoClock::Now() + 10s * kTimeMultiplier,
+      RequireLeaderIsReady::kTrue));
+
+  // Give the tablet hash-spread data and SSTs so it is a viable split candidate.
+  const auto op_id = ASSERT_RESULT(
+      SendMarkedWriteSpreadHashes(tablet_id, kWriteHT, /* num_keys= */ 256));
+  ASSERT_OK(WaitAllReplicasApplied(tablet_id, op_id));
+  ASSERT_OK(cluster_->FlushTablets());
+  ASSERT_OK(WaitForAnySstFiles(cluster_.get(), tablet_id));
+
+  const auto table_id = table_.table()->id();
+  ASSERT_EQ(ListActiveTabletIdsForTable(cluster_.get(), table_id).size(), 1);
+
+  // With the generation active on every replica, the master accepts the split request but the
+  // tablet-side fence rejects the split operation before it is appended to Raft.
+  ASSERT_OK(SetOrderingGenerationOnAllReplicas(tablet_id, MakeActiveOrderingGeneration()));
+  ASSERT_OK(InvokeSplitTabletRpc(
+      cluster_.get(), tablet_id, MonoDelta::FromSeconds(30) * kTimeMultiplier));
+  SleepFor(MonoDelta::FromSeconds(3) * kTimeMultiplier);
+  ASSERT_EQ(ListActiveTabletIdsForTable(cluster_.get(), table_id).size(), 1)
+      << "The split must not proceed while the ordering generation is active";
+
+  // Releasing the generation lifts the fence: the split -- retried by the master or re-invoked
+  // here -- completes and produces two active tablets. This doubles as the positive control
+  // proving the tablet was genuinely splittable and only the fence blocked it.
+  ASSERT_OK(SetOrderingGenerationOnAllReplicas(
+      tablet_id, tablet::IndexBackfillOrderingGeneration()));
+  ASSERT_OK(LoggedWaitFor(
+      [&]() -> Result<bool> {
+        if (ListActiveTabletIdsForTable(cluster_.get(), table_id).size() >= 2) {
+          return true;
+        }
+        WARN_NOT_OK(
+            InvokeSplitTabletRpc(
+                cluster_.get(), tablet_id, MonoDelta::FromSeconds(10) * kTimeMultiplier),
+            "Split retry after ordering generation release");
+        return false;
+      },
+      MonoDelta::FromSeconds(120) * kTimeMultiplier,
+      "tablet to split after the ordering generation was released"));
+}
+
+TEST_F(FixedHybridTimeWriteIdITest, OrderingGenerationSurvivesRemoteBootstrap) {
+  auto leaders = ASSERT_RESULT(WaitForTableActiveTabletLeadersPeers(
+      cluster_.get(), table_.table()->id(), /* num_active_leaders= */ 1));
+  const auto tablet_id = leaders.front()->tablet_id();
+  const auto leader_uuid = leaders.front()->permanent_uuid();
+  ASSERT_OK(WaitUntilTabletHasLeader(
+      cluster_.get(), tablet_id, CoarseMonoClock::Now() + 10s * kTimeMultiplier,
+      RequireLeaderIsReady::kTrue));
+
+  const auto op_id = ASSERT_RESULT(SendMarkedWrite(tablet_id, kWriteHT, {{"row", "value"}}));
+  ASSERT_OK(WaitAllReplicasApplied(tablet_id, op_id));
+  ASSERT_OK(SetOrderingGenerationOnAllReplicas(tablet_id, MakeActiveOrderingGeneration()));
+
+  // Tombstone one follower; it stays in the Raft config, so the leader remote-bootstraps it
+  // back. The recovered replica's superblock comes from the leader and must carry the
+  // generation -- a bootstrapped replica that lost it would stop enforcing the write-ID base
+  // and the split fence.
+  auto peers = ASSERT_RESULT(ListTabletPeers(cluster_.get(), tablet_id));
+  ASSERT_EQ(peers.size(), 3U);
+  tserver::MiniTabletServer* follower_ts = nullptr;
+  std::string follower_uuid;
+  for (const auto& peer : peers) {
+    if (peer->permanent_uuid() != leader_uuid) {
+      follower_uuid = peer->permanent_uuid();
+      break;
+    }
+  }
+  for (size_t i = 0; i != cluster_->num_tablet_servers(); ++i) {
+    if (cluster_->mini_tablet_server(i)->server()->permanent_uuid() == follower_uuid) {
+      follower_ts = cluster_->mini_tablet_server(i);
+      break;
+    }
+  }
+  ASSERT_NE(follower_ts, nullptr);
+
+  std::optional<tserver::TabletServerErrorPB::Code> error_code;
+  ASSERT_OK(follower_ts->server()->tablet_manager()->DeleteTablet(
+      tablet_id, tablet::TABLET_DATA_TOMBSTONED,
+      tablet::ShouldAbortActiveTransactions::kTrue,
+      /* cas_config_opid_index_less_or_equal= */ std::nullopt,
+      /* hide_only= */ false, /* keep_data= */ false, &error_code));
+
+  ASSERT_OK(LoggedWaitFor(
+      [&]() -> Result<bool> {
+        auto peer_result = follower_ts->server()->tablet_manager()->GetTablet(tablet_id);
+        if (!peer_result.ok()) {
+          return false;
+        }
+        const auto& peer = *peer_result;
+        if (peer->state() != tablet::RaftGroupStatePB::RUNNING) {
+          return false;
+        }
+        return peer->tablet_metadata()->index_backfill_ordering_generation().active;
+      },
+      MonoDelta::FromSeconds(60) * kTimeMultiplier,
+      "tombstoned follower to be remote-bootstrapped with the generation intact"));
+
+  const auto generation =
+      ASSERT_RESULT(follower_ts->server()->tablet_manager()->GetTablet(tablet_id))
+          ->tablet_metadata()
+          ->index_backfill_ordering_generation();
+  ASSERT_TRUE(generation.active);
+  ASSERT_EQ(0, generation.base_op_index);
+}
+
+// Forces the tablet-side split fence open and proves the storage-level property the fence is
+// *not* needed for -- per-key write-ID uniqueness. The fence exists for verification-scan
+// stability and lifecycle tracking, not for key correctness: split children inherit the parent's
+// marked entries and continue drawing write IDs from their own (monotonically continuing) Raft
+// indexes, so a marked rewrite of an inherited key lands as a second, distinct physical version.
+TEST_F(FixedHybridTimeWriteIdITest, SplitWithFenceBypassedPreservesPerKeyWriteIdUniqueness) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_bypass_index_backfill_ordering_generation_split_fence) =
+      true;
+
+  auto leaders = ASSERT_RESULT(WaitForTableActiveTabletLeadersPeers(
+      cluster_.get(), table_.table()->id(), /* num_active_leaders= */ 1));
+  const auto tablet_id = leaders.front()->tablet_id();
+  ASSERT_OK(WaitUntilTabletHasLeader(
+      cluster_.get(), tablet_id, CoarseMonoClock::Now() + 10s * kTimeMultiplier,
+      RequireLeaderIsReady::kTrue));
+
+  const auto op_id = ASSERT_RESULT(
+      SendMarkedWriteSpreadHashes(tablet_id, kWriteHT, /* num_keys= */ 256));
+  ASSERT_OK(WaitAllReplicasApplied(tablet_id, op_id));
+  ASSERT_OK(cluster_->FlushTablets());
+  ASSERT_OK(WaitForAnySstFiles(cluster_.get(), tablet_id));
+  ASSERT_OK(SetOrderingGenerationOnAllReplicas(tablet_id, MakeActiveOrderingGeneration()));
+
+  const auto table_id = table_.table()->id();
+  ASSERT_OK(InvokeSplitTabletRpc(
+      cluster_.get(), tablet_id, MonoDelta::FromSeconds(30) * kTimeMultiplier));
+  // The parent stays in the active list until it is deactivated after the children are running,
+  // so wait for the post-split steady state, not merely for the children to appear.
+  ASSERT_OK(LoggedWaitFor(
+      [&]() -> Result<bool> {
+        const auto active = ListActiveTabletIdsForTable(cluster_.get(), table_id);
+        return active.size() == 2 && active.count(tablet_id) == 0;
+      },
+      MonoDelta::FromSeconds(120) * kTimeMultiplier, "tablet to split with the fence bypassed"));
+
+  const auto child_ids = ListActiveTabletIdsForTable(cluster_.get(), table_id);
+  ASSERT_EQ(child_ids.size(), 2U);
+  for (const auto& child_id : child_ids) {
+    ASSERT_OK(WaitUntilTabletHasLeader(
+        cluster_.get(), child_id, CoarseMonoClock::Now() + 30s * kTimeMultiplier,
+        RequireLeaderIsReady::kTrue));
+    auto child_leader = ASSERT_RESULT(GetLeaderPeerForTablet(cluster_.get(), child_id));
+
+    // Children inherit the active generation with the rest of the superblock.
+    ASSERT_TRUE(child_leader->tablet_metadata()->index_backfill_ordering_generation().active);
+
+    // A marked rewrite of a key the child inherited from the parent, at the same fixed hybrid
+    // time. Its write ID derives from the child's own Raft index, distinct from the inherited
+    // version's parent-index-derived ID.
+    const auto& partition = *child_leader->tablet_metadata()->partition();
+    const uint16_t child_hash = partition.partition_key_start().empty()
+        ? 0
+        : dockv::PartitionSchema::DecodeMultiColumnHashValue(partition.partition_key_start());
+    const int inherited_key_number = child_hash == 0
+        ? 0
+        : (child_hash * 256 + 65535) / 65536;  // First spread key at or above the child's start.
+    const auto inherited_key = Format("key-$0", inherited_key_number);
+    const auto rewrite_hash = narrow_cast<uint16_t>((inherited_key_number * 65536) / 256);
+    const auto child_op_id = ASSERT_RESULT(SendMarkedWriteEntries(
+        child_id, kWriteHT, {{rewrite_hash, inherited_key, "rewritten"}}));
+
+    // Per-key uniqueness: every (key, hybrid time, write ID) coordinate in the child is unique,
+    // and the rewritten key holds two distinct physical versions.
+    auto child_tablet = ASSERT_RESULT(child_leader->shared_tablet());
+    std::vector<std::string> entries;
+    child_tablet->TEST_DocDBDumpToContainer(entries, docdb::IncludeIntents::kFalse);
+    std::unordered_set<std::string> coordinates;
+    size_t rewritten_key_versions = 0;
+    for (const auto& entry : entries) {
+      const auto arrow_pos = entry.find(") -> ");
+      ASSERT_NE(arrow_pos, std::string::npos) << entry;
+      const auto coordinate = entry.substr(0, arrow_pos + 1);
+      ASSERT_TRUE(coordinates.insert(coordinate).second)
+          << "Duplicate (key, HT, write ID) coordinate in child " << child_id << ": "
+          << coordinate;
+      if (coordinate.find(Format("\"$0\"", inherited_key)) != std::string::npos) {
+        ++rewritten_key_versions;
+      }
+    }
+    ASSERT_EQ(rewritten_key_versions, 2U)
+        << "Expected the inherited version and the post-split marked rewrite of "
+        << inherited_key << " in child " << child_id << " (child write " << child_op_id << ")";
+  }
 }
 
 }  // namespace yb

--- a/src/yb/tablet/metadata.proto
+++ b/src/yb/tablet/metadata.proto
@@ -231,6 +231,37 @@ message RaftGroupReplicaSuperBlockPB {
   // successful. The master is responsible for not sending multiple clone requests with different
   // sequence_numbers until the previous one is complete or aborted on all tablets.
   optional uint32 last_attempted_clone_seq_no = 38;
+
+  // Active fixed-hybrid-time write-ID ordering generation for unique-index backfill. While
+  // active on an index tablet: marked backfill writes must derive their write IDs from Raft
+  // operation indexes strictly above base_op_index, and tablet splitting and cloning are fenced
+  // so deferred uniqueness verification runs against a stable tablet set. Set by the master
+  // before the first marked backfill write and cleared when the backfill operation reaches a
+  // terminal state. Split children and clones inherit this with the rest of the superblock.
+  optional IndexBackfillOrderingGenerationPB index_backfill_ordering_generation = 39;
+}
+
+message IndexBackfillOrderingGenerationPB {
+  optional bool active = 1;
+
+  // The index table this generation covers (the tablet may host multiple tables when colocated;
+  // colocated indexes select the fully checked mode in v1, but the record names its owner so a
+  // misrouted activation is detectable rather than silently adopted).
+  optional bytes table_id = 2;
+
+  // Raft operation index of the activation ChangeMetadataOperation. Marked backfill writes must
+  // carry indexes strictly above this; see WriteOperation::ValidateLeaderOpId.
+  optional int64 base_op_index = 3;
+
+  // History before this hybrid time is not needed by deferred verification; retention
+  // enforcement holds reads at backfill_read_time.Decremented() while the generation is active.
+  optional fixed64 retention_barrier_ht = 4;
+
+  // Version of the write-ID-floor constant (kBackfillWriteIdFloor) the marked writes of this
+  // generation were stored with, so a future floor change cannot misinterpret older marked data.
+  // Numbering starts at 1 for the initial floor (kIntraTxnWriteIdLimit, 2^31); 0 is reserved as
+  // absent/unknown. Written by the master activation flow.
+  optional uint32 write_id_floor_version = 5;
 }
 
 message FilePB {

--- a/src/yb/tablet/operations/clone_operation.cc
+++ b/src/yb/tablet/operations/clone_operation.cc
@@ -22,6 +22,7 @@
 #include "yb/consensus/consensus_round.h"
 
 #include "yb/tablet/tablet.h"
+#include "yb/tablet/tablet_metadata.h"
 
 #include "yb/util/logging.h"
 #include "yb/util/status_format.h"
@@ -45,6 +46,22 @@ LWCloneTabletRequestPB* RequestTraits<LWCloneTabletRequestPB>::MutableRequest(
 
 Status CloneOperation::Prepare(IsLeaderSide is_leader_side) {
   VLOG_WITH_PREFIX(2) << "Prepare";
+  return Status::OK();
+}
+
+Status CloneOperation::ValidateLeaderOpId(const OpId& op_id) const {
+  // Cloning is rejected while an index-backfill write-ID ordering generation is active. The
+  // clone's data comes from hard-linked snapshot files containing generation-scoped marked
+  // write IDs, but its metadata is built fresh (RaftGroupMetadata::CreateNew, not a superblock
+  // copy), so the clone would carry marked versions with no generation record describing them
+  // and no backfill job tracking their lifecycle. Backfill is expected to be short-lived
+  // relative to clone scheduling, so callers retry after the generation is released.
+  const auto generation =
+      VERIFY_RESULT(tablet_safe())->metadata()->index_backfill_ordering_generation();
+  SCHECK(
+      !generation.active, IllegalState,
+      "Tablet cloning is fenced while an index-backfill write-ID ordering generation is "
+      "active");
   return Status::OK();
 }
 

--- a/src/yb/tablet/operations/clone_operation.h
+++ b/src/yb/tablet/operations/clone_operation.h
@@ -39,6 +39,7 @@ class CloneOperation : public OperationBase<OperationType::kClone, LWCloneTablet
 
  private:
   Status Prepare(IsLeaderSide is_leader_side) override;
+  Status ValidateLeaderOpId(const OpId& op_id) const override;
   Status DoReplicated(int64_t leader_term, Status* complete_status) override;
   Status DoAborted(const Status& status) override;
 

--- a/src/yb/tablet/operations/split_operation.cc
+++ b/src/yb/tablet/operations/split_operation.cc
@@ -23,10 +23,17 @@
 #include "yb/consensus/consensus_round.h"
 
 #include "yb/tablet/tablet.h"
+#include "yb/tablet/tablet_metadata.h"
 #include "yb/tablet/tablet_splitter.h"
 
+#include "yb/util/flags.h"
 #include "yb/util/logging.h"
 #include "yb/util/status_format.h"
+
+DEFINE_test_flag(bool, bypass_index_backfill_ordering_generation_split_fence, false,
+    "Skip the tablet-side rejection of splits while an index-backfill write-ID ordering "
+    "generation is active. Used to demonstrate that per-key uniqueness of marked write IDs "
+    "survives a split that the fence would normally prevent.");
 
 using namespace std::literals;
 
@@ -121,6 +128,24 @@ Status SplitOperation::CheckOperationAllowed(
 
 Status SplitOperation::Prepare(IsLeaderSide is_leader_side) {
   VLOG_WITH_PREFIX(2) << "Prepare";
+  return Status::OK();
+}
+
+Status SplitOperation::ValidateLeaderOpId(const OpId& op_id) const {
+  // Fence splits while a fixed-hybrid-time write-ID ordering generation is active: deferred
+  // uniqueness verification must run against a stable tablet set, and the generation's
+  // lifecycle (activation, release, retention) is tracked per tablet. Rejecting here, before
+  // the split op is appended to Raft, is the fail-closed layer under the master-side split
+  // fence.
+  if (PREDICT_FALSE(FLAGS_TEST_bypass_index_backfill_ordering_generation_split_fence)) {
+    return Status::OK();
+  }
+  const auto generation =
+      VERIFY_RESULT(tablet_safe())->metadata()->index_backfill_ordering_generation();
+  SCHECK(
+      !generation.active, IllegalState,
+      "Tablet splitting is fenced while an index-backfill write-ID ordering generation is "
+      "active");
   return Status::OK();
 }
 

--- a/src/yb/tablet/operations/split_operation.h
+++ b/src/yb/tablet/operations/split_operation.h
@@ -59,6 +59,7 @@ class SplitOperation
 
  private:
   Status Prepare(IsLeaderSide is_leader_side) override;
+  Status ValidateLeaderOpId(const OpId& op_id) const override;
   Status DoReplicated(int64_t leader_term, Status* complete_status) override;
   Status DoAborted(const Status& status) override;
   void AddedAsPending(const TabletPtr& tablet) override;

--- a/src/yb/tablet/operations/write_operation.cc
+++ b/src/yb/tablet/operations/write_operation.cc
@@ -39,6 +39,7 @@
 #include "yb/consensus/consensus.messages.h"
 
 #include "yb/tablet/tablet.h"
+#include "yb/tablet/tablet_metadata.h"
 
 #include "yb/util/debug-util.h"
 #include "yb/util/debug/trace_event.h"
@@ -95,6 +96,20 @@ Status WriteOperation::ValidateLeaderOpId(const OpId& op_id) const {
   SCHECK_LE(
       op_id.index, static_cast<int64_t>(FLAGS_TEST_fixed_hybrid_time_write_id_max), IllegalState,
       "TEST: Raft operation index exceeded the injected fixed-hybrid-time write ID ceiling");
+
+  // When an ordering generation is active, marked writes must carry Raft indexes strictly above
+  // the generation base: the base is the activation operation's own index, so an index at or
+  // below it cannot belong to this generation -- it would indicate misrouting or replay of a
+  // foreign sequence. (Rejecting marked writes when *no* generation is active arrives with the
+  // master activation flow; until then marked writes remain test-only.)
+  const auto generation =
+      VERIFY_RESULT(tablet_safe())->metadata()->index_backfill_ordering_generation();
+  if (generation.active) {
+    SCHECK_GT(
+        op_id.index, generation.base_op_index, IllegalState,
+        "Marked fixed-hybrid-time write carries a Raft index at or below the active ordering "
+        "generation base");
+  }
   return Status::OK();
 }
 

--- a/src/yb/tablet/tablet_metadata.cc
+++ b/src/yb/tablet/tablet_metadata.cc
@@ -1293,6 +1293,20 @@ Status RaftGroupMetadata::LoadFromSuperBlock(const RaftGroupReplicaSuperBlockPB&
     }
 
     cdc_sdk_safe_time_ = HybridTime::FromPB(superblock.cdc_sdk_safe_time());
+    if (superblock.has_index_backfill_ordering_generation()) {
+      const auto& generation_pb = superblock.index_backfill_ordering_generation();
+      index_backfill_ordering_generation_ = IndexBackfillOrderingGeneration {
+          .active = generation_pb.active(),
+          .table_id = generation_pb.table_id(),
+          .base_op_index = generation_pb.base_op_index(),
+          .retention_barrier_ht = HybridTime::FromPB(generation_pb.retention_barrier_ht()),
+          .write_id_floor_version = generation_pb.write_id_floor_version(),
+      };
+    } else {
+      // LoadFromSuperBlock also runs on existing metadata (e.g. remote-bootstrap superblock
+      // replacement), so an absent field must clear any previous generation.
+      index_backfill_ordering_generation_ = IndexBackfillOrderingGeneration();
+    }
     is_under_xcluster_replication_ = superblock.is_under_xcluster_replication();
     hidden_ = superblock.hidden();
     auto restoration_hybrid_time = HybridTime::FromPB(superblock.restoration_hybrid_time());
@@ -1474,6 +1488,16 @@ void RaftGroupMetadata::ToSuperBlockUnlocked(RaftGroupReplicaSuperBlockPB* super
   pb.set_cdc_min_replicated_index(cdc_min_replicated_index_);
   cdc_sdk_min_checkpoint_op_id_.ToPB(pb.mutable_cdc_sdk_min_checkpoint_op_id());
   pb.set_cdc_sdk_safe_time(cdc_sdk_safe_time_.ToUint64());
+  if (index_backfill_ordering_generation_.active) {
+    auto* generation_pb = pb.mutable_index_backfill_ordering_generation();
+    generation_pb->set_active(true);
+    generation_pb->set_table_id(index_backfill_ordering_generation_.table_id);
+    generation_pb->set_base_op_index(index_backfill_ordering_generation_.base_op_index);
+    generation_pb->set_retention_barrier_ht(
+        index_backfill_ordering_generation_.retention_barrier_ht.ToUint64());
+    generation_pb->set_write_id_floor_version(
+        index_backfill_ordering_generation_.write_id_floor_version);
+  }
   pb.set_is_under_xcluster_replication(is_under_xcluster_replication_);
   pb.set_hidden(hidden_);
   if (restoration_hybrid_time_) {
@@ -1854,6 +1878,27 @@ Status RaftGroupMetadata::set_cdc_sdk_safe_time(const HybridTime& cdc_sdk_safe_t
     cdc_sdk_safe_time_ = cdc_sdk_safe_time;
   }
   return Flush();
+}
+
+Status RaftGroupMetadata::set_index_backfill_ordering_generation(
+    const IndexBackfillOrderingGeneration& generation) {
+  // The durable form of an inactive generation is field absence (ToSuperBlockUnlocked persists
+  // only active generations), so an inactive record with populated fields would diverge from
+  // what a reload produces. Normalize so the in-memory and durable states stay identical; the
+  // contract for callers is "set an active generation or set {}".
+  DCHECK(generation.active || generation == IndexBackfillOrderingGeneration())
+      << "Inactive ordering generation with populated fields: " << generation;
+  {
+    std::lock_guard lock(data_mutex_);
+    index_backfill_ordering_generation_ =
+        generation.active ? generation : IndexBackfillOrderingGeneration();
+  }
+  return Flush();
+}
+
+IndexBackfillOrderingGeneration RaftGroupMetadata::index_backfill_ordering_generation() const {
+  std::lock_guard lock(data_mutex_);
+  return index_backfill_ordering_generation_;
 }
 
 Status RaftGroupMetadata::set_all_cdc_retention_barriers(

--- a/src/yb/tablet/tablet_metadata.h
+++ b/src/yb/tablet/tablet_metadata.h
@@ -326,6 +326,38 @@ struct RaftGroupMetadataData {
   std::vector<TableInfoPtr> colocated_tables_infos = {};
 };
 
+// Fixed-hybrid-time write-ID ordering generation for unique-index backfill. While active on an
+// index tablet, marked backfill writes must derive their write IDs from Raft operation indexes
+// strictly above base_op_index, and tablet splitting and cloning are fenced so deferred
+// uniqueness verification runs against a stable tablet set. Durable in the superblock
+// (IndexBackfillOrderingGenerationPB); split children inherit it.
+struct IndexBackfillOrderingGeneration {
+  bool active = false;
+  // The index table this generation covers.
+  TableId table_id;
+  // Raft operation index of the activation ChangeMetadataOperation; marked writes must carry
+  // indexes strictly above it.
+  int64_t base_op_index = 0;
+  // History at or above this hybrid time must be retained while the generation is active
+  // (backfill_read_time.Decremented()); enforcement lands with the verification read fence.
+  HybridTime retention_barrier_ht = HybridTime::kInvalid;
+  // Version of kBackfillWriteIdFloor the generation's marked writes were stored with.
+  uint32_t write_id_floor_version = 0;
+
+  friend bool operator==(
+      const IndexBackfillOrderingGeneration&, const IndexBackfillOrderingGeneration&) = default;
+
+  std::string ToString() const {
+    return YB_STRUCT_TO_STRING(active, table_id, base_op_index, retention_barrier_ht,
+                               write_id_floor_version);
+  }
+
+  friend std::ostream& operator<<(
+      std::ostream& out, const IndexBackfillOrderingGeneration& generation) {
+    return out << generation.ToString();
+  }
+};
+
 // At startup, the TSTabletManager will load a RaftGroupMetadata for each
 // super block found in the tablets/ directory, and then instantiate
 // Raft groups from this data.
@@ -477,6 +509,15 @@ class RaftGroupMetadata : public RefCountedThreadSafe<RaftGroupMetadata>,
   OpId cdc_sdk_min_checkpoint_op_id() const;
 
   HybridTime cdc_sdk_safe_time() const;
+
+  // Persists the fixed-hybrid-time write-ID ordering generation for unique-index backfill
+  // (durable in the superblock, inherited by split children). While active, marked
+  // backfill writes must carry Raft indexes strictly above base_op_index and tablet splitting
+  // and cloning are fenced.
+  Status set_index_backfill_ordering_generation(
+      const IndexBackfillOrderingGeneration& generation);
+
+  IndexBackfillOrderingGeneration index_backfill_ordering_generation() const;
 
   bool is_under_cdc_sdk_replication() const;
 
@@ -913,6 +954,8 @@ class RaftGroupMetadata : public RefCountedThreadSafe<RaftGroupMetadata>,
 
   // The minimum hybrid time based on which data is retained for before image
   HybridTime cdc_sdk_safe_time_ GUARDED_BY(data_mutex_);
+
+  IndexBackfillOrderingGeneration index_backfill_ordering_generation_ GUARDED_BY(data_mutex_);
 
   bool is_under_xcluster_replication_ GUARDED_BY(data_mutex_) = false;
 

--- a/src/yb/tablet/tablet_peer-test.cc
+++ b/src/yb/tablet/tablet_peer-test.cc
@@ -62,6 +62,7 @@
 #include "yb/server/clock.h"
 #include "yb/server/logical_clock.h"
 
+#include "yb/tablet/operations/clone_operation.h"
 #include "yb/tablet/operations/snapshot_operation.h"
 #include "yb/tablet/operations/split_operation.h"
 #include "yb/tablet/tablet-test-util.h"
@@ -711,6 +712,168 @@ TEST_F(TabletPeerTest, FixedHybridTimeWriteIdOverflowRejectedBeforeRaftAppend) {
   ASSERT_OK(write("reused"));
   ASSERT_EQ(last_committed_op_id.index + 1, consensus->GetLastCommittedOpId().index);
   ASSERT_EQ(consensus->GetLastCommittedOpId(), tablet_peer_->log()->GetLatestEntryOpId());
+}
+
+namespace {
+
+IndexBackfillOrderingGeneration MakeActiveOrderingGeneration(int64_t base_op_index) {
+  IndexBackfillOrderingGeneration generation;
+  generation.active = true;
+  generation.base_op_index = base_op_index;
+  return generation;
+}
+
+}  // namespace
+
+TEST_F(TabletPeerTest, FixedHybridTimeWriteRejectedAtOrBelowGenerationBase) {
+  ConsensusBootstrapInfo info;
+  // The base arithmetic below is relative to the committed index, so the leader-election no-op
+  // must be committed first or the next write's index is off by one.
+  auto consensus = ASSERT_RESULT(StartPeerAndWaitForLeaderNoOpCommit(info));
+  const auto kWriteHT = 6000_usec_ht;
+
+  auto write = [&](const std::string& value) {
+    WriteRequestPB request;
+    request.set_tablet_id(tablet()->tablet_id());
+    request.set_external_hybrid_time(kWriteHT.ToUint64());
+    auto* write_batch = request.mutable_write_batch();
+    write_batch->set_use_raft_index_for_write_id(true);
+    auto* write_pair = write_batch->add_write_pairs();
+    const dockv::DocKey doc_key(0, dockv::MakeKeyEntryValues("row"));
+    write_pair->set_key(doc_key.Encode().AsSlice().ToBuffer());
+    std::string encoded_value;
+    dockv::AppendEncodedValue(QLValue::Primitive(value), &encoded_value);
+    write_pair->set_value(encoded_value);
+    return ExecuteWriteAndReturnStatus(tablet_peer_.get(), request);
+  };
+
+  // A base at or above the next Raft index rejects the marked write before WAL append.
+  const auto committed_op_id = consensus->GetLastCommittedOpId();
+  ASSERT_OK(tablet()->metadata()->set_index_backfill_ordering_generation(
+      MakeActiveOrderingGeneration(committed_op_id.index + 1)));
+  const auto status = write("rejected");
+  ASSERT_TRUE(status.IsIllegalState()) << status;
+  ASSERT_STR_CONTAINS(status.message().ToBuffer(), "ordering generation base");
+  ASSERT_EQ(committed_op_id, consensus->GetLastCommittedOpId());
+
+  // A base at the last committed index admits the next write (index = base + 1).
+  ASSERT_OK(tablet()->metadata()->set_index_backfill_ordering_generation(
+      MakeActiveOrderingGeneration(committed_op_id.index)));
+  ASSERT_OK(write("accepted"));
+  ASSERT_EQ(committed_op_id.index + 1, consensus->GetLastCommittedOpId().index);
+
+  // A released generation does not constrain marked writes; rejecting marked writes with no
+  // active generation arrives with the master activation flow. (Inactive-with-populated-fields
+  // is not a representable state: the setter normalizes it to the default, matching the durable
+  // form of field absence.)
+  ASSERT_OK(tablet()->metadata()->set_index_backfill_ordering_generation(
+      IndexBackfillOrderingGeneration()));
+  ASSERT_OK(write("unconstrained"));
+}
+
+TEST_F(TabletPeerTest, IndexBackfillOrderingGenerationPersistsAcrossReload) {
+  ConsensusBootstrapInfo info;
+  ASSERT_OK(StartPeer(info));
+
+  const IndexBackfillOrderingGeneration generation = {
+      .active = true,
+      .table_id = "index-table-id",
+      .base_op_index = 42,
+      .retention_barrier_ht = 5000_usec_ht,
+      .write_id_floor_version = 1,
+  };
+  ASSERT_OK(tablet()->metadata()->set_index_backfill_ordering_generation(generation));
+  const auto tablet_id = tablet()->tablet_id();
+  auto* fs_manager = tablet()->metadata()->fs_manager();
+  ASSERT_OK(tablet_peer_->TEST_Shutdown(
+      ShouldAbortActiveTransactions::kFalse, DisableFlushOnShutdown::kTrue));
+
+  auto metadata = ASSERT_RESULT(RaftGroupMetadata::Load(fs_manager, tablet_id));
+  const auto loaded = metadata->index_backfill_ordering_generation();
+  ASSERT_TRUE(loaded.active);
+  ASSERT_EQ(generation.table_id, loaded.table_id);
+  ASSERT_EQ(generation.base_op_index, loaded.base_op_index);
+  ASSERT_EQ(generation.retention_barrier_ht, loaded.retention_barrier_ht);
+  ASSERT_EQ(generation.write_id_floor_version, loaded.write_id_floor_version);
+
+  // Releasing the generation persists as an absent superblock field.
+  ASSERT_OK(metadata->set_index_backfill_ordering_generation({}));
+  auto reloaded = ASSERT_RESULT(RaftGroupMetadata::Load(fs_manager, tablet_id));
+  ASSERT_FALSE(reloaded->index_backfill_ordering_generation().active);
+}
+
+TEST_F(TabletPeerTest, IndexBackfillOrderingGenerationClearedBySuperblockReplacement) {
+  ConsensusBootstrapInfo info;
+  ASSERT_OK(StartPeer(info));
+
+  // Remote bootstrap replaces the local superblock with the leader's. A source superblock
+  // without a generation must clear any stale local one, or a released generation would
+  // resurrect on the bootstrapped replica and fence its splits forever.
+  RaftGroupReplicaSuperBlockPB superblock_without_generation;
+  tablet()->metadata()->ToSuperBlock(&superblock_without_generation);
+  ASSERT_FALSE(superblock_without_generation.has_index_backfill_ordering_generation());
+
+  ASSERT_OK(tablet()->metadata()->set_index_backfill_ordering_generation(
+      MakeActiveOrderingGeneration(/* base_op_index= */ 7)));
+  ASSERT_TRUE(tablet()->metadata()->index_backfill_ordering_generation().active);
+
+  ASSERT_OK(tablet()->metadata()->ReplaceSuperBlock(superblock_without_generation));
+  ASSERT_FALSE(tablet()->metadata()->index_backfill_ordering_generation().active);
+}
+
+TEST_F(TabletPeerTest, SplitRejectedWhileOrderingGenerationActive) {
+  ConsensusBootstrapInfo info;
+  // Wait out the leader-election no-op so the committed/logged OpId comparison below cannot race
+  // with its commit.
+  auto consensus = ASSERT_RESULT(StartPeerAndWaitForLeaderNoOpCommit(info));
+
+  ASSERT_OK(tablet()->metadata()->set_index_backfill_ordering_generation(
+      MakeActiveOrderingGeneration(/* base_op_index= */ 0)));
+  const auto committed_before = consensus->GetLastCommittedOpId();
+
+  FakeTabletSplitter fake_splitter;
+  // Mirror the production leader path (TabletServiceAdminImpl::SplitTablet): construct without a
+  // request and fill the operation-owned one, which NewReplicateMsg requires.
+  auto operation = std::make_unique<SplitOperation>(
+      ASSERT_RESULT(tablet_peer_->shared_tablet()), &fake_splitter);
+  operation->AllocateRequest()->dup_tablet_id(tablet()->tablet_id());
+  auto synchronizer = std::make_shared<Synchronizer>();
+  operation->set_completion_callback(
+      MakeWeakSynchronizerOperationCompletionCallback(synchronizer));
+  tablet_peer_->Submit(std::move(operation), /* term= */ 1);
+  const auto status = synchronizer->Wait();
+  ASSERT_TRUE(status.IsIllegalState()) << status;
+  ASSERT_STR_CONTAINS(status.message().ToBuffer(), "splitting is fenced");
+  // The rejection happened before WAL append: nothing was committed or logged.
+  ASSERT_EQ(committed_before, consensus->GetLastCommittedOpId());
+  ASSERT_EQ(committed_before, tablet_peer_->log()->GetLatestEntryOpId());
+
+  // With the generation released, the fence no longer rejects the split operation. (It would
+  // proceed into the split machinery, which this harness does not provide, so only the fence
+  // path is exercised here; end-to-end split behavior is covered by the mini-cluster test.)
+}
+
+TEST_F(TabletPeerTest, CloneRejectedWhileOrderingGenerationActive) {
+  ConsensusBootstrapInfo info;
+  auto consensus = ASSERT_RESULT(StartPeerAndWaitForLeaderNoOpCommit(info));
+
+  ASSERT_OK(tablet()->metadata()->set_index_backfill_ordering_generation(
+      MakeActiveOrderingGeneration(/* base_op_index= */ 0)));
+  const auto committed_before = consensus->GetLastCommittedOpId();
+
+  FakeTabletSplitter fake_splitter;
+  auto operation = std::make_unique<CloneOperation>(
+      ASSERT_RESULT(tablet_peer_->shared_tablet()), &fake_splitter);
+  operation->AllocateRequest()->dup_tablet_id(tablet()->tablet_id());
+  auto synchronizer = std::make_shared<Synchronizer>();
+  operation->set_completion_callback(
+      MakeWeakSynchronizerOperationCompletionCallback(synchronizer));
+  tablet_peer_->Submit(std::move(operation), /* term= */ 1);
+  const auto status = synchronizer->Wait();
+  ASSERT_TRUE(status.IsIllegalState()) << status;
+  ASSERT_STR_CONTAINS(status.message().ToBuffer(), "cloning is fenced");
+  ASSERT_EQ(committed_before, consensus->GetLastCommittedOpId());
+  ASSERT_EQ(committed_before, tablet_peer_->log()->GetLatestEntryOpId());
 }
 
 // Ensure that Log::GC() doesn't delete logs with anchors.


### PR DESCRIPTION
## Summary

Deferred uniqueness verification (#33444) scans the marked versions that unique-index
backfill wrote at the fixed backfill hybrid time (#33553). That scan is only sound against a
stable tablet set and a validated write-ID sequence, so each index tablet needs a durable
record of the in-flight backfill's ordering state -- one that survives restart, remote
bootstrap, and inheritance by split children and clones.

The record (`IndexBackfillOrderingGenerationPB`, superblock field 39, persistence following
the `cdc_sdk_safe_time` pattern): `active`, the owning index `table_id`, `base_op_index`,
`retention_barrier_ht`, and `write_id_floor_version`. The full combined shape is defined
here; `retention_barrier_ht` is consumed by the verification read fence and
identity/activation by the master orchestration, both in later parts. The durable form of an
inactive generation is field absence, and the setter normalizes to keep in-memory and
durable state identical; `LoadFromSuperBlock` clears the in-memory record when the field is
absent, so a remote-bootstrap superblock replacement cannot resurrect a released generation.

Enforcement while a generation is active, all before WAL append via the `ValidateLeaderOpId`
hook (#33553):

- **Write base validation** -- marked fixed-hybrid-time writes must carry Raft indexes
  strictly above `base_op_index` (the activation operation's own index, assigned by the
  master flow in the next part): an index at or below the base cannot belong to this
  generation and would indicate misrouting or replay of a foreign sequence. Rejecting marked
  writes when *no* generation is active also arrives with the master activation flow.
- **Split fence** -- `SplitOperation` is rejected while active: verification must run
  against a stable tablet set. This is the fail-closed layer under the master-side split
  fence (next part; today's master-side suppression is in-memory only and lost on failover).
  `TEST_bypass_index_backfill_ordering_generation_split_fence` exists to prove the fence is
  for scan stability and lifecycle tracking, not key correctness: with the fence forced
  open, split children inherit the parent's marked entries, continue drawing write IDs from
  their own Raft indexes, and per-key write-ID uniqueness still holds (tested).
- **Clone fence** -- `CloneOperation` is rejected while active: the clone would inherit an
  active generation with no backfill job attached, permanently fencing its splits and
  pinning its retention.

With no generation active (the only production state until the master orchestration lands),
the hooks reduce to reading a defaulted struct and returning OK for every split, clone, and
marked write.

Stacked on #33403, #33404, #33484, #33544, and #33553, based on
`feature-stack/Shopify/uniq-idx-3a-marked-write-storage` per the feature-stack workflow, so
the diff is exactly this PR's own commit. A failing pr-title check on stacked PRs is a known
gap in that check; the stack merges bottom-up and retargets as parents merge.
## Upgrade/Rollback safety

**Proto change:** `RaftGroupReplicaSuperBlockPB.index_backfill_ordering_generation` (new
optional message, field 39). Additive:

- **Rollback with a flushed generation record:** old binaries parse the superblock without
  error and ignore the field -- no crash, no load failure. However, the superblock is
  regenerated from in-memory state on every metadata flush (not round-tripped), so the first
  flush on an old binary drops the record; a subsequent re-upgrade would see no generation
  and silently stop enforcing the base validation and the split/clone fences. This is
  production-safe today because nothing can activate a generation: the setter's only callers
  are tests, and the master activation flow (next part) is gated behind the same
  one-release-stack constraint as #33553 -- AutoFlag promotion, which requires all nodes
  upgraded, is what authorizes the first activation.
- **Mixed-version cluster:** the record is tablet-local metadata; replicas each persist
  their own copy when the (Raft-replicated) activation operation applies. The only wire path
  for the field itself is a remote-bootstrap superblock copy, where an old-binary recipient
  drops the unknown field on its first flush -- the same benign behavior as rollback. Until
  the activation operation exists, mixed clusters never contain the field at all.

**Behavioral surface pre-activation:** the split/clone/write hooks run unconditionally on
leaders but return OK with the defaulted (inactive) record, so splits, clones, and writes
are unaffected -- covered by the full `tablet-split-itest` (TSAN+debug),
`clone-tablet-itest` (ASAN+debug), `remote_bootstrap-itest` (ASAN), and a full release
`pg_index_backfill-test` regression, all green.

No gflag default changes; the new flag is TEST-only.
## Test plan

macOS arm64, release -- all green:

- [x] New: `TabletPeerTest.IndexBackfillOrderingGenerationPersistsAcrossReload` -- full
      combined record round-trips through the superblock; releasing persists as field
      absence.
- [x] New: `TabletPeerTest.IndexBackfillOrderingGenerationClearedBySuperblockReplacement` --
      remote-bootstrap-style `ReplaceSuperBlock` with an absent field clears a stale local
      generation.
- [x] New: `TabletPeerTest.FixedHybridTimeWriteRejectedAtOrBelowGenerationBase` -- marked
      write with index at/below the base rejected before WAL append; index above the base
      admitted; released generation does not constrain.
- [x] New: `TabletPeerTest.SplitRejectedWhileOrderingGenerationActive` /
      `CloneRejectedWhileOrderingGenerationActive` -- both rejected pre-WAL, nothing logged
      or committed.
- [x] New: `FixedHybridTimeWriteIdITest.MasterSplitRefusedWhileOrderingGenerationActive` --
      end-to-end through the master split path: split refused via the tablet fence while
      active; releasing the generation lets the same split complete (positive control).
- [x] New: `FixedHybridTimeWriteIdITest.OrderingGenerationSurvivesRemoteBootstrap` --
      tombstoned follower is remote-bootstrapped back by the leader; the recovered replica
      carries the generation.
- [x] New: `FixedHybridTimeWriteIdITest.SplitWithFenceBypassedPreservesPerKeyWriteIdUniqueness`
      -- fence forced open, tablet split; children inherit the generation and the parent's
      marked entries; a marked rewrite of an inherited key at the same fixed hybrid time
      lands as a second distinct physical version; per-key (key, HT, write ID) uniqueness
      holds on both children.
- [x] Regression: `TabletPeerTest.FixedHybridTimeWritesUseRaftIndexWriteId` and the #33553
      suites.

AlmaLinux (x86_64, clang21), rebased onto master `c7253d204d`:

At this PR's own commit (`944e3d85f0`), debug -- all green:

- [x] `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`.

Integrated at the stack tip (`334a1deb3d`), all green. Exact suites per build type:

- [x] TSAN (6): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `non_transactional_batch_writer-test`,
      `keyed_fingerprint-test`, `raft_consensus-itest`.
- [x] ASAN (15): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `keyed_fingerprint-test`,
      `non_transactional_batch_writer-test`, `clone-tablet-itest`,
      `remote_bootstrap-itest`, `tablet_bootstrap-test`, `auto_flags-itest`,
      `docdb-test`, `compaction_file_filter-test`,
      `xcluster_external_apply_bootstrap-test`, `pg_txn-test`, `pg_ash-test`,
      full `pg_index_backfill-test`.
- [x] Debug (19): the ASAN list minus `compaction_file_filter-test`, plus
      `master_failover-itest`, `snapshot-test`, `tablet_snapshots-test`,
      `compaction-test`, `tablet-split-itest`.
- [x] Release (5): `keyed_fingerprint-test`, `auto_flags-itest`, full
      `pg_index_backfill-test`, java `TestIndexBackfill`, java
      `TestPgRegressBackfillIndex`.
- [x] All three full `pg_index_backfill-test` runs (ASAN, debug, release) pass with no
      test failures.

Two known-upstream issues surfaced by the tip matrix, both shown not attributable to this
stack:

- TSAN `tablet-split-itest` reports 3 data races in `yb::client::YBTable::~YBTable()`
  (table.cc:81) racing its partition-refresh callback, inside the upstream test
  `AutomaticTabletSplitITest.SizeRatio` (93 cases ran, 0 gtest failures). This stack has zero
  diff under `src/yb/client/`, and that test passes 3/3 isolated at the new master base.
- `wait_states-itest` hangs 9 cases at the 601s timeout (`AshCql`, the `kYCQL_*` group,
  `kBackfillIndex_*`, `kConsensusMeta_Flush`, `kCreatingNewTablet`,
  `kSaveRaftGroupMetadataToDisk`). Reproduced identically on plain master `c7253d204d`
  carrying none of this stack's code: 53 ran, the same 9 failed, same ~600.5s expiries.

Disposition change since the previous revision: the
`PgIndexBackfillBackendsManager.NoAbortTxn/1` flake cited earlier was fixed upstream. It
passes 3/3 at the new base and in all three full `pg_index_backfill-test` runs here, so it is
no longer carried as a known flake.

