### PR TITLE
[DOC-1456] Docs: Document SSH user on Linux versions, not SSH Key Pairs

### DIFF
--- a/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/aws.md
+++ b/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/aws.md
@@ -148,7 +148,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Amazon Machine Image (AMI) ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`.
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard AMIs, use the image's default login user (for example `ec2-user` or `ubuntu`).
 
 1. To configure instances so that the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) _requires_ IMDSv2, select the **Use IMDSv2** option (recommended). If **Use IMDSv2** is not selected, the service accepts both IMDSv1 and IMDSv2 requests.
 

--- a/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/aws.md
+++ b/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/aws.md
@@ -148,7 +148,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Amazon Machine Image (AMI) ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. Leave this empty to use the [default SSH user](#ssh-key-pairs).
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`.
 
 1. To configure instances so that the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) _requires_ IMDSv2, select the **Use IMDSv2** option (recommended). If **Use IMDSv2** is not selected, the service accepts both IMDSv1 and IMDSv2 requests.
 
@@ -156,20 +156,24 @@ To add your own machine images to the catalog:
 
 To edit custom Linux versions, remove Linux versions, and set a version as the default to use when creating universes, click **...** for the version you want to modify.
 
+If you plan to use the `us-gov-east-1` and `us-gov-west-1` regions, add your own Linux version using a [supported OS](../../../reference/configuration/operating-systems/). Do not use YugabyteDB Anywhere-managed Linux versions for those regions.
+
 ### SSH Key Pairs
 
 To be able to provision Amazon Elastic Compute Cloud (EC2) instances with YugabyteDB, YugabyteDB Anywhere requires SSH access.
 
