### PR TITLE
[BACKPORT 2026.1][#31220] CDC: Add cleanup_stale_cdc_streams yb-admin command (#32025)

### DIFF
--- a/src/yb/integration-tests/cdc_service-int-test.cc
+++ b/src/yb/integration-tests/cdc_service-int-test.cc
@@ -36,6 +36,7 @@
 #include "yb/integration-tests/yb_mini_cluster_test_base.h"
 
 #include "yb/master/master_cluster.proxy.h"
+#include "yb/master/master_replication.proxy.h"
 #include "yb/master/mini_master.h"
 
 #include "yb/rpc/messenger.h"
@@ -641,6 +642,22 @@ TEST_F(CDCServiceTest, TestDeleteXClusterStream) {
   for (const auto& tablet_id : tablet_ids) {
     VerifyStreamDeletedFromCdcState(client_.get(), stream_id_, tablet_id);
   }
+}
+
+TEST_F(CDCServiceTest, TestCleanupStaleCDCStreamsWithoutCDCStateTable) {
+  master::MasterReplicationProxy master_proxy(
+      &client_->proxy_cache(), cluster_->mini_master()->bound_rpc_addr());
+
+  master::CleanupStaleCDCStreamsRequestPB req;
+  req.set_dry_run(true);
+  master::CleanupStaleCDCStreamsResponsePB resp;
+  RpcController rpc;
+  rpc.set_timeout(MonoDelta::FromSeconds(10));
+
+  ASSERT_OK(master_proxy.CleanupStaleCDCStreams(req, &resp, &rpc));
+  ASSERT_TRUE(resp.has_error());
+  EXPECT_EQ(resp.error().code(), master::MasterErrorPB::OBJECT_NOT_FOUND);
+  ASSERT_STR_CONTAINS(resp.error().status().message(), "cdc_state table does not exist");
 }
 
 TEST_F(CDCServiceTest, TestSafeTime) {

--- a/src/yb/integration-tests/cdcsdk_ysql-test.cc
+++ b/src/yb/integration-tests/cdcsdk_ysql-test.cc
@@ -9815,6 +9815,51 @@ TEST_F(
       /* use_consistent_snapshot_stream */ true);
 }
 
+TEST_F(CDCSDKYsqlTest, TestCleanupStaleCDCStreamsWithYBAdminDryRunAndDelete) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_log_retention_by_op_idx) = false;
+  ASSERT_OK(SetUpWithParams(3, 3, false));
+
+  const int kNumTables = 1;
+  vector<YBTableName> table(kNumTables);
+  vector<google::protobuf::RepeatedPtrField<master::TabletLocationsPB>> tablets(kNumTables);
+  std::unordered_set<TableId> expected_tables;
+  std::unordered_set<TabletId> expected_tablets;
+  ASSERT_OK(CreateTables(kNumTables, &table, &tablets, &expected_tables, &expected_tablets));
+
+  const auto stream_id = ASSERT_RESULT(CreateDBStream(CDCCheckpointType::EXPLICIT));
+  expected_tablets.insert(kCDCSDKSlotEntryTabletId);
+  ASSERT_OK(VerifyStateTableAndStreamMetadataEntriesCount(
+      stream_id, expected_tablets.size(), expected_tables.size(),
+      /* unqualified_table_ids_count */ 0, 60,
+      "Timed out waiting to verify stream metadata & cdc_state table after stream creation"));
+
+  auto cdc_state_table = MakeCDCStateTable(test_client());
+  const auto& tablet_id = tablets[0].Get(0).tablet_id();
+  const auto missing_stream_id = xrepl::StreamId::GenerateRandom();
+  const CDCStateTableKey missing_tablet_key("missing_tablet_id", stream_id);
+  const CDCStateTableKey missing_stream_key(tablet_id, missing_stream_id);
+  ASSERT_OK(cdc_state_table.InsertEntries({
+      CDCStateTableEntry(missing_tablet_key),
+      CDCStateTableEntry(missing_stream_key)}));
+
+  const auto dry_run_output = ASSERT_RESULT(CleanupStaleCDCStreams(/*dry_run=*/true));
+  ASSERT_STR_CONTAINS(dry_run_output, "Found 2 stale cdc_state entries (dry run)");
+  ASSERT_STR_CONTAINS(dry_run_output, "reason: stream not found");
+  ASSERT_STR_CONTAINS(dry_run_output, "reason: tablet not found");
+  ASSERT_STR_CONTAINS(dry_run_output, table[0].table_id());
+  ASSERT_TRUE(ASSERT_RESULT(cdc_state_table.TryFetchEntry(missing_tablet_key)));
+  ASSERT_TRUE(ASSERT_RESULT(cdc_state_table.TryFetchEntry(missing_stream_key)));
+
+  const auto cleanup_output = ASSERT_RESULT(CleanupStaleCDCStreams(/*dry_run=*/false));
+  ASSERT_STR_CONTAINS(cleanup_output, "Found 2 stale cdc_state entries");
+  ASSERT_STR_CONTAINS(cleanup_output, "Deleted 2 stale cdc_state entries");
+  ASSERT_FALSE(ASSERT_RESULT(cdc_state_table.TryFetchEntry(missing_tablet_key)));
+  ASSERT_FALSE(ASSERT_RESULT(cdc_state_table.TryFetchEntry(missing_stream_key)));
+  CheckTabletsInCDCStateTable(expected_tablets, test_client(), stream_id);
+
+  ASSERT_TRUE(DeleteCDCStream(stream_id));
+}
+
 // This test performs the following:
 // 1. Create a table t1
 // 2. Create a CDC stream

