### PR TITLE
[#33587] YSQL: Fix TestWebserverKill killing unrelated processes on macOS

### DIFF
--- a/src/yb/yql/pgwrapper/pg_libpq-test.cc
+++ b/src/yb/yql/pgwrapper/pg_libpq-test.cc
@@ -3465,7 +3465,8 @@ TEST_F_EX(PgLibPqTest,
           Format("pgrep -P $0 -f 'YSQL webserver' | wc -l", postmaster_pid)));
       return count.find("1") != string::npos;
     }, 2500ms, "Webserver restarting..."));
-    ASSERT_OK(RunShellProcess(Format("pkill -9 -f 'YSQL webserver' -P $0", postmaster_pid)));
+    // Same Mac quirk as above: -P must precede -f, or this kills unrelated processes.
+    ASSERT_OK(RunShellProcess(Format("pkill -9 -P $0 -f 'YSQL webserver'", postmaster_pid)));
   }
 }
 


### PR DESCRIPTION
## Summary

On macOS, pkill stops parsing options at the pattern argument, so `pkill -9 -f 'YSQL webserver' -P <postmaster_pid>` ignores the trailing `-P` and kills every 'YSQL webserver' process on the host — during a parallel test run it kills other tests' webservers, failing tests that were never touched. Reorder to put `-P` before `-f`, matching the pgrep call a few lines above that already works around the same quirk. No behavior change on Linux, where both orders parse identically.

## Test plan

- [x] `./yb_build.sh release --cxx-test pg_libpq-test --gtest_filter PgLibPqTest.TestWebserverKill` on macOS arm64 — passes, and no longer kills processes outside its own cluster during parallel runs.