-Enter the SSH user and port to use by default for machine images. You can override these values for custom Linux versions that you add to the Linux Version Catalog.
+{{< note title="SSH User and Port" >}}
+You cannot enter SSH user or port in this section; those fields are disabled. Specify them for each Linux version in the [Linux version catalog](#linux-version-catalog). The key pair you configure here is used to authenticate as that SSH user.
+{{< /note >}}
+
+YugabyteDB Anywhere-managed Linux versions use `ec2-user`.
 
 You can manage SSH key pairs in the following ways:
 
 - Enable YugabyteDB Anywhere to create and manage [Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html). In this mode, YugabyteDB Anywhere creates SSH Key Pairs across all the regions you choose to set up and stores the relevant private key part of these locally in order to SSH into future EC2 instances.
-- Use your own existing Key Pairs. To do this, provide the name of the Key Pair, as well as the private key content, and the corresponding SSH user. This information must be the same across all the regions you provision.
+- Use your own existing Key Pairs. To do this, provide the name of the Key Pair, as well as the private key content. This information must be the same across all the regions you provision.
 
 If you use YugabyteDB Anywhere to manage SSH Key Pairs for you and you deploy multiple YugabyteDB Anywhere instances across your environment, then the AWS provider name should be unique for each instance of YugabyteDB Anywhere integrating with a given AWS account.
-
-If you are using a YugabyteDB Anywhere-managed AMI and plan to use the `us-gov-east-1` and `us-gov-west-1` regions, you must set the SSH user to `centos` as these regions use CentOS 7 (as opposed to the default Alma 8 used for other regions). If you don't set the SSH user accordingly, universe deployment to these regions will fail.
 
 ### Advanced
 

--- a/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/azure.md
+++ b/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/azure.md
@@ -179,7 +179,7 @@ To add your own machine images to the catalog:
 
 1. Provide a URN to a marketplace image or a shared gallery image by following instructions provided in [Use a shared image gallery](#use-a-shared-image-gallery).
 
-1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. Azure creates this user when it provisions the VM. For a custom or shared-gallery image, choose a username that does not already exist on the image; Azure rejects the request if that user is already present.
 
 1. Click **Add Linux Version**.
 

--- a/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/azure.md
+++ b/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/azure.md
@@ -65,7 +65,6 @@ You need to add the following Azure cloud provider credentials:
 - Resource group name
 - Subscription ID
 - Tenant ID
-- SSH port and user
 
 YugabyteDB Anywhere uses the credentials to automatically provision and deprovision YugabyteDB instances.
 
@@ -180,7 +179,7 @@ To add your own machine images to the catalog:
 
 1. Provide a URN to a marketplace image or a shared gallery image by following instructions provided in [Use a shared image gallery](#use-a-shared-image-gallery).
 
-1. Provide the SSH user and port to use to access the machine image OS. Leave this empty to use the [default SSH user](#ssh-key-pairs).
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
 
 1. Click **Add Linux Version**.
 
@@ -194,7 +193,11 @@ For YugabyteDB Anywhere v2025.1 and later, if you want to deploy a universe on A
 
 To be able to provision cloud instances with YugabyteDB, YugabyteDB Anywhere requires SSH access.
 
-Enter the SSH user and port to use by default for machine images. You can override these values for custom Linux versions that you add to the Linux Version Catalog.
+{{< note title="SSH User and Port" >}}
+You cannot enter SSH user or port in this section; those fields are disabled. Specify them for each Linux version in the [Linux version catalog](#linux-version-catalog). The key pair you configure here is used to authenticate as that SSH user.
+{{< /note >}}
+
+YugabyteDB Anywhere-managed Linux versions use `centos`.
 
 You can manage SSH key pairs in the following ways:
 

--- a/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/gcp.md
+++ b/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/gcp.md
@@ -171,7 +171,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Machine Image ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard images, use the image's default login user (for example `centos` or `ubuntu`).
 
 1. Click **Add Linux Version**.
 

--- a/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/gcp.md
+++ b/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/gcp.md
@@ -171,7 +171,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Machine Image ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. Leave this empty to use the [default SSH user](#ssh-key-pairs).
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
 
 1. Click **Add Linux Version**.
 
@@ -181,7 +181,11 @@ To edit custom Linux versions, remove Linux versions, and set a version as the d
 
 To be able to provision cloud instances with YugabyteDB, YugabyteDB Anywhere requires SSH access.
 
-Enter the SSH user and port to use by default for machine images. You can override these values for custom Linux versions that you add to the Linux Version Catalog.
+{{< note title="SSH User and Port" >}}
+You cannot enter SSH user or port in this section; those fields are disabled. Specify them for each Linux version in the [Linux version catalog](#linux-version-catalog). The key pair you configure here is used to authenticate as that SSH user.
+{{< /note >}}
+
+YugabyteDB Anywhere-managed Linux versions use `centos`.
 
 You can manage SSH key pairs in the following ways:
 

--- a/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-aws.md
+++ b/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-aws.md
@@ -184,8 +184,10 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-If you will be using your own custom SSH keys, then ensure that you have them when installing YBA and creating your public cloud provider.
+The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+
+If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your AWS cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |
-| Custom SSH keys | [AWS provider configuration](../../../configure-yugabyte-platform/kubernetes/) |
+| Custom SSH keys | [AWS provider configuration](../../../configure-yugabyte-platform/aws/) |

--- a/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
+++ b/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
@@ -103,7 +103,9 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-If you will be using your own custom SSH keys, then ensure that you have them when installing YBA and creating your public cloud provider.
+The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+
+If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your Azure cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |

--- a/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
+++ b/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
@@ -103,9 +103,9 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+The key pair authenticates as the SSH user you specify on the Linux version. Azure creates that user when it provisions the VM. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
 
-If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your Azure cloud provider configuration.
+If you will be using your own custom SSH keys, have them when installing YBA and creating your Azure cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |

--- a/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
+++ b/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
@@ -81,7 +81,9 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-If you will be using your own custom SSH keys, then ensure that you have them when installing YBA and creating your public cloud provider.
+The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+
+If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your GCP cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |

--- a/docs/content/stable/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
+++ b/docs/content/stable/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
@@ -25,13 +25,15 @@ Using a YBA-managed Linux version requires connectivity from the database nodes 
 
 For YBA-managed Linux version, YBA manages the creation and provisioning of database nodes, including installing the disk image, configuring the Linux OS, and installing the additional software.
 
-You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes. YBA-managed Linux versions use the image's default login user: `ec2-user` on AWS, `centos` on GCP and Azure.
+You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes. YBA-managed Linux versions use `ec2-user` on AWS and `centos` on GCP and Azure.
 
 ## Custom Linux version with Internet connectivity
 
 If you choose to provide your own custom Linux version and your VMs have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+- [Supported Linux OS](../#linux-os). The SSH user must have passwordless sudo and must not be named `yugabyte` (YBA creates that account during provisioning). YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+  - AWS and GCP: that user must already exist on the image. For standard images, use the image's default login user (for example `ec2-user` or `ubuntu`).
+  - Azure: Azure creates the SSH user you specify when it provisions the VM. For a custom or shared-gallery image, choose a username that does not already exist on the image; Azure rejects the request if that user is already present.
 - [Additional software](../#additional-software)
 
 Take the time now to prepare the Linux disk image.
@@ -49,7 +51,9 @@ Take the time now to prepare the Linux disk image.
 
 If you choose to provide your own custom Linux version and your VMs don't have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+- [Supported Linux OS](../#linux-os). The SSH user must have passwordless sudo and must not be named `yugabyte` (YBA creates that account during provisioning). YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+  - AWS and GCP: that user must already exist on the image. For standard images, use the image's default login user (for example `ec2-user` or `ubuntu`).
+  - Azure: Azure creates the SSH user you specify when it provisions the VM. For a custom or shared-gallery image, choose a username that does not already exist on the image; Azure rejects the request if that user is already present.
 - [Additional software](../#additional-software)
 - [Additional software for airgapped](../#additional-software-for-airgapped-deployment)
 

--- a/docs/content/stable/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
+++ b/docs/content/stable/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
@@ -25,41 +25,41 @@ Using a YBA-managed Linux version requires connectivity from the database nodes 
 
 For YBA-managed Linux version, YBA manages the creation and provisioning of database nodes, including installing the disk image, configuring the Linux OS, and installing the additional software.
 
-You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes.
+You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes. YBA-managed Linux versions use the image's default login user: `ec2-user` on AWS, `centos` on GCP and Azure.
 
 ## Custom Linux version with Internet connectivity
 
 If you choose to provide your own custom Linux version and your VMs have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled, root-privileged user. YBA uses this user to automatically perform additional Linux configuration, such as creating the `yugabyte` user, updating the file descriptor settings via ulimits, and so on.
+- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
 - [Additional software](../#additional-software)
 
 Take the time now to prepare the Linux disk image.
 
-- Save the SSH-enabled, root-privileged user credentials (username and SSH Private Key Content PEM file).
+- Save the SSH user name and the SSH private key PEM file.
 - Save the disk image IDs for later when installing and configuring YBA.
 
 | Save for later | To configure |
 | :--- | :--- |
-| SSH-enabled, root-privileged user name | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| SSH-enabled, root-privileged Private Key Content PEM file | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| Disk image IDs | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
+| SSH user name | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |
+| SSH private key PEM file | [SSH Key Pairs](../../../configure-yugabyte-platform/aws/#ssh-key-pairs) |
+| Disk image IDs | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |
 
 ## Custom Linux version without Internet connectivity
 
 If you choose to provide your own custom Linux version and your VMs don't have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled, root-privileged user. YBA uses this user to automatically perform additional Linux configuration, such as creating the `yugabyte` user, updating the file descriptor settings via ulimits, and so on.
+- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
 - [Additional software](../#additional-software)
 - [Additional software for airgapped](../#additional-software-for-airgapped-deployment)
 
 Take the time now to prepare the Linux disk image.
 
-- Save the SSH-enabled, root-privileged user credentials (username and SSH Private Key Content PEM file).
+- Save the SSH user name and the SSH private key PEM file.
 - Save the disk image IDs for later when installing and configuring YBA.
 
 | Save for later | To configure |
 | :--- | :--- |
-| SSH-enabled, root-privileged user name | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| SSH-enabled, root-privileged Private Key Content PEM file | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| Disk image IDs | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
+| SSH user name | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |
+| SSH private key PEM file | [SSH Key Pairs](../../../configure-yugabyte-platform/aws/#ssh-key-pairs) |
+| Disk image IDs | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |

--- a/docs/content/v2024.2/yugabyte-platform/configure-yugabyte-platform/aws.md
+++ b/docs/content/v2024.2/yugabyte-platform/configure-yugabyte-platform/aws.md
@@ -137,7 +137,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Amazon Machine Image (AMI) ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. Leave this empty to use the [default SSH user](#ssh-key-pairs).
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`.
 
 1. To configure instances so that the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) _requires_ IMDSv2, select the **Use IMDSv2** option (recommended). If **Use IMDSv2** is not selected, the service accepts both IMDSv1 and IMDSv2 requests.
 
@@ -145,20 +145,24 @@ To add your own machine images to the catalog:
 
 To edit custom Linux versions, remove Linux versions, and set a version as the default to use when creating universes, click **...** for the version you want to modify.
 
+If you plan to use the `us-gov-east-1` and `us-gov-west-1` regions, add your own Linux version using a [supported OS](../../../reference/configuration/operating-systems/). Do not use YBA-managed Linux versions for those regions.
+
 ### SSH Key Pairs
 
 To be able to provision Amazon Elastic Compute Cloud (EC2) instances with YugabyteDB, YBA requires SSH access.
 
-Enter the SSH user and port to use by default for machine images. You can override these values for custom Linux versions that you add to the Linux Version Catalog.
+{{< note title="SSH User and Port" >}}
+You cannot enter SSH user or port in this section; those fields are disabled. Specify them for each Linux version in the [Linux version catalog](#linux-version-catalog). The key pair you configure here is used to authenticate as that SSH user.
+{{< /note >}}
+
+YBA-managed Linux versions use `ec2-user`.
 
 You can manage SSH key pairs in the following ways:
 
 - Enable YBA to create and manage [Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html). In this mode, YBA creates SSH Key Pairs across all the regions you choose to set up and stores the relevant private key part of these locally in order to SSH into future EC2 instances.
-- Use your own existing Key Pairs. To do this, provide the name of the Key Pair, as well as the private key content, and the corresponding SSH user. This information must be the same across all the regions you provision.
+- Use your own existing Key Pairs. To do this, provide the name of the Key Pair, as well as the private key content. This information must be the same across all the regions you provision.
 
 If you use YBA to manage SSH Key Pairs for you and you deploy multiple YBA instances across your environment, then the AWS provider name should be unique for each instance of YBA integrating with a given AWS account.
-
-If you are using a YBA-managed AMI and plan to use the `us-gov-east-1` and `us-gov-west-1` regions, you must set the SSH user to `centos` as these regions use CentOS 7 (as opposed to the default Alma 8 used for other regions). If you don't set the SSH user accordingly, universe deployment to these regions will fail.
 
 ### Advanced
 

--- a/docs/content/v2024.2/yugabyte-platform/configure-yugabyte-platform/aws.md
+++ b/docs/content/v2024.2/yugabyte-platform/configure-yugabyte-platform/aws.md
@@ -137,7 +137,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Amazon Machine Image (AMI) ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`.
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard AMIs, use the image's default login user (for example `ec2-user` or `ubuntu`).
 
 1. To configure instances so that the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) _requires_ IMDSv2, select the **Use IMDSv2** option (recommended). If **Use IMDSv2** is not selected, the service accepts both IMDSv1 and IMDSv2 requests.
 

--- a/docs/content/v2024.2/yugabyte-platform/configure-yugabyte-platform/azure.md
+++ b/docs/content/v2024.2/yugabyte-platform/configure-yugabyte-platform/azure.md
@@ -169,7 +169,7 @@ To add your own machine images to the catalog:
 
 1. Provide a URN to a marketplace image or a shared gallery image by following instructions provided in [Use a shared image gallery](#use-a-shared-image-gallery).
 
-1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. Azure creates this user when it provisions the VM. For a custom or shared-gallery image, choose a username that does not already exist on the image; Azure rejects the request if that user is already present.
 
 1. Click **Add Linux Version**.
 

--- a/docs/content/v2024.2/yugabyte-platform/configure-yugabyte-platform/azure.md
+++ b/docs/content/v2024.2/yugabyte-platform/configure-yugabyte-platform/azure.md
@@ -55,7 +55,6 @@ You need to add the following Azure cloud provider credentials:
 - Resource group name
 - Subscription ID
 - Tenant ID
-- SSH port and user
 
 YBA uses the credentials to automatically provision and deprovision YugabyteDB instances.
 
@@ -170,7 +169,7 @@ To add your own machine images to the catalog:
 
 1. Provide a URN to a marketplace image or a shared gallery image by following instructions provided in [Use a shared image gallery](#use-a-shared-image-gallery).
 
-1. Provide the SSH user and port to use to access the machine image OS. Leave this empty to use the [default SSH user](#ssh-key-pairs).
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
 
 1. Click **Add Linux Version**.
 
@@ -180,7 +179,11 @@ To edit custom Linux versions, remove Linux versions, and set a version as the d
 
 To be able to provision cloud instances with YugabyteDB, YBA requires SSH access.
 
-Enter the SSH user and port to use by default for machine images. You can override these values for custom Linux versions that you add to the Linux Version Catalog.
+{{< note title="SSH User and Port" >}}
+You cannot enter SSH user or port in this section; those fields are disabled. Specify them for each Linux version in the [Linux version catalog](#linux-version-catalog). The key pair you configure here is used to authenticate as that SSH user.
+{{< /note >}}
+
+YBA-managed Linux versions use `centos`.
 
 You can manage SSH key pairs in the following ways:
 

--- a/docs/content/v2024.2/yugabyte-platform/configure-yugabyte-platform/gcp.md
+++ b/docs/content/v2024.2/yugabyte-platform/configure-yugabyte-platform/gcp.md
@@ -161,7 +161,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Machine Image ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. Leave this empty to use the [default SSH user](#ssh-key-pairs).
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
 
 1. Click **Add Linux Version**.
 
@@ -171,7 +171,11 @@ To edit custom Linux versions, remove Linux versions, and set a version as the d
 
 To be able to provision cloud instances with YugabyteDB, YBA requires SSH access.
 
-Enter the SSH user and port to use by default for machine images. You can override these values for custom Linux versions that you add to the Linux Version Catalog.
+{{< note title="SSH User and Port" >}}
+You cannot enter SSH user or port in this section; those fields are disabled. Specify them for each Linux version in the [Linux version catalog](#linux-version-catalog). The key pair you configure here is used to authenticate as that SSH user.
+{{< /note >}}
+
+YBA-managed Linux versions use `centos`.
 
 You can manage SSH key pairs in the following ways:
 

--- a/docs/content/v2024.2/yugabyte-platform/configure-yugabyte-platform/gcp.md
+++ b/docs/content/v2024.2/yugabyte-platform/configure-yugabyte-platform/gcp.md
@@ -161,7 +161,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Machine Image ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard images, use the image's default login user (for example `centos` or `ubuntu`).
 
 1. Click **Add Linux Version**.
 

--- a/docs/content/v2024.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-aws.md
+++ b/docs/content/v2024.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-aws.md
@@ -177,8 +177,10 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-If you will be using your own custom SSH keys, then ensure that you have them when installing YBA and creating your public cloud provider configuration.
+The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+
+If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your AWS cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |
-| Custom SSH keys | [AWS provider configuration](../../../configure-yugabyte-platform/kubernetes/) |
+| Custom SSH keys | [AWS provider configuration](../../../configure-yugabyte-platform/aws/) |

--- a/docs/content/v2024.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
+++ b/docs/content/v2024.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
@@ -103,7 +103,9 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-If you will be using your own custom SSH keys, then ensure that you have them when installing YBA and creating your public cloud provider configuration.
+The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+
+If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your Azure cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |

--- a/docs/content/v2024.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
+++ b/docs/content/v2024.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
@@ -103,9 +103,9 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+The key pair authenticates as the SSH user you specify on the Linux version. Azure creates that user when it provisions the VM. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
 
-If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your Azure cloud provider configuration.
+If you will be using your own custom SSH keys, have them when installing YBA and creating your Azure cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |

--- a/docs/content/v2024.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
+++ b/docs/content/v2024.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
@@ -81,7 +81,9 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-If you will be using your own custom SSH keys, then ensure that you have them when installing YBA and creating your public cloud provider configuration.
+The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+
+If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your GCP cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |

--- a/docs/content/v2024.2/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
+++ b/docs/content/v2024.2/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
@@ -25,13 +25,15 @@ Using a YBA-managed Linux version requires connectivity from the database nodes 
 
 For YBA-managed Linux version, YBA manages the creation and provisioning of database cluster nodes, including installing the disk image, configuring the Linux OS, and installing the additional software.
 
-You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes. YBA-managed Linux versions use the image's default login user: `ec2-user` on AWS, `centos` on GCP and Azure.
+You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes. YBA-managed Linux versions use `ec2-user` on AWS and `centos` on GCP and Azure.
 
 ## Custom Linux version with Internet connectivity
 
 If you choose to provide your own custom Linux version and your VMs have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+- [Supported Linux OS](../#linux-os). The SSH user must have passwordless sudo and must not be named `yugabyte` (YBA creates that account during provisioning). YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+  - AWS and GCP: that user must already exist on the image. For standard images, use the image's default login user (for example `ec2-user` or `ubuntu`).
+  - Azure: Azure creates the SSH user you specify when it provisions the VM. For a custom or shared-gallery image, choose a username that does not already exist on the image; Azure rejects the request if that user is already present.
 - [Additional software](../#additional-software)
 
 Take the time now to prepare the Linux disk image.
@@ -49,7 +51,9 @@ Take the time now to prepare the Linux disk image.
 
 If you choose to provide your own custom Linux version and your VMs don't have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+- [Supported Linux OS](../#linux-os). The SSH user must have passwordless sudo and must not be named `yugabyte` (YBA creates that account during provisioning). YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+  - AWS and GCP: that user must already exist on the image. For standard images, use the image's default login user (for example `ec2-user` or `ubuntu`).
+  - Azure: Azure creates the SSH user you specify when it provisions the VM. For a custom or shared-gallery image, choose a username that does not already exist on the image; Azure rejects the request if that user is already present.
 - [Additional software](../#additional-software)
 - [Additional software for airgapped](../#additional-software-for-airgapped-deployment)
 

--- a/docs/content/v2024.2/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
+++ b/docs/content/v2024.2/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
@@ -25,41 +25,41 @@ Using a YBA-managed Linux version requires connectivity from the database nodes 
 
 For YBA-managed Linux version, YBA manages the creation and provisioning of database cluster nodes, including installing the disk image, configuring the Linux OS, and installing the additional software.
 
-You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes.
+You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes. YBA-managed Linux versions use the image's default login user: `ec2-user` on AWS, `centos` on GCP and Azure.
 
 ## Custom Linux version with Internet connectivity
 
 If you choose to provide your own custom Linux version and your VMs have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled, root-privileged user. YBA uses this user to automatically perform additional Linux configuration, such as creating the `yugabyte` user, updating the file descriptor settings via ulimits, and so on.
+- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
 - [Additional software](../#additional-software)
 
 Take the time now to prepare the Linux disk image.
 
-- Save the SSH-enabled, root-privileged user credentials (username and SSH Private Key Content PEM file).
+- Save the SSH user name and the SSH private key PEM file.
 - Save the disk image IDs for later when installing and configuring YBA.
 
 | Save for later | To configure |
 | :--- | :--- |
-| SSH-enabled, root-privileged user name | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| SSH-enabled, root-privileged Private Key Content PEM file | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| Disk image IDs | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
+| SSH user name | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |
+| SSH private key PEM file | [SSH Key Pairs](../../../configure-yugabyte-platform/aws/#ssh-key-pairs) |
+| Disk image IDs | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |
 
 ## Custom Linux version without Internet connectivity
 
 If you choose to provide your own custom Linux version and your VMs don't have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled, root-privileged user. YBA uses this user to automatically perform additional Linux configuration, such as creating the `yugabyte` user, updating the file descriptor settings via ulimits, and so on.
+- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
 - [Additional software](../#additional-software)
 - [Additional software for airgapped](../#additional-software-for-airgapped-deployment)
 
 Take the time now to prepare the Linux disk image.
 
-- Save the SSH-enabled, root-privileged user credentials (username and SSH Private Key Content PEM file).
+- Save the SSH user name and the SSH private key PEM file.
 - Save the disk image IDs for later when installing and configuring YBA.
 
 | Save for later | To configure |
 | :--- | :--- |
-| SSH-enabled, root-privileged user name | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| SSH-enabled, root-privileged Private Key Content PEM file | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| Disk image IDs | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
+| SSH user name | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |
+| SSH private key PEM file | [SSH Key Pairs](../../../configure-yugabyte-platform/aws/#ssh-key-pairs) |
+| Disk image IDs | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |

--- a/docs/content/v2025.1/yugabyte-platform/configure-yugabyte-platform/aws.md
+++ b/docs/content/v2025.1/yugabyte-platform/configure-yugabyte-platform/aws.md
@@ -145,7 +145,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Amazon Machine Image (AMI) ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. Leave this empty to use the [default SSH user](#ssh-key-pairs).
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`.
 
 1. To configure instances so that the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) _requires_ IMDSv2, select the **Use IMDSv2** option (recommended). If **Use IMDSv2** is not selected, the service accepts both IMDSv1 and IMDSv2 requests.
 
@@ -153,20 +153,24 @@ To add your own machine images to the catalog:
 
 To edit custom Linux versions, remove Linux versions, and set a version as the default to use when creating universes, click **...** for the version you want to modify.
 
+If you plan to use the `us-gov-east-1` and `us-gov-west-1` regions, add your own Linux version using a [supported OS](../../../reference/configuration/operating-systems/). Do not use YugabyteDB Anywhere-managed Linux versions for those regions.
+
 ### SSH Key Pairs
 
 To be able to provision Amazon Elastic Compute Cloud (EC2) instances with YugabyteDB, YugabyteDB Anywhere requires SSH access.
 
-Enter the SSH user and port to use by default for machine images. You can override these values for custom Linux versions that you add to the Linux Version Catalog.
+{{< note title="SSH User and Port" >}}
+You cannot enter SSH user or port in this section; those fields are disabled. Specify them for each Linux version in the [Linux version catalog](#linux-version-catalog). The key pair you configure here is used to authenticate as that SSH user.
+{{< /note >}}
+
+YugabyteDB Anywhere-managed Linux versions use `ec2-user`.
 
 You can manage SSH key pairs in the following ways:
 
 - Enable YugabyteDB Anywhere to create and manage [Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html). In this mode, YugabyteDB Anywhere creates SSH Key Pairs across all the regions you choose to set up and stores the relevant private key part of these locally in order to SSH into future EC2 instances.
-- Use your own existing Key Pairs. To do this, provide the name of the Key Pair, as well as the private key content, and the corresponding SSH user. This information must be the same across all the regions you provision.
+- Use your own existing Key Pairs. To do this, provide the name of the Key Pair, as well as the private key content. This information must be the same across all the regions you provision.
 
 If you use YugabyteDB Anywhere to manage SSH Key Pairs for you and you deploy multiple YugabyteDB Anywhere instances across your environment, then the AWS provider name should be unique for each instance of YugabyteDB Anywhere integrating with a given AWS account.
-
-If you are using a YugabyteDB Anywhere-managed AMI and plan to use the `us-gov-east-1` and `us-gov-west-1` regions, you must set the SSH user to `centos` as these regions use CentOS 7 (as opposed to the default Alma 8 used for other regions). If you don't set the SSH user accordingly, universe deployment to these regions will fail.
 
 ### Advanced
 

--- a/docs/content/v2025.1/yugabyte-platform/configure-yugabyte-platform/aws.md
+++ b/docs/content/v2025.1/yugabyte-platform/configure-yugabyte-platform/aws.md
@@ -145,7 +145,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Amazon Machine Image (AMI) ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`.
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard AMIs, use the image's default login user (for example `ec2-user` or `ubuntu`).
 
 1. To configure instances so that the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) _requires_ IMDSv2, select the **Use IMDSv2** option (recommended). If **Use IMDSv2** is not selected, the service accepts both IMDSv1 and IMDSv2 requests.
 

--- a/docs/content/v2025.1/yugabyte-platform/configure-yugabyte-platform/azure.md
+++ b/docs/content/v2025.1/yugabyte-platform/configure-yugabyte-platform/azure.md
@@ -177,7 +177,7 @@ To add your own machine images to the catalog:
 
 1. Provide a URN to a marketplace image or a shared gallery image by following instructions provided in [Use a shared image gallery](#use-a-shared-image-gallery).
 
-1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. Azure creates this user when it provisions the VM. For a custom or shared-gallery image, choose a username that does not already exist on the image; Azure rejects the request if that user is already present.
 
 1. Click **Add Linux Version**.
 

--- a/docs/content/v2025.1/yugabyte-platform/configure-yugabyte-platform/azure.md
+++ b/docs/content/v2025.1/yugabyte-platform/configure-yugabyte-platform/azure.md
@@ -63,7 +63,6 @@ You need to add the following Azure cloud provider credentials:
 - Resource group name
 - Subscription ID
 - Tenant ID
-- SSH port and user
 
 YugabyteDB Anywhere uses the credentials to automatically provision and deprovision YugabyteDB instances.
 
@@ -178,7 +177,7 @@ To add your own machine images to the catalog:
 
 1. Provide a URN to a marketplace image or a shared gallery image by following instructions provided in [Use a shared image gallery](#use-a-shared-image-gallery).
 
-1. Provide the SSH user and port to use to access the machine image OS. Leave this empty to use the [default SSH user](#ssh-key-pairs).
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
 
 1. Click **Add Linux Version**.
 
@@ -194,7 +193,11 @@ For YugabyteDB Anywhere v2025.1 and later, if you want to deploy a universe on A
 
 To be able to provision cloud instances with YugabyteDB, YugabyteDB Anywhere requires SSH access.
 
-Enter the SSH user and port to use by default for machine images. You can override these values for custom Linux versions that you add to the Linux Version Catalog.
+{{< note title="SSH User and Port" >}}
+You cannot enter SSH user or port in this section; those fields are disabled. Specify them for each Linux version in the [Linux version catalog](#linux-version-catalog). The key pair you configure here is used to authenticate as that SSH user.
+{{< /note >}}
+
+YugabyteDB Anywhere-managed Linux versions use `centos`.
 
 You can manage SSH key pairs in the following ways:
 

--- a/docs/content/v2025.1/yugabyte-platform/configure-yugabyte-platform/gcp.md
+++ b/docs/content/v2025.1/yugabyte-platform/configure-yugabyte-platform/gcp.md
@@ -169,7 +169,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Machine Image ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard images, use the image's default login user (for example `centos` or `ubuntu`).
 
 1. Click **Add Linux Version**.
 

--- a/docs/content/v2025.1/yugabyte-platform/configure-yugabyte-platform/gcp.md
+++ b/docs/content/v2025.1/yugabyte-platform/configure-yugabyte-platform/gcp.md
@@ -169,7 +169,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Machine Image ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. Leave this empty to use the [default SSH user](#ssh-key-pairs).
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
 
 1. Click **Add Linux Version**.
 
@@ -179,7 +179,11 @@ To edit custom Linux versions, remove Linux versions, and set a version as the d
 
 To be able to provision cloud instances with YugabyteDB, YugabyteDB Anywhere requires SSH access.
 
-Enter the SSH user and port to use by default for machine images. You can override these values for custom Linux versions that you add to the Linux Version Catalog.
+{{< note title="SSH User and Port" >}}
+You cannot enter SSH user or port in this section; those fields are disabled. Specify them for each Linux version in the [Linux version catalog](#linux-version-catalog). The key pair you configure here is used to authenticate as that SSH user.
+{{< /note >}}
+
+YugabyteDB Anywhere-managed Linux versions use `centos`.
 
 You can manage SSH key pairs in the following ways:
 

--- a/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-aws.md
+++ b/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-aws.md
@@ -184,8 +184,10 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-If you will be using your own custom SSH keys, then ensure that you have them when installing YBA and creating your public cloud provider.
+The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+
+If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your AWS cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |
-| Custom SSH keys | [AWS provider configuration](../../../configure-yugabyte-platform/kubernetes/) |
+| Custom SSH keys | [AWS provider configuration](../../../configure-yugabyte-platform/aws/) |

--- a/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
+++ b/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
@@ -103,7 +103,9 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-If you will be using your own custom SSH keys, then ensure that you have them when installing YBA and creating your public cloud provider.
+The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+
+If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your Azure cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |

--- a/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
+++ b/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
@@ -103,9 +103,9 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+The key pair authenticates as the SSH user you specify on the Linux version. Azure creates that user when it provisions the VM. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
 
-If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your Azure cloud provider configuration.
+If you will be using your own custom SSH keys, have them when installing YBA and creating your Azure cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |

--- a/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
+++ b/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
@@ -81,7 +81,9 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-If you will be using your own custom SSH keys, then ensure that you have them when installing YBA and creating your public cloud provider.
+The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+
+If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your GCP cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |

--- a/docs/content/v2025.1/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
+++ b/docs/content/v2025.1/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
@@ -25,13 +25,15 @@ Using a YBA-managed Linux version requires connectivity from the database nodes 
 
 For YBA-managed Linux version, YBA manages the creation and provisioning of database nodes, including installing the disk image, configuring the Linux OS, and installing the additional software.
 
-You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes. YBA-managed Linux versions use the image's default login user: `ec2-user` on AWS, `centos` on GCP and Azure.
+You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes. YBA-managed Linux versions use `ec2-user` on AWS and `centos` on GCP and Azure.
 
 ## Custom Linux version with Internet connectivity
 
 If you choose to provide your own custom Linux version and your VMs have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+- [Supported Linux OS](../#linux-os). The SSH user must have passwordless sudo and must not be named `yugabyte` (YBA creates that account during provisioning). YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+  - AWS and GCP: that user must already exist on the image. For standard images, use the image's default login user (for example `ec2-user` or `ubuntu`).
+  - Azure: Azure creates the SSH user you specify when it provisions the VM. For a custom or shared-gallery image, choose a username that does not already exist on the image; Azure rejects the request if that user is already present.
 - [Additional software](../#additional-software)
 
 Take the time now to prepare the Linux disk image.
@@ -49,7 +51,9 @@ Take the time now to prepare the Linux disk image.
 
 If you choose to provide your own custom Linux version and your VMs don't have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+- [Supported Linux OS](../#linux-os). The SSH user must have passwordless sudo and must not be named `yugabyte` (YBA creates that account during provisioning). YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+  - AWS and GCP: that user must already exist on the image. For standard images, use the image's default login user (for example `ec2-user` or `ubuntu`).
+  - Azure: Azure creates the SSH user you specify when it provisions the VM. For a custom or shared-gallery image, choose a username that does not already exist on the image; Azure rejects the request if that user is already present.
 - [Additional software](../#additional-software)
 - [Additional software for airgapped](../#additional-software-for-airgapped-deployment)
 

--- a/docs/content/v2025.1/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
+++ b/docs/content/v2025.1/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
@@ -25,41 +25,41 @@ Using a YBA-managed Linux version requires connectivity from the database nodes 
 
 For YBA-managed Linux version, YBA manages the creation and provisioning of database nodes, including installing the disk image, configuring the Linux OS, and installing the additional software.
 
-You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes.
+You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes. YBA-managed Linux versions use the image's default login user: `ec2-user` on AWS, `centos` on GCP and Azure.
 
 ## Custom Linux version with Internet connectivity
 
 If you choose to provide your own custom Linux version and your VMs have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled, root-privileged user. YBA uses this user to automatically perform additional Linux configuration, such as creating the `yugabyte` user, updating the file descriptor settings via ulimits, and so on.
+- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
 - [Additional software](../#additional-software)
 
 Take the time now to prepare the Linux disk image.
 
-- Save the SSH-enabled, root-privileged user credentials (username and SSH Private Key Content PEM file).
+- Save the SSH user name and the SSH private key PEM file.
 - Save the disk image IDs for later when installing and configuring YBA.
 
 | Save for later | To configure |
 | :--- | :--- |
-| SSH-enabled, root-privileged user name | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| SSH-enabled, root-privileged Private Key Content PEM file | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| Disk image IDs | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
+| SSH user name | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |
+| SSH private key PEM file | [SSH Key Pairs](../../../configure-yugabyte-platform/aws/#ssh-key-pairs) |
+| Disk image IDs | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |
 
 ## Custom Linux version without Internet connectivity
 
 If you choose to provide your own custom Linux version and your VMs don't have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled, root-privileged user. YBA uses this user to automatically perform additional Linux configuration, such as creating the `yugabyte` user, updating the file descriptor settings via ulimits, and so on.
+- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
 - [Additional software](../#additional-software)
 - [Additional software for airgapped](../#additional-software-for-airgapped-deployment)
 
 Take the time now to prepare the Linux disk image.
 
-- Save the SSH-enabled, root-privileged user credentials (username and SSH Private Key Content PEM file).
+- Save the SSH user name and the SSH private key PEM file.
 - Save the disk image IDs for later when installing and configuring YBA.
 
 | Save for later | To configure |
 | :--- | :--- |
-| SSH-enabled, root-privileged user name | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| SSH-enabled, root-privileged Private Key Content PEM file | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| Disk image IDs | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
+| SSH user name | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |
+| SSH private key PEM file | [SSH Key Pairs](../../../configure-yugabyte-platform/aws/#ssh-key-pairs) |
+| Disk image IDs | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |

--- a/docs/content/v2025.2/yugabyte-platform/configure-yugabyte-platform/aws.md
+++ b/docs/content/v2025.2/yugabyte-platform/configure-yugabyte-platform/aws.md
@@ -145,7 +145,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Amazon Machine Image (AMI) ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. Leave this empty to use the [default SSH user](#ssh-key-pairs).
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`.
 
 1. To configure instances so that the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) _requires_ IMDSv2, select the **Use IMDSv2** option (recommended). If **Use IMDSv2** is not selected, the service accepts both IMDSv1 and IMDSv2 requests.
 
@@ -153,20 +153,24 @@ To add your own machine images to the catalog:
 
 To edit custom Linux versions, remove Linux versions, and set a version as the default to use when creating universes, click **...** for the version you want to modify.
 
+If you plan to use the `us-gov-east-1` and `us-gov-west-1` regions, add your own Linux version using a [supported OS](../../../reference/configuration/operating-systems/). Do not use YugabyteDB Anywhere-managed Linux versions for those regions.
+
 ### SSH Key Pairs
 
 To be able to provision Amazon Elastic Compute Cloud (EC2) instances with YugabyteDB, YugabyteDB Anywhere requires SSH access.
 
-Enter the SSH user and port to use by default for machine images. You can override these values for custom Linux versions that you add to the Linux Version Catalog.
+{{< note title="SSH User and Port" >}}
+You cannot enter SSH user or port in this section; those fields are disabled. Specify them for each Linux version in the [Linux version catalog](#linux-version-catalog). The key pair you configure here is used to authenticate as that SSH user.
+{{< /note >}}
+
+YugabyteDB Anywhere-managed Linux versions use `ec2-user`.
 
 You can manage SSH key pairs in the following ways:
 
 - Enable YugabyteDB Anywhere to create and manage [Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html). In this mode, YugabyteDB Anywhere creates SSH Key Pairs across all the regions you choose to set up and stores the relevant private key part of these locally in order to SSH into future EC2 instances.
-- Use your own existing Key Pairs. To do this, provide the name of the Key Pair, as well as the private key content, and the corresponding SSH user. This information must be the same across all the regions you provision.
+- Use your own existing Key Pairs. To do this, provide the name of the Key Pair, as well as the private key content. This information must be the same across all the regions you provision.
 
 If you use YugabyteDB Anywhere to manage SSH Key Pairs for you and you deploy multiple YugabyteDB Anywhere instances across your environment, then the AWS provider name should be unique for each instance of YugabyteDB Anywhere integrating with a given AWS account.
-
-If you are using a YugabyteDB Anywhere-managed AMI and plan to use the `us-gov-east-1` and `us-gov-west-1` regions, you must set the SSH user to `centos` as these regions use CentOS 7 (as opposed to the default Alma 8 used for other regions). If you don't set the SSH user accordingly, universe deployment to these regions will fail.
 
 ### Advanced
 

--- a/docs/content/v2025.2/yugabyte-platform/configure-yugabyte-platform/aws.md
+++ b/docs/content/v2025.2/yugabyte-platform/configure-yugabyte-platform/aws.md
@@ -145,7 +145,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Amazon Machine Image (AMI) ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`.
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard AMIs, use the image's default login user (for example `ec2-user` or `ubuntu`).
 
 1. To configure instances so that the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) _requires_ IMDSv2, select the **Use IMDSv2** option (recommended). If **Use IMDSv2** is not selected, the service accepts both IMDSv1 and IMDSv2 requests.
 

--- a/docs/content/v2025.2/yugabyte-platform/configure-yugabyte-platform/azure.md
+++ b/docs/content/v2025.2/yugabyte-platform/configure-yugabyte-platform/azure.md
@@ -177,7 +177,7 @@ To add your own machine images to the catalog:
 
 1. Provide a URN to a marketplace image or a shared gallery image by following instructions provided in [Use a shared image gallery](#use-a-shared-image-gallery).
 
-1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. Azure creates this user when it provisions the VM. For a custom or shared-gallery image, choose a username that does not already exist on the image; Azure rejects the request if that user is already present.
 
 1. Click **Add Linux Version**.
 

--- a/docs/content/v2025.2/yugabyte-platform/configure-yugabyte-platform/azure.md
+++ b/docs/content/v2025.2/yugabyte-platform/configure-yugabyte-platform/azure.md
@@ -63,7 +63,6 @@ You need to add the following Azure cloud provider credentials:
 - Resource group name
 - Subscription ID
 - Tenant ID
-- SSH port and user
 
 YugabyteDB Anywhere uses the credentials to automatically provision and deprovision YugabyteDB instances.
 
@@ -178,7 +177,7 @@ To add your own machine images to the catalog:
 
 1. Provide a URN to a marketplace image or a shared gallery image by following instructions provided in [Use a shared image gallery](#use-a-shared-image-gallery).
 
-1. Provide the SSH user and port to use to access the machine image OS. Leave this empty to use the [default SSH user](#ssh-key-pairs).
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
 
 1. Click **Add Linux Version**.
 
@@ -192,7 +191,11 @@ For YugabyteDB Anywhere v2025.1 and later, if you want to deploy a universe on A
 
 To be able to provision cloud instances with YugabyteDB, YugabyteDB Anywhere requires SSH access.
 
-Enter the SSH user and port to use by default for machine images. You can override these values for custom Linux versions that you add to the Linux Version Catalog.
+{{< note title="SSH User and Port" >}}
+You cannot enter SSH user or port in this section; those fields are disabled. Specify them for each Linux version in the [Linux version catalog](#linux-version-catalog). The key pair you configure here is used to authenticate as that SSH user.
+{{< /note >}}
+
+YugabyteDB Anywhere-managed Linux versions use `centos`.
 
 You can manage SSH key pairs in the following ways:
 

--- a/docs/content/v2025.2/yugabyte-platform/configure-yugabyte-platform/gcp.md
+++ b/docs/content/v2025.2/yugabyte-platform/configure-yugabyte-platform/gcp.md
@@ -169,7 +169,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Machine Image ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard images, use the image's default login user (for example `centos` or `ubuntu`).
 
 1. Click **Add Linux Version**.
 

--- a/docs/content/v2025.2/yugabyte-platform/configure-yugabyte-platform/gcp.md
+++ b/docs/content/v2025.2/yugabyte-platform/configure-yugabyte-platform/gcp.md
@@ -169,7 +169,7 @@ To add your own machine images to the catalog:
 
 1. Enter the Machine Image ID to use for each [provider region](#regions).
 
-1. Provide the SSH user and port to use to access the machine image OS. Leave this empty to use the [default SSH user](#ssh-key-pairs).
+1. Provide the SSH user and port to use to access the machine image OS. The SSH user is required; it must have passwordless sudo access and must not be named `yugabyte`. For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `centos` or `ubuntu`.
 
 1. Click **Add Linux Version**.
 
@@ -179,7 +179,11 @@ To edit custom Linux versions, remove Linux versions, and set a version as the d
 
 To be able to provision cloud instances with YugabyteDB, YugabyteDB Anywhere requires SSH access.
 
-Enter the SSH user and port to use by default for machine images. You can override these values for custom Linux versions that you add to the Linux Version Catalog.
+{{< note title="SSH User and Port" >}}
+You cannot enter SSH user or port in this section; those fields are disabled. Specify them for each Linux version in the [Linux version catalog](#linux-version-catalog). The key pair you configure here is used to authenticate as that SSH user.
+{{< /note >}}
+
+YugabyteDB Anywhere-managed Linux versions use `centos`.
 
 You can manage SSH key pairs in the following ways:
 

--- a/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-aws.md
+++ b/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-aws.md
@@ -184,8 +184,10 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-If you will be using your own custom SSH keys, then ensure that you have them when installing YBA and creating your public cloud provider.
+The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+
+If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your AWS cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |
-| Custom SSH keys | [AWS provider configuration](../../../configure-yugabyte-platform/kubernetes/) |
+| Custom SSH keys | [AWS provider configuration](../../../configure-yugabyte-platform/aws/) |

--- a/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
+++ b/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
@@ -103,7 +103,9 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-If you will be using your own custom SSH keys, then ensure that you have them when installing YBA and creating your public cloud provider.
+The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+
+If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your Azure cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |

--- a/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
+++ b/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-azure.md
@@ -103,9 +103,9 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+The key pair authenticates as the SSH user you specify on the Linux version. Azure creates that user when it provisions the VM. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
 
-If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your Azure cloud provider configuration.
+If you will be using your own custom SSH keys, have them when installing YBA and creating your Azure cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |

--- a/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
+++ b/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
@@ -81,7 +81,9 @@ When creating VMs on the public cloud using a [cloud provider configuration](../
 - YBA managed keys. When YBA creates VMs, it will generate and manage the SSH key pair.
 - Provide a custom key pair. Create your own custom SSH keys and upload the SSH keys when you create the provider.
 
-If you will be using your own custom SSH keys, then ensure that you have them when installing YBA and creating your public cloud provider.
+The key pair authenticates as the image's default login user. For the user requirements, see [Software requirements for cloud provider nodes](../../server-nodes-software/software-cloud-provider/).
+
+If you will be using your own custom SSH keys, ensure they are authorized for that user and that you have them when installing YBA and creating your GCP cloud provider configuration.
 
 | Save for later | To configure |
 | :--- | :--- |

--- a/docs/content/v2025.2/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
+++ b/docs/content/v2025.2/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
@@ -25,13 +25,15 @@ Using a YBA-managed Linux version requires connectivity from the database nodes 
 
 For YBA-managed Linux version, YBA manages the creation and provisioning of database nodes, including installing the disk image, configuring the Linux OS, and installing the additional software.
 
-You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes. YBA-managed Linux versions use the image's default login user: `ec2-user` on AWS, `centos` on GCP and Azure.
+You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes. YBA-managed Linux versions use `ec2-user` on AWS and `centos` on GCP and Azure.
 
 ## Custom Linux version with Internet connectivity
 
 If you choose to provide your own custom Linux version and your VMs have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+- [Supported Linux OS](../#linux-os). The SSH user must have passwordless sudo and must not be named `yugabyte` (YBA creates that account during provisioning). YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+  - AWS and GCP: that user must already exist on the image. For standard images, use the image's default login user (for example `ec2-user` or `ubuntu`).
+  - Azure: Azure creates the SSH user you specify when it provisions the VM. For a custom or shared-gallery image, choose a username that does not already exist on the image; Azure rejects the request if that user is already present.
 - [Additional software](../#additional-software)
 
 Take the time now to prepare the Linux disk image.
@@ -49,7 +51,9 @@ Take the time now to prepare the Linux disk image.
 
 If you choose to provide your own custom Linux version and your VMs don't have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+- [Supported Linux OS](../#linux-os). The SSH user must have passwordless sudo and must not be named `yugabyte` (YBA creates that account during provisioning). YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
+  - AWS and GCP: that user must already exist on the image. For standard images, use the image's default login user (for example `ec2-user` or `ubuntu`).
+  - Azure: Azure creates the SSH user you specify when it provisions the VM. For a custom or shared-gallery image, choose a username that does not already exist on the image; Azure rejects the request if that user is already present.
 - [Additional software](../#additional-software)
 - [Additional software for airgapped](../#additional-software-for-airgapped-deployment)
 

--- a/docs/content/v2025.2/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
+++ b/docs/content/v2025.2/yugabyte-platform/prepare/server-nodes-software/software-cloud-provider.md
@@ -25,41 +25,41 @@ Using a YBA-managed Linux version requires connectivity from the database nodes 
 
 For YBA-managed Linux version, YBA manages the creation and provisioning of database nodes, including installing the disk image, configuring the Linux OS, and installing the additional software.
 
-You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes.
+You can proceed directly to installing YBA, creating your cloud provider configuration, and creating universes. YBA-managed Linux versions use the image's default login user: `ec2-user` on AWS, `centos` on GCP and Azure.
 
 ## Custom Linux version with Internet connectivity
 
 If you choose to provide your own custom Linux version and your VMs have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled, root-privileged user. YBA uses this user to automatically perform additional Linux configuration, such as creating the `yugabyte` user, updating the file descriptor settings via ulimits, and so on.
+- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
 - [Additional software](../#additional-software)
 
 Take the time now to prepare the Linux disk image.
 
-- Save the SSH-enabled, root-privileged user credentials (username and SSH Private Key Content PEM file).
+- Save the SSH user name and the SSH private key PEM file.
 - Save the disk image IDs for later when installing and configuring YBA.
 
 | Save for later | To configure |
 | :--- | :--- |
-| SSH-enabled, root-privileged user name | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| SSH-enabled, root-privileged Private Key Content PEM file | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| Disk image IDs | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
+| SSH user name | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |
+| SSH private key PEM file | [SSH Key Pairs](../../../configure-yugabyte-platform/aws/#ssh-key-pairs) |
+| Disk image IDs | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |
 
 ## Custom Linux version without Internet connectivity
 
 If you choose to provide your own custom Linux version and your VMs don't have connectivity to the public Internet, you must provide to YBA a Linux OS disk image with the following pre-installed:
 
-- [Supported Linux OS](../#linux-os) with an SSH-enabled, root-privileged user. YBA uses this user to automatically perform additional Linux configuration, such as creating the `yugabyte` user, updating the file descriptor settings via ulimits, and so on.
+- [Supported Linux OS](../#linux-os) with an SSH-enabled user that has passwordless sudo. The user must not be named `yugabyte` (YBA creates that account during provisioning). For standard cloud images, use the image's default login user (the user the cloud injects the SSH key into), for example `ec2-user`, `centos`, or `ubuntu`. YBA uses this user to configure the OS, including creating the `yugabyte` user and updating ulimits.
 - [Additional software](../#additional-software)
 - [Additional software for airgapped](../#additional-software-for-airgapped-deployment)
 
 Take the time now to prepare the Linux disk image.
 
-- Save the SSH-enabled, root-privileged user credentials (username and SSH Private Key Content PEM file).
+- Save the SSH user name and the SSH private key PEM file.
 - Save the disk image IDs for later when installing and configuring YBA.
 
 | Save for later | To configure |
 | :--- | :--- |
-| SSH-enabled, root-privileged user name | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| SSH-enabled, root-privileged Private Key Content PEM file | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
-| Disk image IDs | [Cloud provider configuration](../../../configure-yugabyte-platform/aws/) |
+| SSH user name | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |
+| SSH private key PEM file | [SSH Key Pairs](../../../configure-yugabyte-platform/aws/#ssh-key-pairs) |
+| Disk image IDs | [Linux version catalog](../../../configure-yugabyte-platform/aws/#linux-version-catalog) |


### PR DESCRIPTION
## Summary

Cloud provider configuration still told readers they could leave SSH user empty on a Linux version and fall back to SSH Key Pairs. The UI requires SSH user on each Linux version and disables the provider-level SSH User and Port fields.

This updates AWS, GCP, and Azure provider pages (stable, v2025.2, v2025.1, v2024.2) so SSH user is documented on the Linux version: required, passwordless sudo, and not `yugabyte`. On AWS and GCP, stock images use the image's default login user. On Azure, Azure creates the SSH user at VM provision time; for a custom or shared-gallery image, that username must not already exist on the image. SSH Key Pairs now states those fields are disabled. GovCloud no longer recommends CentOS 7; add a supported custom Linux version instead of using YugabyteDB Anywhere-managed images there.

Prepare pages (software requirements and Azure node permissions) match that split.

## Test plan

- [x] No runtime behavior change; visually inspected the provider-page diffs against the current YBA UI (SSH user required on Add Linux Version; SSH User/Port disabled under SSH Key Pairs).
