### PR TITLE
[#33444] DocDB: Orchestrate the index-backfill ordering-generation lifecycle from the master

### DIFF
--- a/src/yb/common/doc_hybrid_time.h
+++ b/src/yb/common/doc_hybrid_time.h
@@ -54,6 +54,12 @@ constexpr IntraTxnWriteId kBackfillWriteIdFloor = kIntraTxnWriteIdLimit;
 constexpr IntraTxnWriteId kBackfillWriteIdIndexMax = kMaxWriteId - kBackfillWriteIdFloor - 1;
 static_assert((kBackfillWriteIdFloor | kBackfillWriteIdIndexMax) == kMaxWriteId - 1);
 
+// Version of the floor scheme recorded in each ordering generation
+// (IndexBackfillOrderingGenerationPB.write_id_floor_version): 1 = the scheme above; 0 is
+// reserved as absent/unknown. Bump if the floor or the derivation ever changes, so marked data
+// written under an older scheme cannot be misinterpreted.
+constexpr uint32_t kIndexBackfillWriteIdFloorVersion = 1;
+
 // An aggressive upper bound on the length of a DocDB-encoded hybrid time with a write id.
 // This could happen in the degenerate case when all three VarInts in encoded representation of a
 // DocHybridTime take 10 bytes (the maximum length for a VarInt-encoded int64_t).

--- a/src/yb/integration-tests/fixed_hybrid_time_write_id-itest.cc
+++ b/src/yb/integration-tests/fixed_hybrid_time_write_id-itest.cc
@@ -285,6 +285,7 @@ TEST_F(FixedHybridTimeWriteIdITest, LeaderChangePreservesDistinctWriteIds) {
   ASSERT_OK(WaitUntilTabletHasLeader(
       cluster_.get(), tablet_id, CoarseMonoClock::Now() + 10s * kTimeMultiplier,
       RequireLeaderIsReady::kTrue));
+  ASSERT_OK(SetOrderingGenerationOnAllReplicas(tablet_id, MakeActiveOrderingGeneration()));
 
   // W1 under the original leader: two distinct keys in one marked op share the op's Raft-index
   // write ID ("dup" is the key W2 collides with later; "stable" pins the shared-ID property).
@@ -344,6 +345,7 @@ TEST_F(FixedHybridTimeWriteIdITest, MasterSplitRefusedWhileOrderingGenerationAct
   ASSERT_OK(WaitUntilTabletHasLeader(
       cluster_.get(), tablet_id, CoarseMonoClock::Now() + 10s * kTimeMultiplier,
       RequireLeaderIsReady::kTrue));
+  ASSERT_OK(SetOrderingGenerationOnAllReplicas(tablet_id, MakeActiveOrderingGeneration()));
 
   // Give the tablet hash-spread data and SSTs so it is a viable split candidate.
   const auto op_id = ASSERT_RESULT(
@@ -355,9 +357,9 @@ TEST_F(FixedHybridTimeWriteIdITest, MasterSplitRefusedWhileOrderingGenerationAct
   const auto table_id = table_.table()->id();
   ASSERT_EQ(ListActiveTabletIdsForTable(cluster_.get(), table_id).size(), 1);
 
-  // With the generation active on every replica, the master accepts the split request but the
-  // tablet-side fence rejects the split operation before it is appended to Raft.
-  ASSERT_OK(SetOrderingGenerationOnAllReplicas(tablet_id, MakeActiveOrderingGeneration()));
+  // The generation has been active on every replica since before the writes; the master
+  // accepts the split request but the tablet-side fence rejects the split operation before it
+  // is appended to Raft.
   ASSERT_OK(InvokeSplitTabletRpc(
       cluster_.get(), tablet_id, MonoDelta::FromSeconds(30) * kTimeMultiplier));
   SleepFor(MonoDelta::FromSeconds(3) * kTimeMultiplier);
@@ -393,9 +395,9 @@ TEST_F(FixedHybridTimeWriteIdITest, OrderingGenerationSurvivesRemoteBootstrap) {
       cluster_.get(), tablet_id, CoarseMonoClock::Now() + 10s * kTimeMultiplier,
       RequireLeaderIsReady::kTrue));
 
+  ASSERT_OK(SetOrderingGenerationOnAllReplicas(tablet_id, MakeActiveOrderingGeneration()));
   const auto op_id = ASSERT_RESULT(SendMarkedWrite(tablet_id, kWriteHT, {{"row", "value"}}));
   ASSERT_OK(WaitAllReplicasApplied(tablet_id, op_id));
-  ASSERT_OK(SetOrderingGenerationOnAllReplicas(tablet_id, MakeActiveOrderingGeneration()));
 
   // Tombstone one follower; it stays in the Raft config, so the leader remote-bootstraps it
   // back. The recovered replica's superblock comes from the leader and must carry the
@@ -464,13 +466,13 @@ TEST_F(FixedHybridTimeWriteIdITest, SplitWithFenceBypassedPreservesPerKeyWriteId
   ASSERT_OK(WaitUntilTabletHasLeader(
       cluster_.get(), tablet_id, CoarseMonoClock::Now() + 10s * kTimeMultiplier,
       RequireLeaderIsReady::kTrue));
+  ASSERT_OK(SetOrderingGenerationOnAllReplicas(tablet_id, MakeActiveOrderingGeneration()));
 
   const auto op_id = ASSERT_RESULT(
       SendMarkedWriteSpreadHashes(tablet_id, kWriteHT, /* num_keys= */ 256));
   ASSERT_OK(WaitAllReplicasApplied(tablet_id, op_id));
   ASSERT_OK(cluster_->FlushTablets());
   ASSERT_OK(WaitForAnySstFiles(cluster_.get(), tablet_id));
-  ASSERT_OK(SetOrderingGenerationOnAllReplicas(tablet_id, MakeActiveOrderingGeneration()));
 
   const auto table_id = table_.table()->id();
   ASSERT_OK(InvokeSplitTabletRpc(

--- a/src/yb/integration-tests/tablet-split-itest.cc
+++ b/src/yb/integration-tests/tablet-split-itest.cc
@@ -973,10 +973,12 @@ TEST_F(TabletSplitITest, MaxCreateTabletsPerTs) {
   auto table = catalog_mgr->GetTableInfo(table_->id());
 
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_max_create_tablets_per_ts) = 1;
-  ASSERT_NOK(master.tablet_split_manager().ValidateSplitCandidateTable(table));
+  ASSERT_NOK(master.tablet_split_manager().ValidateSplitCandidateTable(
+      table, /* indexed_table= */ nullptr));
 
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_max_create_tablets_per_ts) = 2;
-  ASSERT_OK(master.tablet_split_manager().ValidateSplitCandidateTable(table));
+  ASSERT_OK(master.tablet_split_manager().ValidateSplitCandidateTable(
+      table, /* indexed_table= */ nullptr));
 }
 
 TEST_F(TabletSplitITest, SplitDuringReplicaOffline) {
@@ -2765,23 +2767,26 @@ TEST_F(TabletSplitSingleServerITest, AutoSplitNotValidOnceCheckedForTtl) {
   auto table_info = ASSERT_NOTNULL(catalog_mgr->GetTableInfo(table_->id()));
 
   // Candidate table should start as a valid split candidate.
-  ASSERT_OK(split_manager->ValidateSplitCandidateTable(table_info));
+  ASSERT_OK(split_manager->ValidateSplitCandidateTable(
+      table_info, /* indexed_table= */ nullptr));
 
   // State that table should not be split for the next 1 second.
   // Candidate table should no longer be valid.
   split_manager->DisableSplittingForTtlTable(table_->id());
-  ASSERT_NOK(split_manager->ValidateSplitCandidateTable(table_info));
+  ASSERT_NOK(split_manager->ValidateSplitCandidateTable(
+      table_info, /* indexed_table= */ nullptr));
 
   // After 2 seconds, table is a valid split candidate again.
   SleepFor(kSecondsBetweenChecks * 2s);
-  ASSERT_OK(split_manager->ValidateSplitCandidateTable(table_info));
+  ASSERT_OK(split_manager->ValidateSplitCandidateTable(
+      table_info, /* indexed_table= */ nullptr));
 
   // State again that table should not be split for the next 1 second.
   // Candidate table should still be a valid candidate if ignore_disabled_list
   // is true (e.g. in the case of manual tablet splitting).
   split_manager->DisableSplittingForTtlTable(table_->id());
-  ASSERT_OK(split_manager->ValidateSplitCandidateTable(table_info,
-      master::IgnoreDisabledList::kTrue));
+  ASSERT_OK(split_manager->ValidateSplitCandidateTable(
+      table_info, /* indexed_table= */ nullptr, master::IgnoreDisabledList::kTrue));
 }
 
 TEST_F(TabletSplitSingleServerITest, ScheduledFullCompactionsDoNotBlockSplit) {

--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -32,6 +32,7 @@
 #include "yb/tserver/tserver_admin.proxy.h"
 
 #include "yb/common/common_util.h"
+#include "yb/common/doc_hybrid_time.h"
 #include "yb/common/wire_protocol.h"
 
 #include "yb/docdb/doc_rowwise_iterator.h"
@@ -1076,12 +1077,144 @@ Status BackfillTable::DoBackfill() {
     VLOG_WITH_PREFIX(1) << "starting backfill with timestamp: " << read_time_for_backfill();
   }
 
+  if (unique_index_backfill_mode() == UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_SKIP_ALL &&
+      !ordering_generation_activated_.exchange(true)) {
+    // SKIP_ALL writes are marked (Raft-index write IDs), which every index tablet only accepts
+    // under an active ordering generation -- activate before the first chunk. The job continues
+    // into LaunchBackfillTablets through OrderingGenerationUpdateDone once every tablet acks.
+    // On failover resume this re-runs: re-activation is idempotent (the base moves up).
+    return LaunchOrderingGenerationActivation();
+  }
+  return LaunchBackfillTablets();
+}
+
+Status BackfillTable::LaunchBackfillTablets() {
   auto tablets = VERIFY_RESULT(indexed_table_->GetTablets());
   num_tablets_.store(tablets.size(), std::memory_order_release);
   tablets_pending_.store(tablets.size(), std::memory_order_release);
   for (auto& tablet : tablets) {
     auto backfill_tablet = std::make_shared<BackfillTablet>(shared_from_this(), std::move(tablet));
     RETURN_NOT_OK(backfill_tablet->Launch());
+  }
+  return Status::OK();
+}
+
+Result<std::vector<scoped_refptr<TableInfo>>> BackfillTable::GetUniqueIndexTables(
+    RestrictToIndexesToBuild restrict_to_indexes_to_build) const {
+  const auto to_build = indexes_to_build();
+  std::vector<scoped_refptr<TableInfo>> tables;
+  for (const auto& index_info : index_infos_) {
+    if (!index_info.is_unique()) {
+      continue;
+    }
+    if (restrict_to_indexes_to_build && to_build.count(index_info.table_id()) == 0) {
+      continue;
+    }
+    auto res = master_->catalog_manager()->FindTableById(index_info.table_id());
+    if (!res && res.status().IsNotFound()) {
+      // Concurrent DROP INDEX; the job will fail through the missing-IndexInfoPB path.
+      LOG_WITH_PREFIX(WARNING) << "Index " << index_info.table_id() << " was not found; "
+                               << "skipping for ordering-generation update: " << res.status();
+      continue;
+    }
+    tables.push_back(VERIFY_RESULT_PREPEND(
+        std::move(res), Format("Could not find the index table $0", index_info.table_id())));
+  }
+  return tables;
+}
+
+Status BackfillTable::LaunchOrderingGenerationActivation() {
+  if (indexed_table_->GetTableType() != TableType::PGSQL_TABLE_TYPE) {
+    // The SKIP_ALL write path is PGSQL-only (the backfill request mode rides the YSQL chunk
+    // requests; YCQL backfill writes are never marked), so generations would only fence
+    // splits without protecting anything. Reachable today only via the TEST mode override.
+    return LaunchBackfillTablets();
+  }
+  auto index_tables = VERIFY_RESULT(GetUniqueIndexTables(RestrictToIndexesToBuild::kTrue));
+  if (index_tables.empty()) {
+    return LaunchBackfillTablets();
+  }
+
+  // Fence and drain index-table splitting before activating. The tablet-side fences (the
+  // pending-split rejection of CHANGE_METADATA_OP and, once active, the generation split
+  // fence) close the append-time races; this master-side drain removes the split/activation
+  // TOCTOU window entirely under a single master leader, and the persisted fence in the
+  // tablet-split manager (backfill-job state) keeps splits excluded across failover.
+  auto& tablet_split_manager = master_->tablet_split_manager();
+  const CoarseTimePoint deadline =
+      CoarseMonoClock::Now() +
+      FLAGS_index_backfill_tablet_split_completion_timeout_sec * 1s * kTimeMultiplier;
+  for (const auto& index_table : index_tables) {
+    tablet_split_manager.DisableSplittingForBackfillingTable(index_table->id());
+    while (!tablet_split_manager.IsTabletSplittingComplete(
+        *index_table, false /* wait_for_parent_deletion */, deadline)) {
+      if (CoarseMonoClock::Now() > deadline) {
+        return STATUS(
+            TimedOut,
+            "Index-tablet splitting did not complete after being disabled; cannot safely "
+            "activate the ordering generation.");
+      }
+      SleepFor(FLAGS_index_backfill_tablet_split_completion_poll_freq_ms * 1ms * kTimeMultiplier);
+    }
+  }
+
+  std::vector<std::pair<TabletInfoPtr, TableId>> tablets;
+  for (const auto& index_table : index_tables) {
+    for (auto& tablet : VERIFY_RESULT(index_table->GetTablets())) {
+      tablets.emplace_back(std::move(tablet), index_table->id());
+    }
+  }
+  if (tablets.empty()) {
+    return LaunchBackfillTablets();
+  }
+
+  LOG_WITH_PREFIX(INFO) << "Activating index-backfill ordering generation on " << tablets.size()
+                        << " index tablet(s) before launching backfill chunks";
+  activation_tablets_pending_.store(tablets.size(), std::memory_order_release);
+  for (auto& [tablet, index_table_id] : tablets) {
+    auto task = std::make_shared<UpdateOrderingGenerationForTablet>(
+        shared_from_this(), tablet, index_table_id, tablet::ActivateGeneration::kTrue,
+        NotifyBackfillTable::kTrue, epoch_);
+    RETURN_NOT_OK(task->Launch());
+  }
+  return Status::OK();
+}
+
+void BackfillTable::OrderingGenerationUpdateDone(
+    const Status& status, const TabletId& tablet_id) {
+  if (done()) {
+    return;
+  }
+  if (!status.ok()) {
+    LOG_WITH_PREFIX(WARNING) << "Ordering-generation activation failed for tablet " << tablet_id
+                             << ": " << status << "; aborting backfill";
+    WARN_NOT_OK(Abort(), "Failed to abort backfill after activation failure");
+    return;
+  }
+  if (--activation_tablets_pending_ == 0) {
+    LOG_WITH_PREFIX(INFO) << "Ordering generation active on all index tablets; "
+                          << "launching backfill chunks";
+    Status s = LaunchBackfillTablets();
+    if (!s.ok()) {
+      LOG_WITH_PREFIX(WARNING) << "Failed to launch backfill after activation: " << s;
+      WARN_NOT_OK(Abort(), "Failed to abort backfill");
+    }
+  }
+}
+
+Status BackfillTable::SendRpcToReleaseOrderingGenerations() {
+  // Release on every unique index of the job, built or not: activation may have partially
+  // succeeded before a failure. Fire-and-forget -- the tserver metadata validator and master
+  // reload reconciliation converge any straggler.
+  auto index_tables = VERIFY_RESULT(GetUniqueIndexTables(RestrictToIndexesToBuild::kFalse));
+  for (const auto& index_table : index_tables) {
+    for (const auto& tablet : VERIFY_RESULT(index_table->GetTablets())) {
+      auto task = std::make_shared<UpdateOrderingGenerationForTablet>(
+          shared_from_this(), tablet, index_table->id(), tablet::ActivateGeneration::kFalse,
+          NotifyBackfillTable::kFalse, epoch_);
+      WARN_NOT_OK(task->Launch(), "Failed to send ordering-generation release");
+    }
+    master_->tablet_split_manager().ReenableSplittingForBackfillingTable(index_table->id());
   }
   return Status::OK();
 }
@@ -1316,6 +1449,13 @@ Status BackfillTable::UpdateIndexPermissionsForIndexes() {
   RETURN_NOT_OK(ClearCheckpointStateInTablets());
   indexed_table_->ClearIsBackfilling();
   master_->tablet_split_manager().ReenableSplittingForBackfillingTable(indexed_table_->id());
+  if (unique_index_backfill_mode() == UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_SKIP_ALL) {
+    // Terminal funnel: every success/failure/abort path of a SKIP_ALL job passes through here,
+    // so the ordering generations are released (and index-table splitting re-enabled) on all of
+    // them. At-least-once; backstops converge anything this misses (e.g. master death here).
+    WARN_NOT_OK(
+        SendRpcToReleaseOrderingGenerations(), "Failed to release ordering generations");
+  }
 
   VLOG(1) << "Sending alter table requests to the Indexed table";
   RETURN_NOT_OK(master_->catalog_manager_impl()->SendAlterTableRequest(indexed_table_, epoch_));
@@ -1664,6 +1804,115 @@ void GetSafeTimeForTablet::UnregisterAsyncTaskCallback() {
   }
   WARN_NOT_OK(backfill_table_->UpdateSafeTime(status, safe_time),
     "Could not UpdateSafeTime");
+}
+
+UpdateOrderingGenerationForTablet::UpdateOrderingGenerationForTablet(
+    std::shared_ptr<BackfillTable> backfill_table,
+    const TabletInfoPtr& tablet,
+    const TableId& index_table_id,
+    tablet::ActivateGeneration activate,
+    NotifyBackfillTable notify_backfill_table,
+    LeaderEpoch epoch)
+    : RetryingTSRpcTaskWithTable(
+          backfill_table->master(), backfill_table->threadpool(),
+          std::unique_ptr<TSPicker>(new PickLeaderReplica(tablet)), tablet->table(),
+          std::move(epoch),
+          /* async_task_throttler */ nullptr),
+      backfill_table_(backfill_table),
+      tablet_(tablet),
+      index_table_id_(index_table_id),
+      activate_(activate),
+      notify_backfill_table_(notify_backfill_table) {
+  deadline_ = MonoTime::Max();  // Single-attempt deadline comes from ComputeDeadline().
+}
+
+Status UpdateOrderingGenerationForTablet::Launch() {
+  tablet_->table()->AddTask(shared_from_this());
+  RETURN_NOT_OK_PREPEND(
+      Run(),
+      Substitute("Failed to send UpdateOrderingGeneration request for $0. ",
+                 tablet_->ToString()));
+  VLOG(3) << "Started UpdateOrderingGenerationForTablet : " << this->description();
+  return Status::OK();
+}
+
+std::string UpdateOrderingGenerationForTablet::description() const {
+  return Format(
+      "$0 ordering generation for index tablet $1 of $2",
+      activate_ ? "Activate" : "Release", tablet_id(), index_table_id_);
+}
+
+TabletId UpdateOrderingGenerationForTablet::tablet_id() const { return tablet_->id(); }
+
+bool UpdateOrderingGenerationForTablet::SendRequest(int attempt) {
+  ADOPT_WAIT_STATE(backfill_table_->wait_state());
+  tablet::ChangeMetadataRequestPB req;
+  req.set_dest_uuid(permanent_uuid());
+  req.set_tablet_id(tablet_->tablet_id());
+  req.set_propagated_hybrid_time(master_->clock()->Now().ToUint64());
+  auto* generation_op = req.mutable_index_backfill_ordering_generation();
+  generation_op->set_table_id(index_table_id_);
+  generation_op->set_activate(activate_);
+  if (activate_) {
+    // History at and above backfill_read_time.Decremented() must survive until verification;
+    // the record carries the barrier, enforcement lands with the verification read fence.
+    generation_op->set_retention_barrier_ht(
+        backfill_table_->read_time_for_backfill().Decremented().ToUint64());
+    generation_op->set_write_id_floor_version(kIndexBackfillWriteIdFloorVersion);
+  }
+
+  ts_admin_proxy_->UpdateIndexBackfillOrderingGenerationAsync(
+      req, &resp_, &rpc_, BindRpcCallback());
+  VLOG(1) << "Send " << description() << " to " << permanent_uuid()
+          << " (attempt " << attempt << "):\n" << req.DebugString();
+  return true;
+}
+
+void UpdateOrderingGenerationForTablet::HandleResponse(int attempt) {
+  ADOPT_WAIT_STATE(backfill_table_->wait_state());
+  Status status = Status::OK();
+  if (resp_.has_error()) {
+    status = StatusFromPB(resp_.error().status());
+    switch (resp_.error().code()) {
+      case TabletServerErrorPB::TABLET_NOT_FOUND:
+      case TabletServerErrorPB::OPERATION_NOT_SUPPORTED:
+        LOG(WARNING) << "TS " << permanent_uuid() << ": " << description()
+                     << " failed, no further retry: " << status;
+        TransitionToFailedState(MonitoredTaskState::kRunning, status);
+        break;
+      default:
+        LOG(WARNING) << "TS " << permanent_uuid() << ": " << description() << " failed: "
+                     << status << " code " << resp_.error().code();
+        break;
+    }
+  } else {
+    TransitionToCompleteState();
+    VLOG(1) << "TS " << permanent_uuid() << ": " << description() << " complete";
+  }
+
+  server::UpdateClock(resp_, master_->clock());
+}
+
+void UpdateOrderingGenerationForTablet::UnregisterAsyncTaskCallback() {
+  ADOPT_WAIT_STATE(backfill_table_->wait_state());
+  if (state() == MonitoredTaskState::kAborted) {
+    // Deliberately no join notification (same shape as GetSafeTimeForTablet): external task
+    // aborts accompany leadership loss or table teardown, where the job object is dying with
+    // us; notifying could double-drive a job that is already unwinding.
+    VLOG(1) << " was aborted";
+    return;
+  }
+  if (!notify_backfill_table_) {
+    return;
+  }
+
+  Status status;
+  if (resp_.has_error()) {
+    status = StatusFromPB(resp_.error().status());
+  } else if (state() != MonitoredTaskState::kComplete) {
+    status = STATUS_FORMAT(InternalError, "$0 in state $1", description(), state());
+  }
+  backfill_table_->OrderingGenerationUpdateDone(status, tablet_->tablet_id());
 }
 
 BackfillChunk::BackfillChunk(std::shared_ptr<BackfillTablet> backfill_tablet,

--- a/src/yb/master/backfill_index.h
+++ b/src/yb/master/backfill_index.h
@@ -195,12 +195,35 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
 
   Status Abort(bool from_liveness = false);
 
+  // Join point for waited ordering-generation activation: called by
+  // UpdateOrderingGenerationForTablet once per index tablet. Any failure aborts the job;
+  // the last success launches the backfill chunks.
+  void OrderingGenerationUpdateDone(const Status& status, const TabletId& tablet_id);
+
  private:
   void LaunchBackfillOrAbort();
   Status WaitForTabletSplitting();
   Status DoLaunchBackfill();
   Status LaunchComputeSafeTimeForRead() EXCLUDES(mutex_);
   Status DoBackfill();
+
+  // Resolves the unique-index tables of this job (activation/release targets). Missing tables
+  // (concurrent DROP INDEX) are skipped, matching AllowCompactionsToGCDeleteMarkers.
+  Result<std::vector<scoped_refptr<TableInfo>>> GetUniqueIndexTables(
+      RestrictToIndexesToBuild restrict_to_indexes_to_build) const;
+
+  // SKIP_ALL only: fences and drains index-table splitting, then fans out waited activation
+  // tasks over every tablet of every unique index in the job. The job continues into
+  // LaunchBackfillTablets through OrderingGenerationUpdateDone.
+  Status LaunchOrderingGenerationActivation();
+
+  // Launches the per-tablet backfill chunk drivers (the tail of the pre-activation DoBackfill).
+  Status LaunchBackfillTablets();
+
+  // SKIP_ALL only: fire-and-forget release of the ordering generation on every unique-index
+  // tablet; runs in the terminal funnel. Stragglers converge via the tserver metadata
+  // validator and master reload reconciliation.
+  Status SendRpcToReleaseOrderingGenerations();
 
   Status MarkAllIndexesAsFailed();
   Status MarkAllIndexesAsSuccess();
@@ -253,6 +276,8 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
   std::atomic_bool timestamp_chosen_{false};
   std::atomic<size_t> tablets_pending_;
   std::atomic<size_t> num_tablets_;
+  std::atomic<size_t> activation_tablets_pending_{0};
+  std::atomic_bool ordering_generation_activated_{false};
   std::atomic_bool using_table_locks_{false};
   std::shared_ptr<BackfillTableJob> backfill_job_;
   mutable simple_spinlock mutex_;
@@ -409,6 +434,49 @@ class GetSafeTimeForTablet : public RetryingTSRpcTaskWithTable {
   const std::shared_ptr<BackfillTable> backfill_table_;
   const TabletInfoPtr tablet_;
   const HybridTime min_cutoff_;
+};
+
+// Activates or releases the index-backfill write-ID ordering generation on one index tablet
+// via the UpdateIndexBackfillOrderingGeneration admin RPC (a Raft-replicated
+// ChangeMetadataOperation on the tablet). Activation is waited: notify_backfill_table joins
+// back into BackfillTable::OrderingGenerationUpdateDone so the job proceeds only once every
+// index tablet acked, and fails otherwise. Release is fire-and-forget (idempotent,
+// self-healing backstops converge stragglers).
+class UpdateOrderingGenerationForTablet : public RetryingTSRpcTaskWithTable {
+ public:
+  UpdateOrderingGenerationForTablet(
+      std::shared_ptr<BackfillTable> backfill_table,
+      const TabletInfoPtr& tablet,
+      const TableId& index_table_id,
+      tablet::ActivateGeneration activate,
+      NotifyBackfillTable notify_backfill_table,
+      LeaderEpoch epoch);
+
+  Status Launch();
+
+  server::MonitoredTaskType type() const override {
+    return server::MonitoredTaskType::kUpdateIndexBackfillOrderingGeneration;
+  }
+
+  std::string type_name() const override { return "Update index-backfill ordering generation"; }
+
+  std::string description() const override;
+
+ private:
+  TabletId tablet_id() const override;
+
+  void HandleResponse(int attempt) override;
+
+  bool SendRequest(int attempt) override;
+
+  void UnregisterAsyncTaskCallback() override;
+
+  tserver::ChangeMetadataResponsePB resp_;
+  const std::shared_ptr<BackfillTable> backfill_table_;
+  const TabletInfoPtr tablet_;
+  const TableId index_table_id_;
+  const tablet::ActivateGeneration activate_;
+  const NotifyBackfillTable notify_backfill_table_;
 };
 
 // A background task which is responsible for backfilling rows in the partitions

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -947,11 +947,14 @@ IndexStatusPB::BackfillStatus GetBackfillStatus(IndexPermissions permissions) {
     case INDEX_PERM_DELETE_ONLY:                     [[fallthrough]];
     case INDEX_PERM_WRITE_AND_DELETE:                [[fallthrough]];
     case INDEX_PERM_DO_BACKFILL:                     [[fallthrough]];
-    case INDEX_PERM_WRITE_AND_DELETE_WHILE_REMOVING: [[fallthrough]];
-    case INDEX_PERM_DELETE_ONLY_WHILE_REMOVING:      [[fallthrough]];
-    case INDEX_PERM_INDEX_UNUSED:                    [[fallthrough]];
     case INDEX_PERM_NOT_USED:
       return IndexStatusPB::BACKFILL_UNKNOWN;
+    // Removal-path permissions: a failed or dropped index can never reach
+    // READ_WRITE_AND_DELETE, so report the backfill as terminally failed.
+    case INDEX_PERM_WRITE_AND_DELETE_WHILE_REMOVING: [[fallthrough]];
+    case INDEX_PERM_DELETE_ONLY_WHILE_REMOVING:      [[fallthrough]];
+    case INDEX_PERM_INDEX_UNUSED:
+      return IndexStatusPB::BACKFILL_FAILED;
   }
   FATAL_INVALID_ENUM_VALUE(IndexPermissions, permissions);
 }
@@ -3733,8 +3736,14 @@ Status CatalogManager::ValidateSplitCandidateUnlocked(
     const TabletInfoPtr& tablet, const ManualSplit is_manual_split) {
   const IgnoreDisabledList ignore_disabled_list { is_manual_split.get() };
   const IgnoreVectorIndexesValidation ignore_vector_indexes_validation { is_manual_split.get() };
+  // The split manager's table validation must not take catalog locks (this path already holds
+  // mutex_); resolve the indexed table for its backfill fence here, under the held lock.
+  TableInfoPtr indexed_table;
+  if (tablet->table()->is_index()) {
+    indexed_table = GetTableInfoUnlocked(tablet->table()->indexed_table_id());
+  }
   RETURN_NOT_OK(master_->tablet_split_manager().ValidateSplitCandidateTable(
-      tablet->table(), ignore_disabled_list, ignore_vector_indexes_validation));
+      tablet->table(), indexed_table, ignore_disabled_list, ignore_vector_indexes_validation));
   RETURN_NOT_OK(XReplValidateSplitCandidateTableUnlocked(tablet->table()->id()));
 
   const IgnoreTtlValidation ignore_ttl_validation { is_manual_split.get() };

--- a/src/yb/master/master_ddl.proto
+++ b/src/yb/master/master_ddl.proto
@@ -366,8 +366,12 @@ message GetBackfillStatusRequestPB {
 
 message IndexStatusPB {
   enum BackfillStatus {
-    BACKFILL_UNKNOWN = 0; // Unspecified state.
+    BACKFILL_UNKNOWN = 0; // Unspecified state (including backfill still in progress).
     BACKFILL_SUCCESS = 1; // Backfill succeeded.
+    // Backfill can no longer succeed: the index is failed or being removed. Lets tservers
+    // release local backfill state (e.g. the index-backfill ordering generation) for indexes
+    // that will never reach BACKFILL_SUCCESS.
+    BACKFILL_FAILED = 2;
   }
 
   optional TableIdentifierPB index_table = 1;

--- a/src/yb/master/master_fwd.h
+++ b/src/yb/master/master_fwd.h
@@ -132,7 +132,9 @@ using TabletInfos = std::vector<TabletInfoPtr>;
 struct SnapshotScheduleRestoration;
 using SnapshotScheduleRestorationPtr = std::shared_ptr<SnapshotScheduleRestoration>;
 
+YB_STRONGLY_TYPED_BOOL(NotifyBackfillTable);
 YB_STRONGLY_TYPED_BOOL(RegisteredThroughHeartbeat);
+YB_STRONGLY_TYPED_BOOL(RestrictToIndexesToBuild);
 
 // Used to indicate whether inactive tablets should be included in Rpcs such as GetTableLocations.
 // Inactive tablets are parents of split children, that may no longer be allowed to

--- a/src/yb/master/stateful_service-test.cc
+++ b/src/yb/master/stateful_service-test.cc
@@ -52,7 +52,8 @@ TEST_F(StatefulServiceTest, TestCreateStatefulService) {
   ASSERT_EQ(tablets.size(), 1);
 
   // Validate the tablet cannot be split.
-  ASSERT_NOK(master->tablet_split_manager().ValidateSplitCandidateTable(service_table));
+  ASSERT_NOK(master->tablet_split_manager().ValidateSplitCandidateTable(
+      service_table, /* indexed_table= */ nullptr));
 }
 }  // namespace master
 }  // namespace yb

--- a/src/yb/master/tablet_split_manager.cc
+++ b/src/yb/master/tablet_split_manager.cc
@@ -259,6 +259,7 @@ Status TabletSplitManager::ValidatePartitioningVersion(const TableInfo& table) {
 
 Status TabletSplitManager::ValidateSplitCandidateTable(
     const TableInfoPtr& table,
+    const TableInfoPtr& indexed_table,
     const IgnoreDisabledList ignore_disabled_lists,
     const IgnoreVectorIndexesValidation ignore_vector_indexes_validation) {
   if (PREDICT_FALSE(FLAGS_TEST_validate_all_tablet_candidates)) {
@@ -361,6 +362,32 @@ Status TabletSplitManager::ValidateSplitCandidateTable(
   if (table->IsBackfilling()) {
     return STATUS_EC_FORMAT(IllegalState, MasterError(MasterErrorPB::SPLIT_OR_BACKFILL_IN_PROGRESS),
                             "Backfill operation in progress, table: $0", *table);
+  }
+
+  // A unique index built in SKIP_ALL mode must not split between ordering-generation
+  // activation and release: verification scans a stable tablet set. IsBackfilling() and the
+  // disabled list above cover the indexed table and are in-memory only (lost on failover);
+  // this check reads the indexed table's durable backfill-job state, so the fence holds across
+  // master failover. The tablet-side generation fence is the fail-closed layer beneath it.
+  // The indexed table is caller-resolved (see the header): taking catalog locks here would
+  // recurse on the catalog mutex when entered through ValidateSplitCandidateUnlocked.
+  if (table->is_index() && indexed_table) {
+    auto indexed_lock = indexed_table->LockForRead();
+    for (const auto& backfill_job : indexed_lock->pb.backfill_jobs()) {
+      if (backfill_job.unique_index_backfill_mode() !=
+              UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_SKIP_ALL ||
+          backfill_job.backfill_state().count(table->id()) == 0) {
+        continue;
+      }
+      auto status = STATUS_EC_FORMAT(
+          IllegalState, MasterError(MasterErrorPB::SPLIT_OR_BACKFILL_IN_PROGRESS),
+          "Unique-index backfill with deferred verification in progress; splitting is fenced "
+          "until the ordering generation is released, index table: $0", *table);
+      YB_LOG_EVERY_N_SECS(INFO, 30)
+          << "Skipping tablet splitting for index table " << table->ToString() << ": "
+          << status;
+      return status;
+    }
   }
 
   // Check if this table hosts stateful services. Only sys_catalog and ysql tables are currently
@@ -863,7 +890,12 @@ void TabletSplitManager::DoSplitting(
   // https://github.com/yugabyte/yugabyte-db/issues/11459
   std::vector<TableInfoPtr> valid_tables;
   for (const auto& table : tables) {
-    Status status = ValidateSplitCandidateTable(table);
+    // Background path: no catalog mutex held, so the locking lookup is safe here.
+    TableInfoPtr indexed_table;
+    if (table->is_index()) {
+      indexed_table = catalog_manager_.GetTableInfo(table->indexed_table_id());
+    }
+    Status status = ValidateSplitCandidateTable(table, indexed_table);
     if (!status.ok()) {
       VLOG(3) << "Skipping table for splitting. " << status;
       continue;

--- a/src/yb/master/tablet_split_manager.h
+++ b/src/yb/master/tablet_split_manager.h
@@ -61,8 +61,15 @@ class TabletSplitManager {
 
   // Table-level checks for splitting that are checked not only as a best-effort
   // filter, but also after acquiring the table/tablet locks in CatalogManager::DoSplit.
+  //
+  // indexed_table: when `table` is an index, the resolved TableInfo of its indexed table
+  // (nullptr when not an index or when the indexed table is gone). Resolved by the caller
+  // because callers differ in catalog-mutex state -- this function is reachable from
+  // CatalogManager::ValidateSplitCandidateUnlocked with the catalog mutex already held, so it
+  // must not call locking CatalogManager accessors itself.
   Status ValidateSplitCandidateTable(
       const TableInfoPtr& table,
+      const TableInfoPtr& indexed_table,
       IgnoreDisabledList ignore_disabled_list = IgnoreDisabledList::kFalse,
       IgnoreVectorIndexesValidation ignore_vector_indexes_validation =
           IgnoreVectorIndexesValidation::kFalse);

--- a/src/yb/server/monitored_task.h
+++ b/src/yb/server/monitored_task.h
@@ -101,7 +101,8 @@ YB_DEFINE_ENUM(MonitoredTaskType,
   (kXClusterHandleNewSchema)
   (kXClusterInboundReplicationGroupSetup)
   (kXClusterTableSetup)
-  (kXClusterFailover));
+  (kXClusterFailover)
+  (kUpdateIndexBackfillOrderingGeneration));
 
 class MonitoredTask : public std::enable_shared_from_this<MonitoredTask> {
  public:

--- a/src/yb/tablet/operations.proto
+++ b/src/yb/tablet/operations.proto
@@ -175,6 +175,24 @@ message ChangeMetadataRequestPB {
 
   // Index inception / birth hybrid time, sent as part of the BackfillDone RPC.
   optional fixed64 birth_time = 23;
+
+  // Activates or releases the tablet's index-backfill write-ID ordering generation
+  // (IndexBackfillOrderingGenerationPB in the superblock). On activation, the generation's
+  // base_op_index is this operation's own Raft index, so every replica -- including WAL replay
+  // -- derives the same base without consulting runtime state.
+  optional IndexBackfillOrderingGenerationOpPB index_backfill_ordering_generation = 24;
+}
+
+message IndexBackfillOrderingGenerationOpPB {
+  // The index table the generation covers.
+  optional bytes table_id = 1;
+
+  // True activates a generation; false releases any active one (idempotent both ways).
+  optional bool activate = 2;
+
+  // Copied into the persisted record on activation; see IndexBackfillOrderingGenerationPB.
+  optional fixed64 retention_barrier_ht = 3;
+  optional uint32 write_id_floor_version = 4;
 }
 
 message SplitTabletRequestPB {

--- a/src/yb/tablet/operations/change_metadata_operation.cc
+++ b/src/yb/tablet/operations/change_metadata_operation.cc
@@ -161,6 +161,7 @@ Status ChangeMetadataOperation::Apply(int64_t leader_term, Status* complete_stat
     REMOVE_TABLE,
     BACKFILL_DONE,
     ADD_MULTIPLE_TABLES,
+    INDEX_BACKFILL_ORDERING_GENERATION,
   };
 
   MetadataChange metadata_change = MetadataChange::NONE;
@@ -222,6 +223,13 @@ Status ChangeMetadataOperation::Apply(int64_t leader_term, Status* complete_stat
     }
   }
 
+  if (request()->has_index_backfill_ordering_generation()) {
+    metadata_change = MetadataChange::NONE;
+    if (++num_operations == 1) {
+      metadata_change = MetadataChange::INDEX_BACKFILL_ORDERING_GENERATION;
+    }
+  }
+
   // Get the op id corresponding to this raft op.
   const OpId id = op_id();
 
@@ -264,6 +272,17 @@ Status ChangeMetadataOperation::Apply(int64_t leader_term, Status* complete_stat
                                    << num_operations;
       RETURN_NOT_OK(tablet->AddMultipleTables(request()->add_multiple_tables(), id, hybrid_time()));
       break;
+    case MetadataChange::INDEX_BACKFILL_ORDERING_GENERATION: {
+      DCHECK_EQ(1, num_operations) << "Invalid number of change metadata operations: "
+                                   << num_operations;
+      const auto& generation_op = request()->index_backfill_ordering_generation();
+      RETURN_NOT_OK(tablet->UpdateIndexBackfillOrderingGeneration(
+          id, generation_op.table_id().ToBuffer(),
+          ActivateGeneration(generation_op.activate()),
+          HybridTime::FromPB(generation_op.retention_barrier_ht()),
+          generation_op.write_id_floor_version()));
+      break;
+    }
   }
 
   // Now that all of the changes have been applied and the commit is durable

--- a/src/yb/tablet/operations/write_operation.cc
+++ b/src/yb/tablet/operations/write_operation.cc
@@ -97,19 +97,23 @@ Status WriteOperation::ValidateLeaderOpId(const OpId& op_id) const {
       op_id.index, static_cast<int64_t>(FLAGS_TEST_fixed_hybrid_time_write_id_max), IllegalState,
       "TEST: Raft operation index exceeded the injected fixed-hybrid-time write ID ceiling");
 
-  // When an ordering generation is active, marked writes must carry Raft indexes strictly above
-  // the generation base: the base is the activation operation's own index, so an index at or
-  // below it cannot belong to this generation -- it would indicate misrouting or replay of a
-  // foreign sequence. (Rejecting marked writes when *no* generation is active arrives with the
-  // master activation flow; until then marked writes remain test-only.)
+  // Marked writes are only legal under an active ordering generation: the generation is what
+  // records the backfill's ordering state (base, retention barrier, floor version) for
+  // verification, so a marked write with no generation would store versions nothing tracks or
+  // releases. The master activates the generation on every index tablet before launching
+  // SKIP_ALL backfill chunks, so this rejection is only reachable by misrouted or stale
+  // requests (e.g. a chunk retry arriving after the job released).
   const auto generation =
       VERIFY_RESULT(tablet_safe())->metadata()->index_backfill_ordering_generation();
-  if (generation.active) {
-    SCHECK_GT(
-        op_id.index, generation.base_op_index, IllegalState,
-        "Marked fixed-hybrid-time write carries a Raft index at or below the active ordering "
-        "generation base");
-  }
+  SCHECK(
+      generation.active, IllegalState,
+      "Marked fixed-hybrid-time write without an active ordering generation");
+  // The base is the activation operation's own Raft index, so an index at or below it cannot
+  // belong to this generation -- it would indicate misrouting or replay of a foreign sequence.
+  SCHECK_GT(
+      op_id.index, generation.base_op_index, IllegalState,
+      "Marked fixed-hybrid-time write carries a Raft index at or below the active ordering "
+      "generation base");
   return Status::OK();
 }
 

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -3226,6 +3226,17 @@ Status Tablet::MarkBackfillDone(
   return metadata_->Flush();
 }
 
+Status Tablet::UpdateIndexBackfillOrderingGeneration(
+    const OpId& op_id, const TableId& table_id, ActivateGeneration activate,
+    HybridTime retention_barrier_ht, uint32_t write_id_floor_version) {
+  LOG_WITH_PREFIX(INFO) << (activate ? "Activating" : "Releasing")
+                        << " index-backfill ordering generation for table " << table_id
+                        << " at " << op_id;
+  RETURN_NOT_OK(metadata_->ApplyIndexBackfillOrderingGenerationOp(
+      op_id, table_id, activate, retention_barrier_ht, write_id_floor_version));
+  return metadata_->Flush();
+}
+
 Status Tablet::AlterSchema(ChangeMetadataOperation* operation) {
   const auto* request = operation->request();
   auto current_table_info = VERIFY_RESULT(metadata_->GetTableInfo(

--- a/src/yb/tablet/tablet.h
+++ b/src/yb/tablet/tablet.h
@@ -530,6 +530,13 @@ class Tablet : public AbstractTablet,
   Status MarkBackfillDone(
       const OpId& op_id, const TableId& table_id = "", uint64_t birth_time = 0);
 
+  // Applies the index-backfill ordering-generation ChangeMetadataOperation variant: activates
+  // a generation whose base_op_index is the operation's own Raft index, or releases any active
+  // one. Idempotent; see IndexBackfillOrderingGenerationOpPB.
+  Status UpdateIndexBackfillOrderingGeneration(
+      const OpId& op_id, const TableId& table_id, ActivateGeneration activate,
+      HybridTime retention_barrier_ht, uint32_t write_id_floor_version);
+
   // Change wal_retention_secs in the metadata.
   Status AlterWalRetentionSecs(ChangeMetadataOperation* operation);
 

--- a/src/yb/tablet/tablet_fwd.h
+++ b/src/yb/tablet/tablet_fwd.h
@@ -82,6 +82,7 @@ struct TransactionStatusInfo;
 YB_DEFINE_ENUM(FlushMode, (kSync)(kAsync));
 YB_DEFINE_ENUM(RequireLease, (kFalse)(kTrue)(kFallbackToFollower));
 YB_STRONGLY_TYPED_BOOL(AbortOps);
+YB_STRONGLY_TYPED_BOOL(ActivateGeneration);
 YB_STRONGLY_TYPED_BOOL(Destroy);
 YB_STRONGLY_TYPED_BOOL(DisableFlushOnShutdown);
 YB_STRONGLY_TYPED_BOOL(IsSysCatalogTablet);

--- a/src/yb/tablet/tablet_metadata.cc
+++ b/src/yb/tablet/tablet_metadata.cc
@@ -2690,6 +2690,31 @@ Status RaftGroupMetadata::OnBackfillDone(
   return Status::OK();
 }
 
+Status RaftGroupMetadata::ApplyIndexBackfillOrderingGenerationOp(
+    const OpId& op_id, const TableId& table_id, ActivateGeneration activate,
+    HybridTime retention_barrier_ht, uint32_t write_id_floor_version) {
+  std::lock_guard lock(data_mutex_);
+  if (activate) {
+    // The base is the activation operation's own Raft index: replicas and WAL replay derive it
+    // identically, and every marked write appended after this op necessarily carries a higher
+    // index. Re-activation (e.g. a backfill job resumed after master failover) is idempotent --
+    // the base moves to the newer op's index, which only tightens the constraint.
+    index_backfill_ordering_generation_ = IndexBackfillOrderingGeneration {
+        .active = true,
+        .table_id = table_id,
+        .base_op_index = op_id.index,
+        .retention_barrier_ht = retention_barrier_ht,
+        .write_id_floor_version = write_id_floor_version,
+    };
+  } else {
+    index_backfill_ordering_generation_ = IndexBackfillOrderingGeneration();
+  }
+  // Advance the change-metadata replay marker with the flush below (mirrors OnBackfillDone);
+  // without it the op would replay on every bootstrap until some later ChangeMetadata flush.
+  OnChangeMetadataOperationAppliedUnlocked(op_id);
+  return Status::OK();
+}
+
 Status RaftGroupMetadata::OnBackfillDoneUnlocked(
     const TableId& table_id, uint64_t birth_time) {
   if (FLAGS_TEST_skip_metadata_backfill_done) {

--- a/src/yb/tablet/tablet_metadata.h
+++ b/src/yb/tablet/tablet_metadata.h
@@ -511,11 +511,20 @@ class RaftGroupMetadata : public RefCountedThreadSafe<RaftGroupMetadata>,
   HybridTime cdc_sdk_safe_time() const;
 
   // Persists the fixed-hybrid-time write-ID ordering generation for unique-index backfill
-  // (durable in the superblock, inherited by split children). While active, marked
-  // backfill writes must carry Raft indexes strictly above base_op_index and tablet splitting
-  // and cloning are fenced.
+  // (durable in the superblock, inherited by split children). While active, marked backfill
+  // writes must carry Raft indexes strictly above base_op_index and tablet splitting and
+  // cloning are fenced. This setter is for non-Raft-driven mutation (tests, the tserver
+  // metadata validator's local heal); the replicated path is
+  // ApplyIndexBackfillOrderingGenerationOp.
   Status set_index_backfill_ordering_generation(
       const IndexBackfillOrderingGeneration& generation);
+
+  // Applies the ChangeMetadataOperation variant: activates a generation with
+  // base_op_index = op_id.index, or releases any active one. Advances the change-metadata
+  // replay marker; the caller flushes (mirrors OnBackfillDone).
+  Status ApplyIndexBackfillOrderingGenerationOp(
+      const OpId& op_id, const TableId& table_id, ActivateGeneration activate,
+      HybridTime retention_barrier_ht, uint32_t write_id_floor_version);
 
   IndexBackfillOrderingGeneration index_backfill_ordering_generation() const;
 

--- a/src/yb/tablet/tablet_peer-test.cc
+++ b/src/yb/tablet/tablet_peer-test.cc
@@ -62,6 +62,7 @@
 #include "yb/server/clock.h"
 #include "yb/server/logical_clock.h"
 
+#include "yb/tablet/operations/change_metadata_operation.h"
 #include "yb/tablet/operations/clone_operation.h"
 #include "yb/tablet/operations/snapshot_operation.h"
 #include "yb/tablet/operations/split_operation.h"
@@ -515,6 +516,17 @@ TEST_F(TabletPeerTest, SnapshotAbortBeforePendingDoesNotUnregisterFilter) {
       std::move(operation), consensus.get(), tablet_peer_.get()));
 }
 
+namespace {
+
+IndexBackfillOrderingGeneration MakeActiveOrderingGeneration(int64_t base_op_index) {
+  IndexBackfillOrderingGeneration generation;
+  generation.active = true;
+  generation.base_op_index = base_op_index;
+  return generation;
+}
+
+}  // namespace
+
 TEST_F(TabletPeerTest, FixedHybridTimeWritesUseRaftIndexWriteId) {
   ConsensusBootstrapInfo info;
   ASSERT_OK(StartPeer(info));
@@ -522,6 +534,9 @@ TEST_F(TabletPeerTest, FixedHybridTimeWritesUseRaftIndexWriteId) {
 
   const dockv::DocKey doc_key(0, dockv::MakeKeyEntryValues("row"));
   const auto encoded_key = doc_key.Encode();
+  // Marked writes require an active ordering generation since the master-orchestration part.
+  ASSERT_OK(tablet()->metadata()->set_index_backfill_ordering_generation(
+      MakeActiveOrderingGeneration(/* base_op_index= */ 0)));
   const auto kWriteHT = 6000_usec_ht;
 
   auto write = [&](const std::string& value) {
@@ -623,6 +638,9 @@ TEST_F(TabletPeerTest, FixedHybridTimeWriteIdRequiresUniqueUnversionedKeys) {
   ASSERT_OK(StartPeer(info));
   auto consensus = ASSERT_RESULT(tablet_peer_->GetConsensus());
   const auto kWriteHT = 6000_usec_ht;
+  // Marked writes require an active ordering generation since the master-orchestration part.
+  ASSERT_OK(tablet()->metadata()->set_index_backfill_ordering_generation(
+      MakeActiveOrderingGeneration(/* base_op_index= */ 0)));
 
   auto initialize_request = [&](WriteRequestPB* request) {
     request->set_tablet_id(tablet()->tablet_id());
@@ -668,6 +686,9 @@ TEST_F(TabletPeerTest, FixedHybridTimeWriteIdRequiresUniqueUnversionedKeys) {
 TEST_F(TabletPeerTest, FixedHybridTimeWriteIdOverflowRejectedBeforeRaftAppend) {
   ConsensusBootstrapInfo info;
   auto consensus = ASSERT_RESULT(StartPeerAndWaitForLeaderNoOpCommit(info));
+  // Marked writes require an active ordering generation since the master-orchestration part.
+  ASSERT_OK(tablet()->metadata()->set_index_backfill_ordering_generation(
+      MakeActiveOrderingGeneration(/* base_op_index= */ 0)));
   const auto initial_op_id = consensus->GetLastCommittedOpId();
   ASSERT_EQ(initial_op_id, tablet_peer_->log()->GetLatestEntryOpId());
   const auto kWriteHT = 6000_usec_ht;
@@ -714,17 +735,6 @@ TEST_F(TabletPeerTest, FixedHybridTimeWriteIdOverflowRejectedBeforeRaftAppend) {
   ASSERT_EQ(consensus->GetLastCommittedOpId(), tablet_peer_->log()->GetLatestEntryOpId());
 }
 
-namespace {
-
-IndexBackfillOrderingGeneration MakeActiveOrderingGeneration(int64_t base_op_index) {
-  IndexBackfillOrderingGeneration generation;
-  generation.active = true;
-  generation.base_op_index = base_op_index;
-  return generation;
-}
-
-}  // namespace
-
 TEST_F(TabletPeerTest, FixedHybridTimeWriteRejectedAtOrBelowGenerationBase) {
   ConsensusBootstrapInfo info;
   // The base arithmetic below is relative to the committed index, so the leader-election no-op
@@ -762,13 +772,15 @@ TEST_F(TabletPeerTest, FixedHybridTimeWriteRejectedAtOrBelowGenerationBase) {
   ASSERT_OK(write("accepted"));
   ASSERT_EQ(committed_op_id.index + 1, consensus->GetLastCommittedOpId().index);
 
-  // A released generation does not constrain marked writes; rejecting marked writes with no
-  // active generation arrives with the master activation flow. (Inactive-with-populated-fields
-  // is not a representable state: the setter normalizes it to the default, matching the durable
-  // form of field absence.)
+  // With the generation released, marked writes are rejected outright: nothing tracks or
+  // releases the versions they would store (e.g. a stale chunk retry arriving after the job
+  // reached a terminal state).
   ASSERT_OK(tablet()->metadata()->set_index_backfill_ordering_generation(
       IndexBackfillOrderingGeneration()));
-  ASSERT_OK(write("unconstrained"));
+  const auto released_status = write("rejected-after-release");
+  ASSERT_TRUE(released_status.IsIllegalState()) << released_status;
+  ASSERT_STR_CONTAINS(
+      released_status.message().ToBuffer(), "without an active ordering generation");
 }
 
 TEST_F(TabletPeerTest, IndexBackfillOrderingGenerationPersistsAcrossReload) {
@@ -874,6 +886,54 @@ TEST_F(TabletPeerTest, CloneRejectedWhileOrderingGenerationActive) {
   ASSERT_STR_CONTAINS(status.message().ToBuffer(), "cloning is fenced");
   ASSERT_EQ(committed_before, consensus->GetLastCommittedOpId());
   ASSERT_EQ(committed_before, tablet_peer_->log()->GetLatestEntryOpId());
+}
+
+TEST_F(TabletPeerTest, OrderingGenerationChangeMetadataOpSetsBaseFromOwnRaftIndex) {
+  ConsensusBootstrapInfo info;
+  ASSERT_OK(StartPeer(info));
+  auto consensus = ASSERT_RESULT(tablet_peer_->GetConsensus());
+  ASSERT_OK(LoggedWaitFor(
+      [&] {
+        const auto committed_op_id = consensus->GetLastCommittedOpId();
+        return committed_op_id.index > 0 &&
+               committed_op_id == tablet_peer_->log()->GetLatestEntryOpId();
+      },
+      MonoDelta::FromSeconds(5), "leader-election no-op to commit"));
+
+  const auto kRetentionBarrier = 5000_usec_ht;
+  auto submit_generation_op = [&](bool activate) -> Status {
+    auto operation = std::make_unique<ChangeMetadataOperation>(
+        VERIFY_RESULT(tablet_peer_->shared_tablet()), tablet_peer_->log());
+    auto* request = operation->AllocateRequest();
+    request->dup_tablet_id(tablet()->tablet_id());
+    auto* generation_op = request->mutable_index_backfill_ordering_generation();
+    generation_op->dup_table_id("index-table-id");
+    generation_op->set_activate(activate);
+    if (activate) {
+      generation_op->set_retention_barrier_ht(kRetentionBarrier.ToUint64());
+      generation_op->set_write_id_floor_version(kIndexBackfillWriteIdFloorVersion);
+    }
+    auto synchronizer = std::make_shared<Synchronizer>();
+    operation->set_completion_callback(
+        MakeWeakSynchronizerOperationCompletionCallback(synchronizer));
+    tablet_peer_->Submit(std::move(operation), /* term= */ 1);
+    return synchronizer->Wait();
+  };
+
+  // Activation: the persisted base is the ChangeMetadataOperation's own Raft index, so a marked
+  // write appended right after it (the next index) is admitted by the base validation.
+  ASSERT_OK(submit_generation_op(/* activate= */ true));
+  const auto activation_op_id = consensus->GetLastCommittedOpId();
+  const auto generation = tablet()->metadata()->index_backfill_ordering_generation();
+  ASSERT_TRUE(generation.active);
+  ASSERT_EQ("index-table-id", generation.table_id);
+  ASSERT_EQ(activation_op_id.index, generation.base_op_index);
+  ASSERT_EQ(kRetentionBarrier, generation.retention_barrier_ht);
+  ASSERT_EQ(kIndexBackfillWriteIdFloorVersion, generation.write_id_floor_version);
+
+  // Release through the same replicated variant persists as an absent field.
+  ASSERT_OK(submit_generation_op(/* activate= */ false));
+  ASSERT_FALSE(tablet()->metadata()->index_backfill_ordering_generation().active);
 }
 
 // Ensure that Log::GC() doesn't delete logs with anchors.

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -209,6 +209,10 @@ DEFINE_test_flag(bool, block_backfill_before_index_map, false,
     "If true, BackfillIndex will block right before looking up the index_map. "
     "Used to test the race between table drop and backfill to repro GH#29830.");
 
+DEFINE_test_flag(bool, fail_index_backfill_ordering_generation_update, false,
+    "Fail UpdateIndexBackfillOrderingGeneration RPCs, to exercise activation-failure handling "
+    "of SKIP_ALL unique-index backfill jobs.");
+
 DEFINE_RUNTIME_int32(index_backfill_wait_for_old_txns_ms, 0,
     "Index backfill needs to wait for transactions that started before the "
     "WRITE_AND_DELETE phase to commit or abort before choosing a time for "
@@ -718,6 +722,46 @@ void TabletServiceAdminImpl::BackfillDone(
       MakeRpcOperationCompletionCallback(std::move(context), resp, server_->Clock()));
 
   // Submit the alter schema op. The RPC will be responded to asynchronously.
+  tablet.peer->Submit(std::move(operation), tablet.leader_term);
+}
+
+void TabletServiceAdminImpl::UpdateIndexBackfillOrderingGeneration(
+    const tablet::ChangeMetadataRequestPB* req, ChangeMetadataResponsePB* resp,
+    rpc::RpcContext context) {
+  if (!CheckUuidMatchOrRespond(
+          server_->tablet_manager(), "UpdateIndexBackfillOrderingGeneration", req, resp,
+          &context)) {
+    return;
+  }
+  DVLOG(3) << "Received UpdateIndexBackfillOrderingGeneration RPC: " << req->DebugString();
+
+  if (PREDICT_FALSE(FLAGS_TEST_fail_index_backfill_ordering_generation_update)) {
+    // OPERATION_NOT_SUPPORTED is in the task's no-retry set, so the failure reaches the
+    // backfill job immediately instead of after the retry budget.
+    SetupErrorAndRespond(
+        resp->mutable_error(),
+        STATUS(NotSupported, "TEST: failing ordering-generation update"),
+        TabletServerErrorPB::OPERATION_NOT_SUPPORTED, &context);
+    return;
+  }
+
+  server::UpdateClock(*req, server_->Clock());
+
+  // Leader-only, like BackfillDone: the operation must be Raft-replicated so every replica
+  // persists the generation.
+  auto tablet =
+      LookupLeaderTabletOrRespond(server_->tablet_peer_lookup(), req->tablet_id(), resp, &context);
+  if (!tablet) {
+    return;
+  }
+
+  auto operation = std::make_unique<ChangeMetadataOperation>(
+      tablet.tablet, tablet.peer->log());
+  operation->AllocateRequest()->CopyFrom(*req);
+
+  operation->set_completion_callback(
+      MakeRpcOperationCompletionCallback(std::move(context), resp, server_->Clock()));
+
   tablet.peer->Submit(std::move(operation), tablet.leader_term);
 }
 

--- a/src/yb/tserver/tablet_service.h
+++ b/src/yb/tserver/tablet_service.h
@@ -350,6 +350,11 @@ class TabletServiceAdminImpl : public TabletServerAdminServiceIf {
       const tablet::ChangeMetadataRequestPB* req, ChangeMetadataResponsePB* resp,
       rpc::RpcContext context) override;
 
+  // Activates or releases the index-backfill write-ID ordering generation on an index tablet.
+  void UpdateIndexBackfillOrderingGeneration(
+      const tablet::ChangeMetadataRequestPB* req, ChangeMetadataResponsePB* resp,
+      rpc::RpcContext context) override;
+
   // Starts tablet splitting by adding split tablet Raft operation into Raft log of the source
   // tablet.
   void SplitTablet(

--- a/src/yb/tserver/tablet_validator.cc
+++ b/src/yb/tserver/tablet_validator.cc
@@ -140,12 +140,27 @@ bool IsBackfillDone(const master::IndexStatusPB& index_status) {
          index_status.backfill_status() == master::IndexStatusPB::BACKFILL_SUCCESS;
 }
 
+// The backfill can never succeed: the index is failed, being removed, or gone. Local backfill
+// state (the ordering generation) must be released even though retain_delete_markers stays
+// with the removal path.
+bool IsBackfillTerminallyFailed(const master::IndexStatusPB& index_status) {
+  if (index_status.has_backfill_status() &&
+      index_status.backfill_status() == master::IndexStatusPB::BACKFILL_FAILED) {
+    return true;
+  }
+  return index_status.has_error() && StatusFromPB(index_status.error()).IsNotFound();
+}
+
 struct IndexUpdateInfo {
   TableId index_table_id;
   uint64_t birth_time = 0;
+  // True: backfill reached BACKFILL_SUCCESS (heal retain_delete_markers and release any
+  // ordering generation). False: terminally failed or index gone (release the ordering
+  // generation only -- retain_delete_markers stays owned by the removal path).
+  bool backfill_succeeded = true;
 
   std::string ToString() const {
-    return YB_STRUCT_TO_STRING(index_table_id, birth_time);
+    return YB_STRUCT_TO_STRING(index_table_id, birth_time, backfill_succeeded);
   }
 };
 
@@ -295,19 +310,23 @@ bool TabletMetadataValidator::Impl::HandleMasterResponse(
     }
     cached_tables.insert({now, index_status});
 
-    // Second step, check table error and handle backfill status in case of success.
-    if (index_status.has_error()) {
+    // Second step, check table error and handle terminal backfill states. Success heals
+    // retain_delete_markers (and releases any ordering generation); terminal failure -- the
+    // index is failed, being removed, or not found -- releases the ordering generation only.
+    const bool backfill_done = !index_status.has_error() && IsBackfillDone(index_status);
+    const bool backfill_failed = IsBackfillTerminallyFailed(index_status);
+    if (index_status.has_error() && !backfill_failed) {
       LOG(INFO) << "Failed to get index status for table " << index_table_id << ", "
                 << "error: [" << StatusFromPB(index_status.error()) << "]. "
                 << "It is expected to get some errors from time to time.";
-    } else if (IsBackfillDone(index_status)) {
+    } else if (backfill_done || backfill_failed) {
       const uint64_t birth_time = index_status.has_birth_time()
           ? index_status.birth_time() : 0;
       auto [index_tablets_begin, index_tablets_end] =
           index_tablets_to_sync_.get<IndexTableIdTag>().equal_range(index_table_id);
       for (auto it = index_tablets_begin; it != index_tablets_end; ++it) {
         indexes_for_update[it->index_tablet_id].push_back(
-            IndexUpdateInfo{index_table_id, birth_time});
+            IndexUpdateInfo{index_table_id, birth_time, backfill_done});
       }
     }
 
@@ -436,12 +455,33 @@ bool TabletMetadataValidator::Impl::ScheduleTabletPropertiesValidation(
           meta.raft_group_id(), info.table_id, std::move(group_id) });
     }
   });
+  // Also pick up a straggler index-backfill ordering generation: its Raft-replicated release
+  // was lost (e.g. the master died mid-funnel after clearing the job), so nothing will release
+  // it but this validator. Group by the indexed table like the retain-delete-markers
+  // candidates, so one GetBackfillStatus RPC covers both properties.
+  const auto generation = meta.index_backfill_ordering_generation();
+  if (generation.active && !generation.table_id.empty()) {
+    const bool already_scheduled = std::any_of(
+        candidates.begin(), candidates.end(),
+        [&generation](const auto& candidate) {
+          return candidate.index_table_id == generation.table_id;
+        });
+    if (!already_scheduled) {
+      const auto primary = meta.primary_table_info();
+      auto group_id = primary->index_info ? primary->index_info->indexed_table_id()
+                                          : generation.table_id;
+      candidates.emplace_back(IndexTableInfo{
+          meta.raft_group_id(), generation.table_id, std::move(group_id)});
+    }
+  }
+
   if (candidates.empty()) {
     return false;
   }
 
   LOG_WITH_PREFIX(INFO) << "Tablet " << meta.raft_group_id() << ": found index table(s) with "
-                        << "retain delete markers set: " << yb::ToString(candidates);
+                        << "retain delete markers or an ordering generation set: "
+                        << yb::ToString(candidates);
   {
     std::lock_guard lock(scheduled_index_tablets_mutex_);
     scheduled_index_tablets_.insert(
@@ -540,6 +580,9 @@ void TabletMetadataValidator::Impl::TriggerMetadataUpdate(
 
     // Iterate through all tables of the current tablet and trigger backfill done.
     for (const auto& index_update : index_tables) {
+      if (!index_update.backfill_succeeded) {
+        continue;  // Terminal failure: only the ordering-generation release below applies.
+      }
       LOG_WITH_PREFIX(INFO) << "Tablet " << index_tablet_id << " index table "
                             << index_update.index_table_id << ": resetting backfill as done"
                             << " (birth_time=" << index_update.birth_time << ")";
@@ -551,6 +594,27 @@ void TabletMetadataValidator::Impl::TriggerMetadataUpdate(
         LOG_WITH_PREFIX(DFATAL) << "Tablet " << index_tablet_id << " table "
                                 << index_update.index_table_id
                                 << " backfill done failed, status: " << status;
+      }
+    }
+
+    // Release a straggler ordering generation once the master confirms the covering backfill
+    // reached a terminal state (success, terminal failure, or index gone) -- an unreleased
+    // generation would fence splits forever and pin retention. Local, non-Raft mutation like
+    // OnBackfillDone above: each replica heals itself (the setter normalizes and flushes).
+    const auto generation = tablet_meta->index_backfill_ordering_generation();
+    if (generation.active) {
+      for (const auto& index_update : index_tables) {
+        if (index_update.index_table_id != generation.table_id) {
+          continue;
+        }
+        LOG_WITH_PREFIX(INFO) << "Tablet " << index_tablet_id
+                              << ": releasing index-backfill ordering generation for "
+                              << generation.table_id << " (backfill confirmed complete)";
+        auto release_status = tablet_meta->set_index_backfill_ordering_generation({});
+        LOG_IF_WITH_PREFIX(WARNING, !release_status.ok())
+            << "Tablet " << index_tablet_id << " ordering-generation release failed: "
+            << release_status;
+        break;
       }
     }
 

--- a/src/yb/tserver/tserver_admin.proto
+++ b/src/yb/tserver/tserver_admin.proto
@@ -486,6 +486,13 @@ service TabletServerAdminService {
     option (yb.rpc.send_metadata) = true;
   }
 
+  // Activates or releases the index-backfill write-ID ordering generation on an index tablet
+  // (request carries ChangeMetadataRequestPB.index_backfill_ordering_generation).
+  rpc UpdateIndexBackfillOrderingGeneration(tablet.ChangeMetadataRequestPB)
+      returns (ChangeMetadataResponsePB) {
+    option (yb.rpc.send_metadata) = true;
+  }
+
   rpc FlushTablets(FlushTabletsRequestPB) returns (FlushTabletsResponsePB);
 
   rpc CountIntents(CountIntentsRequestPB) returns (CountIntentsResponsePB);

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -20,6 +20,7 @@
 #include "yb/client/table_info.h"
 
 #include "yb/common/schema.h"
+#include "yb/common/wire_protocol.h"
 
 #include "yb/integration-tests/backfill-test-util.h"
 #include "yb/integration-tests/external_mini_cluster_validator.h"
@@ -1325,6 +1326,61 @@ TEST_P(PgIndexBackfillRaftOrderingActivation, MarkerReachesRaftIndexValidation) 
   ASSERT_OK(log_waiter.WaitFor(MonoDelta::FromSeconds(30) * kTimeMultiplier));
 }
 
+// The master activates the ordering generation on the index tablets before launching backfill
+// chunks and releases it in the terminal funnel -- both observable as replicated
+// ChangeMetadataOperations applying on the tservers.
+TEST_P(PgIndexBackfillSkipAllRaftOrdering, OrderingGenerationActivatedAndReleased) {
+  std::vector<ExternalDaemon*> tserver_daemons;
+  for (auto* tserver : cluster_->tserver_daemons()) {
+    tserver_daemons.push_back(tserver);
+  }
+  // An ExternalDaemon holds a single log listener, so the two waiters must watch different
+  // daemons: the master logs the activation fan-out, the tservers log the release applying.
+  auto activation_waiter =
+      cluster_->GetMasterLogWaiter("Activating index-backfill ordering generation on");
+  LogWaiter release_waiter(
+      tserver_daemons, "Releasing index-backfill ordering generation");
+
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, 100) g", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+
+  ASSERT_OK(activation_waiter.WaitFor(MonoDelta::FromSeconds(30) * kTimeMultiplier));
+  // The release is fire-and-forget from the terminal funnel, so it may land shortly after
+  // CREATE INDEX returns.
+  ASSERT_OK(release_waiter.WaitFor(MonoDelta::FromSeconds(30) * kTimeMultiplier));
+  ASSERT_OK(CheckIndexConsistency(kIndexName));
+}
+
+class PgIndexBackfillSkipAllActivationFailure : public PgIndexBackfillSkipAllRaftOrdering {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillSkipAllRaftOrdering::UpdateMiniClusterOptions(options);
+    options->extra_tserver_flags.push_back(
+        "--TEST_fail_index_backfill_ordering_generation_update=true");
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillSkipAllActivationFailure, ::testing::Bool());
+
+// Partial activation fails the job before any backfill write: CREATE INDEX errors cleanly
+// (no hang, no crash) and the base table remains fully usable.
+TEST_P(PgIndexBackfillSkipAllActivationFailure, ActivationFailureFailsCreateIndexCleanly) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (1, 1)", kTableName));
+
+  const auto status = conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName);
+  ASSERT_NOK(status);
+
+  // The base table is unaffected; the failed (invalid) index can be dropped.
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (2, 2)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("DROP INDEX $0", kIndexName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (3, 3)", kTableName));
+}
+
 // Override the index backfill test to have slower backfill-related operations
 class PgIndexBackfillSlow : public PgIndexBackfillTest {
  public:
@@ -1375,6 +1431,71 @@ class PgIndexBackfillBlockDoBackfill : public PgIndexBackfillTest {
 };
 
 INSTANTIATE_TEST_CASE_P(, PgIndexBackfillBlockDoBackfill, ::testing::Bool());
+
+class PgIndexBackfillSkipAllBlocked : public PgIndexBackfillBlockDoBackfill {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillBlockDoBackfill::UpdateMiniClusterOptions(options);
+    options->extra_master_flags.push_back(
+        "--TEST_ysql_index_backfill_unique_check_mode=skip_all");
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillSkipAllBlocked, ::testing::Bool());
+
+// The master-side split fence reads the indexed table's durable backfill-job state: while a
+// SKIP_ALL job exists, a manual split of an index tablet is refused; after the job completes,
+// the same split is accepted.
+TEST_P(PgIndexBackfillSkipAllBlocked, SplitFencedDuringBackfill) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, 100) g", kTableName));
+
+  thread_holder_.AddThreadFunctor([this] {
+    auto create_conn = ASSERT_RESULT(Connect());
+    ASSERT_OK(create_conn.ExecuteFormat(
+        "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+  });
+
+  // Safe time persisted implies the backfill job (and its SKIP_ALL mode) is durable in the
+  // sys catalog; DoBackfill is spinning on TEST_block_do_backfill.
+  ASSERT_OK(WaitForBackfillSafeTime(kYBTableName));
+
+  auto client = ASSERT_RESULT(cluster_->CreateClient());
+  const auto index_table_id = ASSERT_RESULT(
+      GetTableIdByTableName(client.get(), kDatabaseName, kIndexName));
+  google::protobuf::RepeatedPtrField<master::TabletLocationsPB> tablets;
+  ASSERT_OK(client->GetTabletsFromTableId(index_table_id, 0, &tablets));
+  ASSERT_GT(tablets.size(), 0);
+  const auto index_tablet_id = tablets.Get(0).tablet_id();
+
+  // The refusal must come from the durable-state fence: at this point activation has not run
+  // (DoBackfill is blocked before it), so neither in-memory suppression covers the index table
+  // -- only the backfill-job check can reject. Assert the fence's Status text through the
+  // master RPC directly: the dedicated log line is rate-limited (YB_LOG_EVERY_N_SECS), and
+  // the background split-manager scan racing through the same validation can consume the
+  // window, so a LogWaiter on it is timing-dependent (and yb-admin's Status drops stderr).
+  {
+    auto proxy = cluster_->GetLeaderMasterProxy<master::MasterAdminProxy>();
+    master::SplitTabletRequestPB req;
+    req.set_tablet_id(index_tablet_id);
+    master::SplitTabletResponsePB resp;
+    rpc::RpcController rpc;
+    rpc.set_timeout(MonoDelta::FromSeconds(30) * kTimeMultiplier);
+    ASSERT_OK(proxy.SplitTablet(req, &resp, &rpc));
+    ASSERT_TRUE(resp.has_error());
+    const auto split_status = StatusFromPB(resp.error().status());
+    ASSERT_STR_CONTAINS(
+        split_status.ToString(), "Unique-index backfill with deferred verification in progress");
+  }
+
+  ASSERT_OK(cluster_->SetFlagOnMasters("TEST_block_do_backfill", "false"));
+  thread_holder_.JoinAll();
+  ASSERT_OK(CheckIndexConsistency(kIndexName));
+
+  // With the job gone the fence is lifted: the same split is now accepted.
+  ASSERT_OK(cluster_->CallYbAdmin({"split_tablet", index_tablet_id}));
+}
 
 class PgIndexBackfillBlockIndisready : public PgIndexBackfillTest {
  public:


### PR DESCRIPTION
## Summary

The persisted ordering generation (#33580) had no production lifecycle: nothing activated it
before marked backfill writes, nothing released it, and the master-side split suppression
protecting a backfill is in-memory only (lost on failover). This part wires the full
lifecycle and flips marked-write gating fail-closed.

Activation rides `ChangeMetadataOperation` (a new
`ChangeMetadataRequestPB.index_backfill_ordering_generation` variant, applied via
`Tablet::UpdateIndexBackfillOrderingGeneration` exactly like `mark_backfill_done`):
Raft-replicated, follower-applied, WAL-replayed, and `base_op_index` is the activation
operation's **own Raft index**, so every replica and every replay derives the same base with
no master-side bookkeeping. Re-activation (failover resume) is idempotent -- the base only
moves up.

Master flow, SKIP_ALL jobs on PGSQL indexed tables only (the mode rides YSQL chunk requests;
YCQL backfill writes are never marked, so generations would only fence their splits without
protecting anything):

- **Activation, waited** -- before the first chunk, the job disables and drains index-table
  splitting, then fans out one `UpdateOrderingGenerationForTablet` task per index tablet (the
  `GetSafeTimeForTablet` join pattern). All acks -> chunks launch; any failure -> the job
  aborts before a single marked write exists and CREATE INDEX fails cleanly. The drain closes
  the activation/split TOCTOU: consensus already rejects `CHANGE_METADATA_OP` while a split
  is pending, the generation fence rejects splits after activation applies, and a split
  appended in the append-to-apply window can at worst fail the activation task -- never
  corrupt a tablet set that marked writes exist in.
- **Release, fire-and-forget** -- from the terminal funnel
  (`UpdateIndexPermissionsForIndexes`), which every success/failure/abort path traverses. The
  tserver metadata validator converges stragglers, mirroring the `retain_delete_markers`
  machinery: tablets with an active generation join its existing `GetBackfillStatus` poll and
  release locally (no Raft) once the master reports a terminal state. `IndexStatusPB` gains
  `BACKFILL_FAILED` (removal-path index permissions map to it) so a failed job whose funnel
  release was lost cannot leave an orphaned invalid index permanently split-fenced and
  retention-pinned; the `retain_delete_markers` heal itself stays success-only.
- **Durable master split fence** -- the tablet-split manager refuses to split an index whose
  indexed table has a durable SKIP_ALL backfill job (`SysTablesEntryPB.backfill_jobs`,
  survives failover, cleared in the funnel), with an INFO-level skip reason. Today's two
  in-memory suppressions cover only the indexed table and evaporate on failover; the
  tablet-side generation fence stays as the fail-closed layer beneath.

Gating flip: `WriteOperation::ValidateLeaderOpId` now rejects marked writes with *no* active
generation (previously deferred) -- a marked write outside a generation would store versions
nothing tracks or releases (e.g. a stale chunk retry after the job's terminal state).

Performance: the only production-reachable path is unchanged -- the mode selector remains
hardcoded to CHECK_ALL (#33484), so activation, drain, and release never execute outside
tests. Foreground writes see only the pre-existing one-field marker check in
`ValidateLeaderOpId` (#33553); the generation metadata read happens only for marked batches.
The costs this PR adds are per-job fixed (one waited RPC round plus a split drain before the
first chunk, one fire-and-forget round at the end), not per-row, and the split-manager clause
and validator scan run in existing background loops. Measured end-to-end pricing
(FULL vs SKIP_ALL including verification, foreground p99 during backfill) lands with the
activation decision per the measurement plan in #33444.

Stacked on #33403, #33404, #33484, #33544, #33553, and #33580, based on
`feature-stack/Shopify/uniq-idx-3b-i-generation-record` per the feature-stack workflow, so
the diff is exactly this PR's own commit. A failing pr-title check on stacked PRs is a known
gap in that check; the stack merges bottom-up and retargets as parents merge.
## Upgrade/Rollback safety

Three wire surfaces change, all additive:

- **`ChangeMetadataRequestPB.index_backfill_ordering_generation` (field 24) +
  `IndexBackfillOrderingGenerationOpPB`** (`src/yb/tablet/operations.proto`). Only sent by a
  new master running a SKIP_ALL job, which cannot exist in production (hardcoded CHECK_ALL
  selector; TEST-only override). **Rollback with an unflushed activation/release WAL entry
  fails loudly, not silently**: an old binary sees the variant as an unknown field, so
  `ChangeMetadataOperation::Apply` hits the no-variant case and returns `InvalidArgument`,
  which `PlayChangeMetadataRequest` propagates -- the index tablet fails bootstrap on the
  rolled-back binary (until re-bootstrapped from a peer or the WAL entry is flushed past
  before rollback). This is the standard property of every new ChangeMetadata variant and is
  unreachable in production before activation; after activation the stack's
  kLocalPersisted/upgrade-finalize stance already prohibits rollback (#33553).
- **`UpdateIndexBackfillOrderingGeneration` admin RPC** (`src/yb/tserver/tserver_admin.proto`).
  A new master calling an old tserver gets a clean unknown-RPC failure; the activation task
  treats it as fatal and the backfill job aborts with a clean CREATE INDEX error -- fail-closed,
  no partial state.
- **`IndexStatusPB.BackfillStatus.BACKFILL_FAILED`** (`src/yb/master/master_ddl.proto`).
  **This is the stack's one wire-visible change that is not gated behind a flag or an
  unreachable code path**: a new master emits the new enum value on the existing
  `GetBackfillStatus` RPC unconditionally, for any index on a removal-path permission --
  no SKIP_ALL job required. It is nonetheless safe in both directions. New master -> old
  tserver: proto2 treats the unrecognized enum value as unknown, so `has_backfill_status()`
  is false and the old validator no-ops exactly as it does today for `BACKFILL_UNKNOWN`
  (the value it would previously have received for those permissions). Old master -> new
  tserver: the value is never sent, so a new tserver's failed-index release simply stays
  inert until the master upgrades. Neither direction changes what any existing consumer
  does, because every one of them tests `== BACKFILL_SUCCESS`.

No gflag default changes; the new flag is TEST-only. As with the rest of the stack: ships in
the same release as #33553 through activation, under the same one-release constraint.

## Test plan

macOS arm64, release -- all green:

- [x] New: `TabletPeerTest.OrderingGenerationChangeMetadataOpSetsBaseFromOwnRaftIndex` -- the
      replicated variant activates with base == the op's own Raft index (retention barrier and
      floor version round-trip); release persists as field absence.
- [x] New: `PgIndexBackfillSkipAllRaftOrdering.OrderingGenerationActivatedAndReleased/0` --
      a real CREATE UNIQUE INDEX under the SKIP_ALL override activates on the index tablets
      before chunks and releases from the terminal funnel (observed via master + tserver log
      waiters); index consistent afterwards.
- [x] New: `PgIndexBackfillSkipAllActivationFailure.ActivationFailureFailsCreateIndexCleanly/0`
      -- activation RPCs failing on every tserver: CREATE INDEX errors cleanly, base table
      stays usable, invalid index droppable.
- [x] New: `PgIndexBackfillSkipAllBlocked.SplitFencedDuringBackfill/0` -- with DoBackfill
      blocked *before activation*, a manual index-tablet split is refused by the durable
      backfill-job fence (the only fence in force at that point, pinned via the master's skip
      log line); after the job completes, the same split is accepted.
- [x] Gating flip: `TabletPeerTest.FixedHybridTimeWriteRejectedAtOrBelowGenerationBase` now
      also asserts marked writes are rejected once the generation is released.
- [x] Retrofitted (marked writes require an active generation): all
      `TabletPeerTest.FixedHybridTimeWrite*` tests and the full
      `fixed_hybrid_time_write_id-itest` suite (leader change, master fence, RBS survival,
      bypassed-split S1-L6).
- [x] Regressions: `UniqueIndexBackfillAndForegroundCheck/0` and
      `MarkerReachesRaftIndexValidation/0` now run through the real activation flow;
      uniq-idx-1 mode tests; `DuplicatesExistBeforeBackfill/0`; 3b-i generation tests; 0a/0b
      abort tests; drop-path tests for the permissions-mapping change
      (`PgIndexBackfillTest.Drop/0`,
      `PgIndexBackfillFastClientTimeout.DropWhileBackfilling/0`).

AlmaLinux (x86_64, clang21), rebased onto master `c7253d204d`:

At this PR's own commit (`0065b321b7`), debug -- all green:

- [x] `tablet_peer-test`, `clone-tablet-itest`, full `tablet-split-itest`.
- [x] `PgIndexBackfillSkipAllBlocked.SplitFencedDuringBackfill`: 3 repetitions x both
      params, all green.

The repetition is deliberate. The previous revision of that test asserted on a log line
emitted under `YB_LOG_EVERY_N_SECS(INFO, 30)`, which the background split-manager thread could
consume 27 ms before the manual split ran -- timing out the 10s waiter while the fence itself
worked correctly. The test now asserts on the yb-admin error text, which is unique to the
durable-state fence path; 6/6 clean runs confirm the race is gone.

Integrated at the stack tip (`334a1deb3d`), all green. Exact suites per build type:

- [x] TSAN (6): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `non_transactional_batch_writer-test`,
      `keyed_fingerprint-test`, `raft_consensus-itest`.
- [x] ASAN (15): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `keyed_fingerprint-test`,
      `non_transactional_batch_writer-test`, `clone-tablet-itest`,
      `remote_bootstrap-itest`, `tablet_bootstrap-test`, `auto_flags-itest`,
      `docdb-test`, `compaction_file_filter-test`,
      `xcluster_external_apply_bootstrap-test`, `pg_txn-test`, `pg_ash-test`,
      full `pg_index_backfill-test`.
- [x] Debug (19): the ASAN list minus `compaction_file_filter-test`, plus
      `master_failover-itest`, `snapshot-test`, `tablet_snapshots-test`,
      `compaction-test`, `tablet-split-itest`.
- [x] Release (5): `keyed_fingerprint-test`, `auto_flags-itest`, full
      `pg_index_backfill-test`, java `TestIndexBackfill`, java
      `TestPgRegressBackfillIndex`.
- [x] All three full `pg_index_backfill-test` runs (ASAN, debug, release) pass with no
      test failures.

Two known-upstream issues surfaced by the tip matrix, both shown not attributable to this
stack:

- TSAN `tablet-split-itest` reports 3 data races in `yb::client::YBTable::~YBTable()`
  (table.cc:81) racing its partition-refresh callback, inside the upstream test
  `AutomaticTabletSplitITest.SizeRatio` (93 cases ran, 0 gtest failures). This stack has zero
  diff under `src/yb/client/`, and that test passes 3/3 isolated at the new master base.
- `wait_states-itest` hangs 9 cases at the 601s timeout (`AshCql`, the `kYCQL_*` group,
  `kBackfillIndex_*`, `kConsensusMeta_Flush`, `kCreatingNewTablet`,
  `kSaveRaftGroupMetadataToDisk`). Reproduced identically on plain master `c7253d204d`
  carrying none of this stack's code: 53 ran, the same 9 failed, same ~600.5s expiries.

Disposition change since the previous revision: the
`PgIndexBackfillBackendsManager.NoAbortTxn/1` flake cited earlier was fixed upstream. It
passes 3/3 at the new base and in all three full `pg_index_backfill-test` runs here, so it is
no longer carried as a known flake.