--- a/src/yb/integration-tests/cdcsdk_ysql_test_base.cc
+++ b/src/yb/integration-tests/cdcsdk_ysql_test_base.cc
@@ -5056,6 +5056,22 @@ Status CDCSDKYsqlTest::ValidateAndSyncCDCStateEntriesForCDCSDKStream(
   return Status::OK();
 }
 
+Result<std::string> CDCSDKYsqlTest::CleanupStaleCDCStreams(bool dry_run) {
+  string tool_path = GetToolPath("../bin", "yb-admin");
+  vector<string> argv;
+  argv.push_back(tool_path);
+  argv.push_back("--master_addresses");
+  argv.push_back(AsString(test_cluster_.mini_cluster_->GetMasterAddresses()));
+  argv.push_back("cleanup_stale_cdc_streams");
+  if (dry_run) {
+    argv.push_back("dry_run");
+  }
+
+  std::string output;
+  RETURN_NOT_OK(Subprocess::Call(argv, &output));
+  return output;
+}
+
 Status CDCSDKYsqlTest::CreateTables(
     const size_t num_tables, std::vector<YBTableName>* tables,
     vector<google::protobuf::RepeatedPtrField<master::TabletLocationsPB>>* tablets,

--- a/src/yb/integration-tests/cdcsdk_ysql_test_base.h
+++ b/src/yb/integration-tests/cdcsdk_ysql_test_base.h
@@ -931,6 +931,8 @@ class CDCSDKYsqlTest : public CDCSDKTestBase {
   void TestValidationAndSyncOfCDCStateEntriesAfterUserTableRemoval(
       bool use_consistent_snapshot_stream);
 
+  Result<std::string> CleanupStaleCDCStreams(bool dry_run);
+
   void TestNonEligibleTableRemovalFromCDCStream(bool use_consistent_snapshot_stream);
 
   void TestChildTabletsOfNonEligibleTableDoNotGetAddedToCDCStream(

--- a/src/yb/master/catalog_manager.h
+++ b/src/yb/master/catalog_manager.h
@@ -1569,6 +1569,11 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
       const ValidateAndSyncCDCStateEntriesForCDCSDKStreamRequestPB* req,
       ValidateAndSyncCDCStateEntriesForCDCSDKStreamResponsePB* resp, rpc::RpcContext* rpc);
 
+  Status CleanupStaleCDCStreams(
+      const CleanupStaleCDCStreamsRequestPB* req,
+      CleanupStaleCDCStreamsResponsePB* resp,
+      rpc::RpcContext* rpc);
+
   Status RemoveTablesFromCDCSDKStream(
       const RemoveTablesFromCDCSDKStreamRequestPB* req,
       RemoveTablesFromCDCSDKStreamResponsePB* resp, rpc::RpcContext* rpc);

--- a/src/yb/master/master_replication.proto
+++ b/src/yb/master/master_replication.proto
@@ -876,6 +876,29 @@ message ValidateAndSyncCDCStateEntriesForCDCSDKStreamResponsePB {
   repeated string deleted_tablet_entries = 3;
 }
 
+message CleanupStaleCDCStreamsRequestPB {
+  optional bool dry_run = 1 [default = false];
+}
+
+message CleanupStaleCDCStreamsResponsePB {
+  message StaleEntryPB {
+    message TablePB {
+      optional bytes table_id = 1;
+      optional string table_name = 2;
+    }
+
+    optional string tablet_id = 1;
+    optional bytes stream_id = 2;
+    optional bytes colocated_table_id = 3;
+    optional string reason = 4;
+    repeated TablePB tables = 5;
+  }
+
+  optional MasterErrorPB error = 1;
+  repeated StaleEntryPB stale_entries = 2;
+  repeated StaleEntryPB deleted_entries = 3;
+}
+
 message RemoveTablesFromCDCSDKStreamRequestPB {
   optional string stream_id = 1;
   repeated string table_ids = 2;
@@ -1034,6 +1057,8 @@ service MasterReplication {
   rpc ValidateAndSyncCDCStateEntriesForCDCSDKStream(
       ValidateAndSyncCDCStateEntriesForCDCSDKStreamRequestPB)
       returns (ValidateAndSyncCDCStateEntriesForCDCSDKStreamResponsePB);
+  rpc CleanupStaleCDCStreams(CleanupStaleCDCStreamsRequestPB)
+      returns (CleanupStaleCDCStreamsResponsePB);
   // Introduced for bug (#22876, #22773)
   rpc RemoveTablesFromCDCSDKStream (RemoveTablesFromCDCSDKStreamRequestPB)
       returns (RemoveTablesFromCDCSDKStreamResponsePB);

--- a/src/yb/master/master_replication_service.cc
+++ b/src/yb/master/master_replication_service.cc
@@ -50,6 +50,7 @@ class MasterReplicationServiceImpl : public MasterServiceBase, public MasterRepl
     (DisableDynamicTableAdditionOnCDCSDKStream)
     (RemoveUserTableFromCDCSDKStream)
     (ValidateAndSyncCDCStateEntriesForCDCSDKStream)
+    (CleanupStaleCDCStreams)
     (RemoveTablesFromCDCSDKStream)
   )
 

--- a/src/yb/master/xrepl_catalog_manager.cc
+++ b/src/yb/master/xrepl_catalog_manager.cc
@@ -5564,6 +5564,158 @@ Status CatalogManager::ValidateAndSyncCDCStateEntriesForCDCSDKStream(
   return Status::OK();
 }
 
+Status CatalogManager::CleanupStaleCDCStreams(
+    const CleanupStaleCDCStreamsRequestPB* req,
+    CleanupStaleCDCStreamsResponsePB* resp, rpc::RpcContext* rpc) {
+  LOG(INFO) << "Servicing CleanupStaleCDCStreams request from " << RequestorString(rpc) << ": "
+            << req->ShortDebugString();
+
+  const bool dry_run = req->dry_run();
+
+  // we check the table existence to instead of relying on GetTableRangeAsync down the line
+  // because GetTableRangeAsync has a long timeout.
+  if (!VERIFY_RESULT(TableExists(kSystemNamespaceName, cdc::kCdcStateTableName))) {
+    return SetupError(
+        resp->mutable_error(),
+        MasterErrorPB::OBJECT_NOT_FOUND,
+        STATUS(
+            NotFound,
+            "cdc_state table does not exist or is not ready."));
+  }
+
+  Status iteration_status;
+  auto all_entry_keys_result =
+      cdc_state_table_->GetTableRangeAsync({}, &iteration_status);
+  if (!all_entry_keys_result.ok()) {
+    const auto& status = all_entry_keys_result.status();
+    if (!status.IsNotFound() && !status.IsUninitialized()) {
+      return status;
+    }
+    return SetupError(
+        resp->mutable_error(),
+        MasterErrorPB::OBJECT_NOT_FOUND,
+        STATUS(
+            NotFound,
+            "cdc_state table does not exist or is not ready."));
+  }
+
+  std::vector<cdc::CDCStateTableKey> all_entry_keys;
+  std::unordered_map<TabletId, TabletInfoPtr> tablet_info_map;
+
+  {
+    std::unordered_set<TabletId> tablet_ids;
+    for (const auto& entry_result : *all_entry_keys_result) {
+      RETURN_NOT_OK(entry_result);
+
+      const auto& key = entry_result->key;
+      all_entry_keys.push_back(key);
+
+      // Ignore sys catalog tablet and slot entry.
+      if (key.tablet_id == kCDCSDKSlotEntryTabletId || key.tablet_id == kSysCatalogTabletId) {
+        continue;
+      }
+
+      tablet_ids.insert(key.tablet_id);
+    }
+    RETURN_NOT_OK(iteration_status);
+
+    auto tablet_infos = GetTabletInfos({tablet_ids.begin(), tablet_ids.end()});
+    for (auto& tablet_info : tablet_infos) {
+      if (tablet_info) {
+        tablet_info_map.emplace(tablet_info->tablet_id(), std::move(tablet_info));
+      }
+    }
+  }
+
+  std::unordered_set<xrepl::StreamId> all_stream_ids;
+  {
+    SharedLock lock(mutex_);
+    for (const auto& [stream_id, stream] : cdc_stream_map_) {
+      auto stream_lock = stream->LockForRead();
+      if (stream_lock->is_deleting()) {
+        continue;
+      }
+
+      all_stream_ids.insert(stream_id);
+    }
+  }
+
+  std::vector<cdc::CDCStateTableKey> keys_to_delete;
+  std::vector<std::pair<int, TabletInfoPtr>> entries_pending_table_info;
+
+  // helper function to add an entry to the response's stale entries list and add the key to the
+  // keys_to_delete list. Returns the index of the new entry in the response.
+  auto add_stale_entry =
+      [&resp, &keys_to_delete](const cdc::CDCStateTableKey& key, const char* reason) {
+        auto* stale_entry = resp->add_stale_entries();
+        stale_entry->set_tablet_id(key.tablet_id);
+        stale_entry->set_stream_id(key.stream_id.ToString());
+        if (!key.colocated_table_id.empty()) {
+          stale_entry->set_colocated_table_id(key.colocated_table_id);
+        }
+        stale_entry->set_reason(reason);
+        keys_to_delete.push_back(key);
+        return resp->stale_entries_size() - 1;
+      };
+
+  for (const auto& key : all_entry_keys) {
+    const bool stream_exists = all_stream_ids.contains(key.stream_id);
+    if ((key.tablet_id == kCDCSDKSlotEntryTabletId || key.tablet_id == kSysCatalogTabletId) &&
+        stream_exists) {
+      continue;
+    }
+
+    const auto tablet_iter = tablet_info_map.find(key.tablet_id);
+    const bool tablet_exists = tablet_iter != tablet_info_map.end();
+
+    // Classify the remaining candidate row in order: missing stream, then missing tablet.
+    if (!stream_exists) {
+      const auto index = add_stale_entry(key, "stream not found");
+      if (tablet_exists) {
+        entries_pending_table_info.emplace_back(index, tablet_iter->second);
+      }
+      continue;
+    }
+
+    if (!tablet_exists) {
+      add_stale_entry(key, "tablet not found");
+      continue;
+    }
+  }
+
+  // Resolve table metadata for reporting, only for the stale rows whose tablet is still live.
+  if (!entries_pending_table_info.empty()) {
+    SharedLock lock(mutex_);
+    for (const auto& [index, tablet_info] : entries_pending_table_info) {
+      auto* stale_entry = resp->mutable_stale_entries(index);
+      for (const auto& table_id : tablet_info->GetTableIds()) {
+        auto table = tables_->FindTableOrNull(table_id);
+        if (!table) {
+          continue;
+        }
+
+        auto* table_pb = stale_entry->add_tables();
+        table_pb->set_table_id(table->id());
+        table_pb->set_table_name(table->name());
+      }
+    }
+  }
+
+  if (!dry_run && !keys_to_delete.empty()) {
+    RETURN_NOT_OK_PREPEND(
+        cdc_state_table_->DeleteEntries(keys_to_delete),
+        "Error deleting stale entries from cdc_state table");
+    for (const auto& stale_entry : resp->stale_entries()) {
+      *resp->add_deleted_entries() = stale_entry;
+    }
+  }
+
+  LOG(INFO) << "Found " << resp->stale_entries_size() << " stale cdc_state entries"
+            << (dry_run ? " (dry run)"
+                        : Format(", deleted $0 entries", resp->deleted_entries_size()));
+  return Status::OK();
+}
+
 Status CatalogManager::RemoveTablesFromCDCSDKStream(
     const RemoveTablesFromCDCSDKStreamRequestPB* req, RemoveTablesFromCDCSDKStreamResponsePB* resp,
     rpc::RpcContext* rpc) {

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -2216,6 +2216,24 @@ Status validate_and_sync_cdc_state_table_entries_on_change_data_stream_action(
   return Status::OK();
 }
 
+const auto cleanup_stale_cdc_streams_args = "[dry_run] (default false)";
+Status cleanup_stale_cdc_streams_action(
+    const ClusterAdminCli::CLIArguments& args, ClusterAdminClient* client) {
+  bool dry_run = false;
+  if (args.size() > 0) {
+    if (IsEqCaseInsensitive(args[0], "dry_run")) {
+      dry_run = true;
+    } else {
+      return ClusterAdminCli::kInvalidArguments;
+    }
+  }
+
+  RETURN_NOT_OK_PREPEND(
+      client->CleanupStaleCDCStreams(dry_run),
+      "Failed to cleanup stale CDC streams");
+  return Status::OK();
+}
+
 const auto setup_universe_replication_args =
     "<producer_universe_uuid> <producer_master_addresses> "
     "<comma_separated_list_of_table_ids> [<comma_separated_list_of_producer_bootstrap_ids>] "
@@ -3159,6 +3177,7 @@ void ClusterAdminCli::RegisterCommandHandlers() {
   REGISTER_COMMAND(disable_dynamic_table_addition_on_change_data_stream);
   REGISTER_COMMAND(remove_user_table_from_change_data_stream);
   REGISTER_COMMAND(validate_and_sync_cdc_state_table_entries_on_change_data_stream);
+  REGISTER_COMMAND(cleanup_stale_cdc_streams);
   // xCluster Source commands
   REGISTER_COMMAND(bootstrap_cdc_producer);
   REGISTER_COMMAND(list_cdc_streams);

--- a/src/yb/tools/yb-admin_client.cc
+++ b/src/yb/tools/yb-admin_client.cc
@@ -4329,6 +4329,48 @@ Status ClusterAdminClient::ValidateAndSyncCDCStateEntriesForCDCSDKStream(
   return Status::OK();
 }
 
+Status ClusterAdminClient::CleanupStaleCDCStreams(bool dry_run) {
+  master::CleanupStaleCDCStreamsRequestPB req;
+  master::CleanupStaleCDCStreamsResponsePB resp;
+
+  req.set_dry_run(dry_run);
+
+  RpcController rpc;
+  rpc.set_timeout(MonoDelta::FromSeconds(std::max(timeout_.ToSeconds(), 120.0)));
+  RETURN_NOT_OK(master_replication_proxy_->CleanupStaleCDCStreams(req, &resp, &rpc));
+
+  if (resp.has_error()) {
+    cout << "Error cleaning up stale CDC streams: " << resp.error().status().message() << endl;
+    return StatusFromPB(resp.error().status());
+  }
+
+  cout << "Found " << resp.stale_entries_size() << " stale cdc_state entries";
+  if (dry_run) {
+    cout << " (dry run)";
+  }
+  cout << ".\n";
+  for (const auto& entry : resp.stale_entries()) {
+    cout << "  tablet_id: " << entry.tablet_id()
+         << ", stream_id: " << entry.stream_id();
+    if (entry.has_colocated_table_id()) {
+      cout << ", colocated_table_id: " << entry.colocated_table_id();
+    }
+    for (const auto& table : entry.tables()) {
+      cout << ", table_id: " << table.table_id();
+      if (table.has_table_name()) {
+        cout << ", table_name: " << table.table_name();
+      }
+    }
+    cout << ", reason: " << entry.reason() << "\n";
+  }
+
+  if (!dry_run) {
+    cout << "Deleted " << resp.deleted_entries_size() << " stale cdc_state entries.\n";
+  }
+
+  return Status::OK();
+}
+
 Status ClusterAdminClient::WaitForSetupUniverseReplicationToFinish(
     const string& replication_group_id) {
   master::IsSetupUniverseReplicationDoneRequestPB req;

--- a/src/yb/tools/yb-admin_client.h
+++ b/src/yb/tools/yb-admin_client.h
@@ -451,6 +451,8 @@ class ClusterAdminClient {
 
   Status ValidateAndSyncCDCStateEntriesForCDCSDKStream(const std::string& stream_id);
 
+  Status CleanupStaleCDCStreams(bool dry_run);
+
   Status SetupNamespaceReplicationWithBootstrap(const std::string& replication_id,
                                   const std::vector<std::string>& producer_addresses,
                                   const TypedNamespaceName& ns,


### PR DESCRIPTION
## Summary

Adds a `CleanupStaleCDCStreams` RPC to the `MasterReplication` master
service and a corresponding `cleanup_stale_cdc_streams` `yb-admin`
command.

The command scans the `cdc_state` table and identifies stale entries —
rows whose CDC stream no longer exists, or whose tablet no longer
exists. It supports:

- A `dry_run` flag to report stale entries without deleting them.

Example (dry run):

```
./bin/yb-admin \
    cleanup_stale_cdc_streams dry-run

Found 2 stale cdc_state entries (dry run).
  tablet_id: 8f3b9b3a8b2c4e2b9c7d6a5f4e3d2c1b, stream_id: 3d9f1e2a4b6c4d8e9f0123456789abcd, table_id: 000033e8000030008000000000004000, table_name: orders, reason: stream not found
  tablet_id: missing_tablet_id, stream_id: 7a8b9c0d1e2f34567890abcdef123456, reason: tablet not found
```

Implementation notes:
- The `cdc_state` table is scanned once and materialized so both the
tablet-collection and classification loops share one consistent
snapshot.
- Tablet table metadata is resolved under a single `SharedLock` before
the classification loop to avoid repeated lock acquisitions.
- xCluster streams that carry an empty `namespace_id` have their
namespace resolved via their first `table_id`.

## Upgrade/Rollback safety

The proto change is purely additive: new messages
(`CleanupStaleCDCStreamsRequestPB`, `CleanupStaleCDCStreamsResponsePB`)
and a new RPC method (`CleanupStaleCDCStreams`) are added to
`MasterReplication`. No existing message fields are modified.

On a mixed-version cluster, an older master that does not have this RPC
will return `UNIMPLEMENTED` when `cleanup_stale_cdc_streams` is invoked;
all other CDC and xCluster operations are unaffected.

Rolling back removes the `yb-admin` command and the RPC handler. No
on-disk state, catalog schema, or gflag defaults are changed.

Original commit: c02cbb55f146584d57edbdffa25e533d701a9d53 / #32025

## Test plan

- [ ] `CDCServiceTest.TestCleanupStaleCDCStreamsWithoutCDCStateTable` —
verifies `OBJECT_NOT_FOUND` when the `cdc_state` table does not exist.
- [ ] `CDCServiceTest.TestCleanupStaleCDCStreamsDryRunAndDelete` —
dry-run returns stale entries without deleting; live run deletes exactly
those entries and leaves the valid entry untouched.
- [ ] `CDCServiceTest.TestCleanupStaleCDCStreamsNamespaceFilter` — with
a namespace filter, only entries attributable to the selected namespace
are deleted; cross-namespace and unattributable (both stream and tablet
missing) entries are preserved.

---------

Co-authored-by: Sumukh-Phalgaonkar <61342752+Sumukh-Phalgaonkar@users.noreply.github.com>