### PR TITLE
[#33444] DocDB: Add the identity-aware unique-index verification scan

### DIFF
--- a/src/yb/docdb/CMakeLists.txt
+++ b/src/yb/docdb/CMakeLists.txt
@@ -102,6 +102,7 @@ set(DOCDB_SRCS
         shared_lock_manager.cc
         transaction_dump.cc
         transaction_status_cache.cc
+        unique_index_verifier.cc
         wait_queue.cc
         )
 
@@ -172,6 +173,7 @@ ADD_YB_TEST(non_transactional_batch_writer-test)
 ADD_YB_TEST(randomized_docdb-test)
 ADD_YB_TEST(scan_choices-test)
 ADD_YB_TEST(shared_lock_manager-test)
+ADD_YB_TEST(unique_index_verifier-test)
 ADD_YB_TEST(consensus_frontier-test)
 ADD_YB_TEST(compaction_file_filter-test)
 ADD_YB_TEST(usearch_vector_index-test)

--- a/src/yb/docdb/docdb_fwd.h
+++ b/src/yb/docdb/docdb_fwd.h
@@ -61,6 +61,7 @@ class WaitQueue;
 class YQLRowwiseIteratorIf;
 class YQLStorageIf;
 
+struct UniqueIndexVerificationResult;
 struct ApplyTransactionState;
 struct DocDB;
 struct DocReadContext;

--- a/src/yb/docdb/unique_index_verifier-test.cc
+++ b/src/yb/docdb/unique_index_verifier-test.cc
@@ -1,0 +1,451 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include <limits>
+#include <string>
+
+#include "yb/common/doc_hybrid_time.h"
+#include "yb/common/ql_type.h"
+#include "yb/common/schema.h"
+
+#include "yb/docdb/docdb_test_base.h"
+#include "yb/docdb/unique_index_verifier.h"
+
+#include "yb/dockv/doc_key.h"
+#include "yb/dockv/packed_row.h"
+#include "yb/dockv/primitive_value.h"
+#include "yb/dockv/schema_packing.h"
+#include "yb/dockv/value_type.h"
+
+#include "yb/rocksdb/db.h"
+
+#include "yb/util/status_log.h"
+#include "yb/util/test_macros.h"
+
+namespace yb::docdb {
+
+namespace {
+
+// Verification-window bounds shared by the tests. The backfill hybrid time sits strictly
+// inside so tests can place records below, at, and above it.
+constexpr HybridTime kWindowLower = 3000_usec_ht;   // backfill_read_ht.
+constexpr HybridTime kBackfillHT = kWindowLower;    // Backfill writes land exactly here.
+constexpr HybridTime kWindowUpper = 9000_usec_ht;   // verify_upper_ht.
+
+// A marked-domain write ID: backfill writes carry kBackfillWriteIdFloor | raft_index, and
+// the verifier uses the floor to attribute non-packed column records to backfill operations.
+constexpr IntraTxnWriteId kBackfillWriteId = kBackfillWriteIdFloor + 1;
+
+}  // namespace
+
+class UniqueIndexVerifierTest : public DocDBTestBase {
+ protected:
+  void SetUp() override {
+    DocDBTestBase::SetUp();
+
+    // A unique-index-shaped schema: hashed indexed value, the null-suffix range column,
+    // then ybidxbasectid and one INCLUDE column as regular value columns.
+    SchemaBuilder builder;
+    ASSERT_OK(builder.AddHashKeyColumn("v", DataType::INT32));
+    ASSERT_OK(builder.AddKeyColumn("ybuniqueidxkeysuffix", DataType::BINARY));
+    ASSERT_OK(builder.AddColumn("ybidxbasectid", DataType::BINARY));
+    ASSERT_OK(builder.AddNullableColumn("inc", DataType::INT32));
+    schema_ = builder.Build();
+    schema_packing_ = std::make_shared<dockv::SchemaPacking>(
+        TableType::PGSQL_TABLE_TYPE, schema_);
+
+    const auto basectid_idx = ASSERT_RESULT(schema_.ColumnIndexByName("ybidxbasectid"));
+    basectid_column_id_ = schema_.column_id(basectid_idx);
+    const auto include_idx = ASSERT_RESULT(schema_.ColumnIndexByName("inc"));
+    include_column_id_ = schema_.column_id(include_idx);
+  }
+
+  Schema CreateSchema() override { return Schema(); }
+
+  // --- Physical shape builders ------------------------------------------------------------
+
+  dockv::DocKey IndexDocKey(int32_t indexed_value) {
+    return dockv::DocKey(
+        kFixedHashCode, {dockv::KeyEntryValue::Int32(indexed_value)},
+        {dockv::KeyEntryValue(dockv::KeyEntryType::kNullLow)});
+  }
+
+  std::string RowLevelKey(int32_t v, HybridTime ht, IntraTxnWriteId write_id) {
+    dockv::KeyBytes key = IndexDocKey(v).Encode();
+    key.AppendKeyEntryType(dockv::KeyEntryType::kHybridTime);
+    key.AppendHybridTime(DocHybridTime(ht, write_id));
+    return key.ToStringBuffer();
+  }
+
+  std::string ColumnKey(int32_t v, ColumnId column, HybridTime ht, IntraTxnWriteId write_id) {
+    dockv::KeyBytes key = IndexDocKey(v).Encode();
+    dockv::KeyEntryValue::MakeColumnId(column).AppendToKey(&key);
+    key.AppendKeyEntryType(dockv::KeyEntryType::kHybridTime);
+    key.AppendHybridTime(DocHybridTime(ht, write_id));
+    return key.ToStringBuffer();
+  }
+
+  std::string LivenessKey(int32_t v, HybridTime ht, IntraTxnWriteId write_id) {
+    dockv::KeyBytes key = IndexDocKey(v).Encode();
+    dockv::KeyEntryValue::kLivenessColumn.AppendToKey(&key);
+    key.AppendKeyEntryType(dockv::KeyEntryType::kHybridTime);
+    key.AppendHybridTime(DocHybridTime(ht, write_id));
+    return key.ToStringBuffer();
+  }
+
+  static QLValuePB BinaryValue(const std::string& data) {
+    QLValuePB value;
+    value.set_binary_value(data);
+    return value;
+  }
+
+  static std::string EncodedBinary(const std::string& data) {
+    std::string out;
+    dockv::AppendEncodedValue(BinaryValue(data), &out);
+    return out;
+  }
+
+  void Put(const std::string& key, const std::string& value) {
+    rocksdb::WriteBatch batch;
+    batch.Put(key, value);
+    ASSERT_OK(regular_db_->Write(write_options(), &batch));
+  }
+
+  // A packed-row insert (V1 or V2) or update (V2 only) carrying the identity and a null
+  // INCLUDE column.
+  std::string PackedRow(
+      dockv::PackedRowVersion version, const std::string& identity, bool is_update) {
+    constexpr auto kNoLimit = std::numeric_limits<int64_t>::max();
+    constexpr SchemaVersion kSchemaVersion = 0;
+    QLValuePB include_value;  // null
+    if (version == dockv::PackedRowVersion::kV1) {
+      CHECK(!is_update);
+      dockv::RowPackerV1 packer(kSchemaVersion, *schema_packing_, kNoLimit, Slice());
+      CHECK_OK(packer.AddValue(basectid_column_id_, BinaryValue(identity)));
+      CHECK_OK(packer.AddValue(include_column_id_, include_value));
+      return CHECK_RESULT(packer.Complete()).ToBuffer();
+    }
+    dockv::RowPackerV2 packer(
+        kSchemaVersion, *schema_packing_, kNoLimit, Slice(), is_update);
+    CHECK_OK(packer.AddValue(basectid_column_id_, BinaryValue(identity)));
+    CHECK_OK(packer.AddValue(include_column_id_, include_value));
+    return CHECK_RESULT(packer.Complete()).ToBuffer();
+  }
+
+  // --- Logical event writers --------------------------------------------------------------
+
+  // Backfill-shaped insert: packed V2 row at the backfill hybrid time with a marked-domain
+  // write ID.
+  void WriteBackfillInsert(
+      int32_t v, const std::string& identity, IntraTxnWriteId write_id = kBackfillWriteId) {
+    Put(RowLevelKey(v, kBackfillHT, write_id),
+        PackedRow(dockv::PackedRowVersion::kV2, identity, /* is_update= */ false));
+  }
+
+  // Foreground-shaped non-packed insert: liveness + identity column + INCLUDE column at one
+  // hybrid time with consecutive write IDs.
+  void WriteNonPackedInsert(
+      int32_t v, const std::string& identity, HybridTime ht, IntraTxnWriteId first_write_id) {
+    Put(LivenessKey(v, ht, first_write_id), std::string(1, dockv::ValueEntryTypeAsChar::kNullLow));
+    Put(ColumnKey(v, basectid_column_id_, ht, first_write_id + 1), EncodedBinary(identity));
+    std::string include_encoded;
+    QLValuePB include_value;
+    include_value.set_int32_value(7);
+    dockv::AppendEncodedValue(include_value, &include_encoded);
+    Put(ColumnKey(v, include_column_id_, ht, first_write_id + 2), include_encoded);
+  }
+
+  // In-place identity update (yb_lsm.c doAssignForIdxUpdate shape): a lone ybidxbasectid
+  // column write.
+  void WriteInPlaceIdentityUpdate(
+      int32_t v, const std::string& identity, HybridTime ht, IntraTxnWriteId write_id = 0) {
+    Put(ColumnKey(v, basectid_column_id_, ht, write_id), EncodedBinary(identity));
+  }
+
+  // Backfill-shaped NON-packed insert (packing disabled): every record of one marked
+  // operation shares the operation's Raft-index write ID.
+  void WriteNonPackedBackfillInsert(
+      int32_t v, const std::string& identity, IntraTxnWriteId write_id) {
+    Put(LivenessKey(v, kBackfillHT, write_id),
+        std::string(1, dockv::ValueEntryTypeAsChar::kNullLow));
+    Put(ColumnKey(v, basectid_column_id_, kBackfillHT, write_id), EncodedBinary(identity));
+  }
+
+  void WriteRowTombstone(int32_t v, HybridTime ht, IntraTxnWriteId write_id = 0) {
+    Put(RowLevelKey(v, ht, write_id), std::string(1, dockv::ValueEntryTypeAsChar::kTombstone));
+  }
+
+  // --- Verification -----------------------------------------------------------------------
+
+  Result<UniqueIndexVerificationResult> Verify(
+      size_t max_dockey_groups = 0, const std::string& start_dockey = std::string(),
+      size_t max_buffered = 1024) {
+    // Flush so verification reads SSTs as production does (also exercises key bounds).
+    RETURN_NOT_OK(FlushRocksDbAndWait(rocksdb::FlushReason::kTestOnly));
+    TestSchemaPackingProvider provider(schema_packing_);
+    UniqueIndexVerifierOptions options;
+    options.window_lower = kWindowLower;
+    options.window_upper = kWindowUpper;
+    options.ybidxbasectid_column_id = basectid_column_id_;
+    options.start_dockey = start_dockey;
+    options.max_dockey_groups = max_dockey_groups;
+    options.max_buffered_versions_per_group = max_buffered;
+    return VerifyUniqueIndexTablet(
+        regular_db_.get(), KeyBounds(), &provider, options);
+  }
+
+  void ExpectOutcome(
+      UniqueIndexVerificationOutcome expected,
+      const UniqueIndexVerificationResult& result) {
+    ASSERT_EQ(expected, result.outcome) << result.ToString();
+  }
+
+  class TestSchemaPackingProvider : public SchemaPackingProvider {
+   public:
+    explicit TestSchemaPackingProvider(std::shared_ptr<const dockv::SchemaPacking> packing)
+        : packing_(std::move(packing)) {}
+
+    Result<CompactionSchemaInfo> CotablePacking(
+        const Uuid& cotable_id, uint32_t schema_version, HybridTime history_cutoff) override {
+      CompactionSchemaInfo info;
+      info.table_type = TableType::PGSQL_TABLE_TYPE;
+      info.schema_version = schema_version;
+      info.schema_packing = packing_;
+      return info;
+    }
+
+    Result<CompactionSchemaInfo> ColocationPacking(
+        ColocationId colocation_id, uint32_t schema_version, HybridTime history_cutoff) override {
+      return CotablePacking(Uuid::Nil(), schema_version, history_cutoff);
+    }
+
+   private:
+    std::shared_ptr<const dockv::SchemaPacking> packing_;
+  };
+
+  static constexpr uint16_t kFixedHashCode = 0;
+
+  Schema schema_;
+  std::shared_ptr<dockv::SchemaPacking> schema_packing_;
+  ColumnId basectid_column_id_{0};
+  ColumnId include_column_id_{0};
+};
+
+TEST_F(UniqueIndexVerifierTest, EmptyTabletIsClean) {
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, result);
+  ASSERT_EQ(0, result.dockey_groups_scanned);
+  ASSERT_TRUE(result.resume_from_dockey.empty());
+}
+
+TEST_F(UniqueIndexVerifierTest, SingleBackfillInsertIsClean) {
+  WriteBackfillInsert(1, "ctid-A");
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, result);
+  ASSERT_EQ(1, result.dockey_groups_scanned);
+}
+
+TEST_F(UniqueIndexVerifierTest, TwoDistinctIdentitiesAtBackfillHTIsViolation) {
+  // The funnel-duplicate shape SKIP_ALL exists to catch: two base rows with the same indexed
+  // value, both re-materialized at backfill_read_ht under distinct marked write IDs.
+  WriteBackfillInsert(1, "ctid-A", kBackfillWriteId);
+  WriteBackfillInsert(1, "ctid-B", kBackfillWriteId + 1);
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kViolation, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, TwoNonPackedBackfillInsertsDistinctIdentitiesIsViolation) {
+  // The funnel-duplicate shape on a packing-disabled cluster: each marked operation's column
+  // records share one write ID, so the two candidates assemble into two insert events and
+  // the duplicate is a Violation, not an ambiguity.
+  WriteNonPackedBackfillInsert(1, "ctid-A", kBackfillWriteId);
+  WriteNonPackedBackfillInsert(1, "ctid-B", kBackfillWriteId + 1);
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kViolation, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, TwoNonPackedBackfillInsertsSameIdentityIsClean) {
+  WriteNonPackedBackfillInsert(1, "ctid-A", kBackfillWriteId);
+  WriteNonPackedBackfillInsert(1, "ctid-A", kBackfillWriteId + 5);
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, RetriedBackfillChunkIsIdempotent) {
+  // 3a review L3: marked writes make chunk retries physically visible -- same identity at
+  // the same hybrid time under distinct write IDs. Idempotent, never a violation.
+  WriteBackfillInsert(1, "ctid-A", kBackfillWriteId);
+  WriteBackfillInsert(1, "ctid-A", kBackfillWriteId + 7);
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, ForegroundBeforeBackfillAtEqualHT) {
+  // A foreground insert landing at exactly backfill_read_ht carries a write ID below the
+  // marked-domain floor, so chronological replay orders it first; the backfill insert of the
+  // same identity is then an idempotent repeat.
+  WriteNonPackedInsert(1, "ctid-A", kBackfillHT, /* first_write_id= */ 3);
+  WriteBackfillInsert(1, "ctid-A", kBackfillWriteId);
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, result);
+
+  // Distinct identities at the equal hybrid time are a violation regardless of order.
+  WriteBackfillInsert(2, "ctid-C", kBackfillWriteId);
+  WriteNonPackedInsert(2, "ctid-D", kBackfillHT, /* first_write_id= */ 3);
+  result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kViolation, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, InsertDeleteInsertIsClean) {
+  WriteBackfillInsert(1, "ctid-A");
+  WriteRowTombstone(1, 5000_usec_ht);
+  WriteNonPackedInsert(1, "ctid-B", 6000_usec_ht, /* first_write_id= */ 0);
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, TransientOverlapIsViolation) {
+  // The overlap existed between 4000 and 5000 even though it was later resolved; verification
+  // reports what the index allowed, not just its final state.
+  WriteBackfillInsert(1, "ctid-A");
+  WriteNonPackedInsert(1, "ctid-B", 4000_usec_ht, /* first_write_id= */ 0);
+  WriteRowTombstone(1, 5000_usec_ht);
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kViolation, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, InPlaceIdentityUpdateIsClean) {
+  // Legal PK update: the base row's ctid changes in place (standalone ybidxbasectid column
+  // shape); the identity is replaced, never a duplicate.
+  WriteBackfillInsert(1, "ctid-A");
+  WriteInPlaceIdentityUpdate(1, "ctid-B", 5000_usec_ht);
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, PackedUpdateReplacesIdentity) {
+  // The same legal PK update in the packed-V2-with-kIsUpdateFlag shape
+  // (pack_full_row_update + mark).
+  WriteBackfillInsert(1, "ctid-A");
+  Put(RowLevelKey(1, 5000_usec_ht, 0),
+      PackedRow(dockv::PackedRowVersion::kV2, "ctid-B", /* is_update= */ true));
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, result);
+
+  // An unflagged packed row of a distinct identity is an insert and must still violate.
+  Put(RowLevelKey(1, 6000_usec_ht, 0),
+      PackedRow(dockv::PackedRowVersion::kV2, "ctid-C", /* is_update= */ false));
+  result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kViolation, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, PackedV1InsertShapes) {
+  WriteBackfillInsert(1, "ctid-A");
+  Put(RowLevelKey(1, 5000_usec_ht, 0),
+      PackedRow(dockv::PackedRowVersion::kV1, "ctid-A", /* is_update= */ false));
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, result);
+
+  Put(RowLevelKey(1, 6000_usec_ht, 0),
+      PackedRow(dockv::PackedRowVersion::kV1, "ctid-B", /* is_update= */ false));
+  result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kViolation, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, UpdateEstablishesOnEmptyLiveSet) {
+  // Defensive semantics (scan-algorithm-0812 Finding 4): an update as the first in-window
+  // event establishes the identity. It cannot mask a duplicate: had two identities been live
+  // at the window start, SKIP_ALL would have re-materialized both as inserts.
+  WriteInPlaceIdentityUpdate(1, "ctid-A", 5000_usec_ht);
+  WriteBackfillInsert(1, "ctid-A");  // Same identity later re-asserted: idempotent.
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, IncludeColumnUpdateKeepsLiveIdentity) {
+  WriteBackfillInsert(1, "ctid-A");
+  // INCLUDE-column-only update: no identity change.
+  std::string include_encoded;
+  QLValuePB include_value;
+  include_value.set_int32_value(9);
+  dockv::AppendEncodedValue(include_value, &include_encoded);
+  Put(ColumnKey(1, include_column_id_, 5000_usec_ht, 0), include_encoded);
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, result);
+
+  // The live identity survived the no-op event: a later distinct insert still violates.
+  WriteNonPackedInsert(1, "ctid-B", 6000_usec_ht, /* first_write_id= */ 0);
+  result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kViolation, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, RecordsOutsideWindowAreIgnored) {
+  // Below the window: pre-backfill foreground maintenance, superseded by SKIP_ALL
+  // re-materialization. Above the window: outside this verification's responsibility.
+  WriteNonPackedInsert(1, "ctid-old", 1000_usec_ht, /* first_write_id= */ 0);
+  WriteBackfillInsert(1, "ctid-A");
+  WriteNonPackedInsert(1, "ctid-new", 9500_usec_ht, /* first_write_id= */ 0);
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, result);
+}
+
+TEST_F(UniqueIndexVerifierTest, UnknownEncodingIsInconclusive) {
+  WriteBackfillInsert(1, "ctid-A");
+  // A row-level value type the verifier does not understand (an object container marker).
+  Put(RowLevelKey(1, 5000_usec_ht, 0),
+      std::string(1, dockv::ValueEntryTypeAsChar::kObject));
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kInconclusive, result);
+  ASSERT_FALSE(result.reason.empty());
+}
+
+TEST_F(UniqueIndexVerifierTest, PaginationIsDocKeyAligned) {
+  WriteBackfillInsert(1, "ctid-A");
+  WriteBackfillInsert(2, "ctid-B");
+  WriteBackfillInsert(2, "ctid-C", kBackfillWriteId + 1);  // Violation in the second group.
+
+  auto first_page = ASSERT_RESULT(Verify(/* max_dockey_groups= */ 1));
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, first_page);
+  ASSERT_EQ(1, first_page.dockey_groups_scanned);
+  ASSERT_FALSE(first_page.resume_from_dockey.empty());
+
+  auto second_page = ASSERT_RESULT(
+      Verify(/* max_dockey_groups= */ 0, first_page.resume_from_dockey));
+  ExpectOutcome(UniqueIndexVerificationOutcome::kViolation, second_page);
+}
+
+TEST_F(UniqueIndexVerifierTest, OversizedGroupFallsBackToReverseWalk) {
+  // A group larger than the buffer bound is replayed by the reverse walk. The event order
+  // matters: insert A, delete, insert B is clean only when replayed chronologically.
+  WriteBackfillInsert(1, "ctid-A");
+  WriteRowTombstone(1, 4000_usec_ht);
+  WriteNonPackedInsert(1, "ctid-B", 5000_usec_ht, /* first_write_id= */ 0);
+  for (int i = 0; i != 8; ++i) {
+    WriteInPlaceIdentityUpdate(1, "ctid-B", HybridTime::FromMicros(6000 + i), /* write_id= */ 0);
+  }
+  // A second, buffered group after the oversized one must still be verified.
+  WriteBackfillInsert(2, "ctid-C", kBackfillWriteId);
+  WriteBackfillInsert(2, "ctid-D", kBackfillWriteId + 1);
+
+  auto result = ASSERT_RESULT(Verify(
+      /* max_dockey_groups= */ 0, std::string(), /* max_buffered= */ 4));
+  ExpectOutcome(UniqueIndexVerificationOutcome::kViolation, result);
+  ASSERT_EQ(1, result.dockey_groups_scanned);  // Group 1 clean; violation stops in group 2.
+
+  // The same oversized group is clean on its own (fallback replay order is chronological).
+  auto clean_result = ASSERT_RESULT(Verify(
+      /* max_dockey_groups= */ 1, std::string(), /* max_buffered= */ 4));
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, clean_result);
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/unique_index_verifier.cc
+++ b/src/yb/docdb/unique_index_verifier.cc
@@ -1,0 +1,604 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/docdb/unique_index_verifier.h"
+
+#include <algorithm>
+#include <array>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "yb/common/doc_hybrid_time.h"
+#include "yb/common/value.messages.h"
+
+#include "yb/docdb/bounded_rocksdb_iterator.h"
+#include "yb/docdb/docdb_compaction_context.h"
+
+#include "yb/dockv/doc_key.h"
+#include "yb/dockv/packed_row.h"
+#include "yb/dockv/packed_value.h"
+#include "yb/dockv/primitive_value.h"
+#include "yb/dockv/schema_packing.h"
+#include "yb/dockv/value.h"
+#include "yb/dockv/value_type.h"
+
+#include "yb/rocksdb/db.h"
+
+#include "yb/util/fast_varint.h"
+#include "yb/util/format.h"
+#include "yb/util/status_format.h"
+
+namespace yb::docdb {
+
+namespace {
+
+// Classification of one physical record inside a DocKey group.
+YB_DEFINE_ENUM(RecordKind,
+    (kTombstone)        // Row-level DEL.
+    (kPackedInsert)     // Packed row without the update flag (V1, or V2 sans kIsUpdateFlag).
+    (kPackedUpdate)     // Packed V2 row with kIsUpdateFlag.
+    (kLivenessColumn)   // The system liveness column of a non-packed insert.
+    (kTargetColumn)     // The ybidxbasectid column.
+    (kOtherColumn));    // Any other column (INCLUDE columns etc.); carries no identity.
+
+struct PhysicalRecord {
+  DocHybridTime doc_ht;
+  RecordKind kind;
+  // Normalized identity bytes for kPacked* / kTargetColumn records (PrimitiveValue
+  // representation, comparable across packed and non-packed shapes).
+  std::optional<dockv::PrimitiveValue> identity;
+};
+
+// The logical event a batch of same-hybrid-time records assembles into.
+YB_DEFINE_ENUM(EventKind, (kInsert)(kUpdate)(kDelete)(kNoOp));
+
+struct LogicalEvent {
+  EventKind kind;
+  std::optional<dockv::PrimitiveValue> identity;
+};
+
+Result<dockv::PrimitiveValue> UnpackIdentity(dockv::PackedValueV1 value) {
+  RETURN_NOT_OK(dockv::ValueControlFields::Decode(&*value));
+  return dockv::UnpackPrimitiveValue(value, DataType::BINARY);
+}
+
+class Verifier {
+ public:
+  Verifier(
+      rocksdb::DB* regular_db, const KeyBounds& key_bounds,
+      SchemaPackingProvider* schema_packing_provider, const UniqueIndexVerifierOptions& options)
+      : db_(regular_db),
+        key_bounds_(key_bounds),
+        schema_packing_provider_(schema_packing_provider),
+        options_(options),
+        iter_(regular_db, VerifierReadOptions(), &key_bounds_) {}
+
+  // The scan is a one-shot pass over history that regular reads never touch; keep it from
+  // evicting the working set.
+  static rocksdb::ReadOptions VerifierReadOptions() {
+    rocksdb::ReadOptions read_options;
+    read_options.fill_cache = false;
+    return read_options;
+  }
+
+  Result<UniqueIndexVerificationResult> Run() {
+    if (!options_.start_dockey.empty()) {
+      iter_.Seek(options_.start_dockey);
+    } else {
+      iter_.SeekToFirst();
+    }
+
+    while (iter_.Valid()) {
+      const auto group_prefix_size = VERIFY_RESULT(dockv::DocKey::EncodedSize(
+          iter_.key(), dockv::DocKeyPart::kWholeDocKey));
+      // Copied: the underlying slice is invalidated by iterator movement.
+      const auto group_prefix_str = iter_.key().Prefix(group_prefix_size).ToBuffer();
+      const Slice group_prefix(group_prefix_str);
+
+      if ((options_.max_dockey_groups != 0 &&
+           result_.dockey_groups_scanned >= options_.max_dockey_groups) ||
+          CoarseMonoClock::Now() >= options_.deadline) {
+        result_.resume_from_dockey = group_prefix_str;
+        return result_;
+      }
+
+      RETURN_NOT_OK(VerifyGroup(group_prefix));
+      if (result_.outcome != UniqueIndexVerificationOutcome::kClean) {
+        return result_;
+      }
+      ++result_.dockey_groups_scanned;
+    }
+    RETURN_NOT_OK(iter_.status());
+    return result_;
+  }
+
+ private:
+  // Replays one DocKey group chronologically. Storage order within a group is hybrid time
+  // descending, then write ID descending; full reversal of that order is exactly
+  // "hybrid time ascending, write ID ascending within one hybrid time" -- the required
+  // replay order, with foreground write IDs (below the marked-domain floor) sorting before
+  // floored backfill write IDs at an equal hybrid time. The group is buffered and replayed
+  // in reverse; a group exceeding the buffer bound falls back to a bounded-memory reverse
+  // walk (Prev() from the group's end is natively chronological).
+  Status VerifyGroup(Slice group_prefix) {
+    std::vector<PhysicalRecord> buffered;
+    bool buffering = true;
+
+    while (iter_.Valid() && iter_.key().starts_with(group_prefix)) {
+      if (buffering) {
+        auto record = VERIFY_RESULT(DecodeRecord(group_prefix, iter_.key(), iter_.value()));
+        ++result_.versions_scanned;
+        if (record) {
+          buffered.push_back(std::move(*record));
+        }
+        if (result_.outcome == UniqueIndexVerificationOutcome::kInconclusive) {
+          return Status::OK();
+        }
+        if (buffered.size() > options_.max_buffered_versions_per_group) {
+          buffering = false;
+          buffered.clear();
+        }
+      }
+      iter_.Next();
+    }
+    RETURN_NOT_OK(iter_.status());
+
+    if (buffering) {
+      return ReplayBuffered(std::move(buffered));
+    }
+    return ReverseWalkGroup(group_prefix);
+  }
+
+  // Buffered path. Storage order within a group is subkey-section-major (all row-level
+  // versions, then each column's versions), not hybrid-time-major, so the buffer is sorted
+  // into chronological order -- hybrid time ascending, write ID ascending -- before batching
+  // records that share one hybrid time.
+  Status ReplayBuffered(std::vector<PhysicalRecord> buffered) {
+    live_.reset();
+    std::sort(
+        buffered.begin(), buffered.end(), [](const PhysicalRecord& a, const PhysicalRecord& b) {
+          return a.doc_ht < b.doc_ht;
+        });
+    std::vector<PhysicalRecord> ht_batch;
+    for (auto& record : buffered) {
+      if (!ht_batch.empty() &&
+          ht_batch.back().doc_ht.hybrid_time() != record.doc_ht.hybrid_time()) {
+        RETURN_NOT_OK(ReplayHybridTimeBatch(ht_batch));
+        if (result_.outcome != UniqueIndexVerificationOutcome::kClean) {
+          return Status::OK();
+        }
+        ht_batch.clear();
+      }
+      ht_batch.push_back(std::move(record));
+    }
+    if (!ht_batch.empty()) {
+      RETURN_NOT_OK(ReplayHybridTimeBatch(ht_batch));
+    }
+    return Status::OK();
+  }
+
+  // A reverse cursor over one subkey section of a DocKey group (the row-level section or one
+  // column's section). Within a section, storage order is hybrid time descending / write ID
+  // descending, so a Prev() walk from the section's end is natively chronological.
+  class SectionCursor {
+   public:
+    SectionCursor(rocksdb::DB* db, const KeyBounds* key_bounds, std::string section_prefix)
+        : section_prefix_(std::move(section_prefix)),
+          iter_(db, Verifier::VerifierReadOptions(), key_bounds) {
+      // No valid key byte is kMaxByte, so prefix + kMaxByte seeks past every key of the
+      // section (same construction as the compaction code's ranged deletes).
+      std::string past_section = section_prefix_;
+      past_section.push_back(dockv::KeyEntryTypeAsChar::kMaxByte);
+      iter_.Seek(past_section);
+      if (iter_.Valid()) {
+        iter_.Prev();
+      } else {
+        iter_.SeekToLast();
+      }
+      Revalidate();
+    }
+
+    bool valid() const { return valid_; }
+    Slice key() const { return iter_.key(); }
+    Slice value() const { return iter_.value(); }
+
+    void Advance() {
+      iter_.Prev();
+      Revalidate();
+    }
+
+    Status status() const { return iter_.status(); }
+
+   private:
+    void Revalidate() {
+      valid_ = iter_.Valid() && iter_.key().starts_with(section_prefix_);
+    }
+
+    std::string section_prefix_;
+    BoundedRocksDbIterator iter_;
+    bool valid_ = false;
+  };
+
+  // Bounded-memory fallback for oversized groups: merge three reverse section cursors --
+  // row-level records (packed rows, tombstones), the liveness column, and the ybidxbasectid
+  // column -- in chronological order. Other columns never affect the live-identity state, so
+  // their sections are not walked. Memory is O(records at one hybrid time).
+  Status ReverseWalkGroup(Slice group_prefix) {
+    live_.reset();
+
+    const auto group = group_prefix.ToBuffer();
+    auto make_column_prefix = [&group](const dockv::KeyEntryValue& column) {
+      dockv::KeyBytes key;
+      key.AppendRawBytes(group);
+      column.AppendToKey(&key);
+      return key.ToStringBuffer();
+    };
+    // Row-level keys are group + kHybridTime + inverted doc hybrid time; column keys are
+    // group + <subkey> + kHybridTime + ..., so prefixing with the group plus the hybrid-time
+    // terminator scopes the first cursor to exactly the row-level section.
+    std::string row_level_prefix = group;
+    row_level_prefix.push_back(dockv::KeyEntryTypeAsChar::kHybridTime);
+    std::array<SectionCursor, 3> cursors{
+        SectionCursor(db_, &key_bounds_, row_level_prefix),
+        SectionCursor(db_, &key_bounds_, make_column_prefix(dockv::KeyEntryValue::kLivenessColumn)),
+        SectionCursor(
+            db_, &key_bounds_,
+            make_column_prefix(
+                dockv::KeyEntryValue::MakeColumnId(options_.ybidxbasectid_column_id)))};
+
+    std::vector<PhysicalRecord> ht_batch;
+    while (true) {
+      // Pick the chronologically smallest current record among valid cursors.
+      SectionCursor* next = nullptr;
+      DocHybridTime next_doc_ht;
+      std::optional<PhysicalRecord> next_record;
+      for (auto& cursor : cursors) {
+        while (cursor.valid()) {
+          auto record = VERIFY_RESULT(DecodeRecord(group_prefix, cursor.key(), cursor.value()));
+          if (result_.outcome == UniqueIndexVerificationOutcome::kInconclusive) {
+            return Status::OK();
+          }
+          if (!record) {  // Outside the window.
+            ++result_.versions_scanned;
+            cursor.Advance();
+            continue;
+          }
+          if (next == nullptr || record->doc_ht < next_doc_ht) {
+            next = &cursor;
+            next_doc_ht = record->doc_ht;
+            next_record = std::move(*record);
+          }
+          break;
+        }
+        RETURN_NOT_OK(cursor.status());
+      }
+      if (next == nullptr) {
+        break;
+      }
+      ++result_.versions_scanned;
+      next->Advance();
+
+      if (!ht_batch.empty() &&
+          ht_batch.back().doc_ht.hybrid_time() != next_record->doc_ht.hybrid_time()) {
+        RETURN_NOT_OK(ReplayHybridTimeBatch(ht_batch));
+        if (result_.outcome != UniqueIndexVerificationOutcome::kClean) {
+          return Status::OK();
+        }
+        ht_batch.clear();
+      }
+      ht_batch.push_back(std::move(*next_record));
+    }
+    if (!ht_batch.empty()) {
+      RETURN_NOT_OK(ReplayHybridTimeBatch(ht_batch));
+    }
+    return Status::OK();
+  }
+
+  // One non-packed logical event being assembled from column records.
+  struct ColumnGroup {
+    IntraTxnWriteId position = 0;  // Write ID of the group's first record (event order).
+    bool has_records = false;
+    bool saw_liveness = false;
+    std::optional<dockv::PrimitiveValue> identity;
+  };
+
+  // Assembles the records of one hybrid time (write ID ascending) into logical events and
+  // applies them in write ID order. Packed rows and tombstones are self-contained events at
+  // their own write IDs. Non-packed column records group into events by write-ID structure:
+  //  - Marked records (write ID at or above the marked-domain floor) come from marked
+  //    backfill batches, where every record of one operation shares the operation's
+  //    Raft-index-derived write ID -- so column records group by exact write ID, one event
+  //    per backfill operation. This is what lets two non-packed backfill candidates at the
+  //    fixed hybrid time surface as two inserts (a Violation) rather than an ambiguity.
+  //  - Unmarked records come from foreground transactions, whose intents take consecutive
+  //    write IDs from the intra-transaction sequence -- so all unmarked column records of
+  //    one hybrid time assemble into a single event (two foreground writers of one DocKey
+  //    at one commit hybrid time would collide physically; conflicting shapes fail closed).
+  // Group semantics: liveness present -> insert (identity from the ybidxbasectid record; an
+  // insert always carries it); a lone ybidxbasectid record -> in-place update (yb_lsm.c
+  // doAssignForIdxUpdate); other-column records alone (e.g. INCLUDE updates) -> no event.
+  Status ReplayHybridTimeBatch(const std::vector<PhysicalRecord>& batch) {
+    std::vector<std::pair<IntraTxnWriteId, LogicalEvent>> events;
+    ColumnGroup unmarked_group;
+    std::map<IntraTxnWriteId, ColumnGroup> marked_groups;
+
+    for (const auto& record : batch) {
+      const auto write_id = record.doc_ht.write_id();
+      switch (record.kind) {
+        case RecordKind::kTombstone:
+          events.emplace_back(write_id, LogicalEvent{EventKind::kDelete, std::nullopt});
+          continue;
+        case RecordKind::kPackedInsert:
+          events.emplace_back(write_id, LogicalEvent{EventKind::kInsert, record.identity});
+          continue;
+        case RecordKind::kPackedUpdate:
+          events.emplace_back(write_id, LogicalEvent{EventKind::kUpdate, record.identity});
+          continue;
+        case RecordKind::kLivenessColumn: [[fallthrough]];
+        case RecordKind::kTargetColumn:   [[fallthrough]];
+        case RecordKind::kOtherColumn:
+          break;
+      }
+      auto& group = write_id >= kBackfillWriteIdFloor ? marked_groups[write_id]
+                                                      : unmarked_group;
+      if (!group.has_records) {
+        group.has_records = true;
+        group.position = write_id;
+      }
+      if (record.kind == RecordKind::kLivenessColumn) {
+        group.saw_liveness = true;
+      } else if (record.kind == RecordKind::kTargetColumn) {
+        if (group.identity && *group.identity != *record.identity) {
+          Inconclusive("multiple distinct identities in one non-packed event group");
+          return Status::OK();
+        }
+        group.identity = record.identity;
+      }
+    }
+
+    const auto emit_group = [&events, this](const ColumnGroup& group) {
+      if (!group.has_records) {
+        return true;
+      }
+      if (group.saw_liveness) {
+        if (!group.identity) {
+          Inconclusive("insert-shaped event group without an identity column");
+          return false;
+        }
+        events.emplace_back(group.position, LogicalEvent{EventKind::kInsert, group.identity});
+      } else if (group.identity) {
+        events.emplace_back(group.position, LogicalEvent{EventKind::kUpdate, group.identity});
+      }
+      return true;
+    };
+    if (!emit_group(unmarked_group)) {
+      return Status::OK();
+    }
+    for (const auto& [_, group] : marked_groups) {
+      if (!emit_group(group)) {
+        return Status::OK();
+      }
+    }
+
+    std::stable_sort(
+        events.begin(), events.end(),
+        [](const auto& a, const auto& b) { return a.first < b.first; });
+    for (const auto& [_, event] : events) {
+      RETURN_NOT_OK(ApplyEvent(event));
+      if (result_.outcome != UniqueIndexVerificationOutcome::kClean) {
+        return Status::OK();
+      }
+    }
+    return Status::OK();
+  }
+
+  // The live-identity state machine (design document 3.2.4 / scan-algorithm-0812 Finding 4).
+  Status ApplyEvent(const LogicalEvent& event) {
+    switch (event.kind) {
+      case EventKind::kInsert:
+        if (!live_) {
+          live_ = event.identity;
+          return Status::OK();
+        }
+        if (*live_ == *event.identity) {
+          return Status::OK();  // Idempotent retry (chunk retry, maintenance rewrite).
+        }
+        result_.outcome = UniqueIndexVerificationOutcome::kViolation;
+        result_.reason = "second distinct identity became live in a DocKey group";
+        return Status::OK();
+      case EventKind::kUpdate:
+        // Replace, or establish on an empty set: an update can only be issued against an
+        // entry that was already live, and it cannot mask a duplicate because SKIP_ALL
+        // re-materializes every window-start identity as an insert inside the window.
+        live_ = event.identity;
+        return Status::OK();
+      case EventKind::kDelete:
+        live_.reset();
+        return Status::OK();
+      case EventKind::kNoOp:
+        return Status::OK();
+    }
+    FATAL_INVALID_ENUM_VALUE(EventKind, event.kind);
+  }
+
+  // Decodes one physical record; returns nullopt for records outside the verification
+  // window. Sets kInconclusive (and returns nullopt) for encodings the verifier cannot
+  // interpret conclusively.
+  Result<std::optional<PhysicalRecord>> DecodeRecord(
+      Slice group_prefix, Slice key, Slice value) {
+    dockv::SubDocKey subdoc_key;
+    RETURN_NOT_OK(subdoc_key.FullyDecodeFrom(key, dockv::HybridTimeRequired::kTrue));
+    const auto doc_ht = subdoc_key.doc_hybrid_time();
+
+    const auto ht = doc_ht.hybrid_time();
+    if (ht < options_.window_lower || ht > options_.window_upper) {
+      // Below the window: superseded pre-backfill maintenance, re-materialized by SKIP_ALL
+      // inside the window. Above the window: outside this verification's responsibility.
+      return std::nullopt;
+    }
+
+    PhysicalRecord record;
+    record.doc_ht = doc_ht;
+
+    const auto& subkeys = subdoc_key.subkeys();
+    if (subkeys.empty()) {
+      return DecodeRowLevelRecord(subdoc_key, value, std::move(record));
+    }
+    if (subkeys.size() != 1) {
+      Inconclusive("unexpected subkey depth");
+      return std::nullopt;
+    }
+    const auto& subkey = subkeys.front();
+    if (subkey.type() == dockv::KeyEntryType::kSystemColumnId) {
+      if (subkey != dockv::KeyEntryValue::kLivenessColumn) {
+        Inconclusive("unexpected system column");
+        return std::nullopt;
+      }
+      record.kind = RecordKind::kLivenessColumn;
+      return record;
+    }
+    if (subkey.type() != dockv::KeyEntryType::kColumnId) {
+      Inconclusive("unexpected subkey type");
+      return std::nullopt;
+    }
+    if (subkey.GetColumnId() != options_.ybidxbasectid_column_id) {
+      record.kind = RecordKind::kOtherColumn;
+      return record;
+    }
+    record.kind = RecordKind::kTargetColumn;
+    auto identity = UnpackIdentity(dockv::PackedValueV1(value));
+    if (!identity.ok()) {
+      Inconclusive("undecodable identity column value");
+      return std::nullopt;
+    }
+    record.identity = std::move(*identity);
+    return record;
+  }
+
+  Result<std::optional<PhysicalRecord>> DecodeRowLevelRecord(
+      const dockv::SubDocKey& subdoc_key, Slice value, PhysicalRecord record) {
+    auto value_copy = value;
+    auto control_fields_result = dockv::ValueControlFields::Decode(&value_copy);
+    if (!control_fields_result.ok() || value_copy.empty()) {
+      Inconclusive("undecodable row-level value");
+      return std::nullopt;
+    }
+    const auto value_type = dockv::DecodeValueEntryType(value_copy);
+    if (value_type == dockv::ValueEntryType::kTombstone) {
+      record.kind = RecordKind::kTombstone;
+      return std::move(record);
+    }
+    const auto packed_version = dockv::GetPackedRowVersion(value_type);
+    if (!packed_version) {
+      Inconclusive("unexpected row-level value type");
+      return std::nullopt;
+    }
+
+    value_copy.consume_byte();
+    auto identity_result = DecodePackedIdentity(
+        subdoc_key.doc_key(), *packed_version, &value_copy, &record);
+    if (!identity_result.ok()) {
+      Inconclusive("undecodable packed row");
+      return std::nullopt;
+    }
+    return std::move(record);
+  }
+
+  // Extracts the ybidxbasectid column from a packed row and classifies insert vs update
+  // (packed V2 rows carry kIsUpdateFlag when written by full-row-update packing; V1 rows
+  // and unflagged V2 rows are inserts).
+  Status DecodePackedIdentity(
+      const dockv::DocKey& doc_key, dockv::PackedRowVersion version, Slice* value,
+      PhysicalRecord* record) {
+    SchemaVersion schema_version;
+    bool is_update = false;
+    if (version == dockv::PackedRowVersion::kV2) {
+      // The V2 header parse does not advance the slice; consume the schema-version varint so
+      // the slice lands on the flags byte, which is where PackedRowDecoderV2 expects it.
+      const auto header = VERIFY_RESULT(dockv::ParsePackedRowV2Header(*value));
+      schema_version = header.schema_version;
+      is_update = header.IsUpdate();
+      RETURN_NOT_OK(FastDecodeUnsignedVarInt(value));
+    } else {
+      schema_version = narrow_cast<SchemaVersion>(
+          VERIFY_RESULT(FastDecodeUnsignedVarInt(value)));
+    }
+
+    CompactionSchemaInfo packing_info;
+    if (doc_key.colocation_id() != kColocationIdNotSet) {
+      packing_info = VERIFY_RESULT(schema_packing_provider_->ColocationPacking(
+          doc_key.colocation_id(), schema_version, HybridTime::kMax));
+    } else {
+      packing_info = VERIFY_RESULT(schema_packing_provider_->CotablePacking(
+          doc_key.has_cotable_id() ? doc_key.cotable_id() : Uuid::Nil(), schema_version,
+          HybridTime::kMax));
+    }
+    const auto& packing = *packing_info.schema_packing;
+
+    switch (version) {
+      case dockv::PackedRowVersion::kV1: {
+        record->kind = RecordKind::kPackedInsert;
+        auto column_value = packing.GetValue(options_.ybidxbasectid_column_id, *value);
+        SCHECK(column_value.has_value(), NotFound, "identity column absent from packed row");
+        record->identity = VERIFY_RESULT(UnpackIdentity(dockv::PackedValueV1(*column_value)));
+        return Status::OK();
+      }
+      case dockv::PackedRowVersion::kV2: {
+        record->kind = is_update ? RecordKind::kPackedUpdate : RecordKind::kPackedInsert;
+        dockv::PackedRowDecoderV2 decoder(packing, value->data());
+        auto column_value = decoder.FetchValue(options_.ybidxbasectid_column_id);
+        SCHECK(!column_value.IsNull(), NotFound, "identity column null in packed row");
+        record->identity =
+            VERIFY_RESULT(dockv::UnpackPrimitiveValue(column_value, DataType::BINARY));
+        return Status::OK();
+      }
+    }
+    FATAL_INVALID_ENUM_VALUE(dockv::PackedRowVersion, version);
+  }
+
+  void Inconclusive(const std::string& reason) {
+    result_.outcome = UniqueIndexVerificationOutcome::kInconclusive;
+    result_.reason = reason;
+  }
+
+  rocksdb::DB* db_;
+  const KeyBounds& key_bounds_;
+  SchemaPackingProvider* schema_packing_provider_;
+  const UniqueIndexVerifierOptions& options_;
+  BoundedRocksDbIterator iter_;
+  UniqueIndexVerificationResult result_;
+  std::optional<dockv::PrimitiveValue> live_;
+};
+
+}  // namespace
+
+std::string UniqueIndexVerificationResult::ToString() const {
+  return YB_STRUCT_TO_STRING(outcome, reason, dockey_groups_scanned, versions_scanned,
+                             resume_from_dockey);
+}
+
+Result<UniqueIndexVerificationResult> VerifyUniqueIndexTablet(
+    rocksdb::DB* regular_db,
+    const KeyBounds& key_bounds,
+    SchemaPackingProvider* schema_packing_provider,
+    const UniqueIndexVerifierOptions& options) {
+  SCHECK(options.window_lower && options.window_upper, InvalidArgument,
+         "Verification window bounds must be valid hybrid times");
+  SCHECK_LE(options.window_lower, options.window_upper, InvalidArgument,
+            "Verification window is inverted");
+  return Verifier(regular_db, key_bounds, schema_packing_provider, options).Run();
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/unique_index_verifier.h
+++ b/src/yb/docdb/unique_index_verifier.h
@@ -1,0 +1,93 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <string>
+
+#include "yb/common/column_id.h"
+#include "yb/common/hybrid_time.h"
+
+#include "yb/docdb/docdb_fwd.h"
+
+#include "yb/rocksdb/rocksdb_fwd.h"
+
+#include "yb/util/enums.h"
+#include "yb/util/monotime.h"
+#include "yb/util/result.h"
+
+namespace yb::docdb {
+
+// Per-tablet outcome of a deferred uniqueness verification scan (#33444).
+// kClean: no DocKey group in the scanned range ever had two distinct live identities.
+// kViolation: some group had a second distinct identity become live inside the window.
+// kInconclusive: a physical record could not be interpreted conclusively; fail closed.
+YB_DEFINE_ENUM(UniqueIndexVerificationOutcome, (kClean)(kViolation)(kInconclusive));
+
+struct UniqueIndexVerifierOptions {
+  // Inclusive verification window [backfill_read_ht, verify_upper_ht]. Sufficiency of this
+  // window rests on the SKIP_ALL invariant: backfill unconditionally re-materializes every
+  // identity live at backfill_read_ht *at* backfill_read_ht, so each DocKey group replays
+  // from an empty live set. Any change that reintroduces conditional backfill writes
+  // invalidates this scan range.
+  HybridTime window_lower;
+  HybridTime window_upper;
+
+  // The ybidxbasectid column of the unique index (a regular value column; the identity).
+  ColumnId ybidxbasectid_column_id;
+
+  // Encoded DocKey to resume from (inclusive); empty scans from the beginning of the tablet's
+  // key bounds. Pagination is DocKey-aligned: a group's history is never split across calls.
+  std::string start_dockey;
+
+  // Stop (with a resume key) after this many complete DocKey groups; 0 = unbounded.
+  size_t max_dockey_groups = 0;
+
+  // Stop (with a resume key) at the first group boundary past the deadline.
+  CoarseTimePoint deadline = CoarseTimePoint::max();
+
+  // Version-group buffering bound; a group exceeding it is replayed by the bounded-memory
+  // reverse walk instead of being buffered.
+  size_t max_buffered_versions_per_group = 1024;
+};
+
+struct UniqueIndexVerificationResult {
+  UniqueIndexVerificationOutcome outcome = UniqueIndexVerificationOutcome::kClean;
+
+  // Value-free context for kViolation / kInconclusive: encoding classes and counts only,
+  // never key or value bytes. (A keyed diagnostic fingerprint is deliberately absent until
+  // the observability part lands; see the design document's privacy requirements.)
+  std::string reason;
+
+  // Non-empty when the scan stopped early (group budget or deadline): the encoded DocKey to
+  // resume from. Empty means the scan reached the end of the key bounds.
+  std::string resume_from_dockey;
+
+  size_t dockey_groups_scanned = 0;
+  size_t versions_scanned = 0;
+
+  std::string ToString() const;
+};
+
+// Scans the regular database of a unique-index tablet and replays every DocKey group's
+// physical history in the window chronologically (hybrid time ascending; write ID ascending
+// within one hybrid time, which orders foreground records before floored backfill records).
+// Read-only. The caller is responsible for ensuring intents through window_upper are applied
+// and history at window_lower is retained.
+Result<UniqueIndexVerificationResult> VerifyUniqueIndexTablet(
+    rocksdb::DB* regular_db,
+    const KeyBounds& key_bounds,
+    SchemaPackingProvider* schema_packing_provider,
+    const UniqueIndexVerifierOptions& options);
+
+}  // namespace yb::docdb


### PR DESCRIPTION
## Summary

The read half of deferred uniqueness verification (#33444): `docdb::VerifyUniqueIndexTablet`
scans a unique-index tablet's regular database over the inclusive window
`[backfill_read_ht, verify_upper_ht]` and replays every DocKey group's physical history
chronologically, deciding Clean / Violation / Inconclusive per the design document's
live-identity state machine. Read-only library + unit tests; the tserver RPC and the master
coordinator that drive it are the next parts of the stack.

The window starts each group from an empty live set because SKIP_ALL backfill unconditionally
re-materializes every identity live at `backfill_read_ht` *at* `backfill_read_ht` -- stated as
a precondition on the options, since any change reintroducing conditional backfill writes
invalidates the scan range.

Replay order is hybrid time ascending, write ID ascending within one hybrid time -- which
orders foreground records (write IDs below the marked-domain floor, #33553) before floored
backfill records at an equal hybrid time. Storage order within a group is
subkey-section-major (all row-level versions, then each column's), not hybrid-time-major, so
the default path buffers a group and sorts it chronologically; a group exceeding the buffer
bound is replayed by a bounded-memory merge of three reverse section cursors (row-level,
liveness column, ybidxbasectid column -- other columns never affect identity state). Within
one section a Prev() walk is natively chronological.

Physical records assemble into logical events per (DocKey, hybrid time): packed rows and
row-level tombstones are self-contained events at their own write IDs (packed V2 rows with
kIsUpdateFlag are updates; V1 and unflagged V2 are inserts). Non-packed column records group
by write-ID structure: marked records (at or above `kBackfillWriteIdFloor`) group by exact
write ID -- every record of one marked backfill operation shares the operation's Raft-index
write ID, so two non-packed backfill candidates surface as two inserts (a Violation) even on
packing-disabled clusters -- while unmarked records assemble into one foreground event
(intents take consecutive write IDs; two foreground writers of one DocKey at one commit
hybrid time would collide physically, and conflicting shapes fail closed). With the liveness
column present a group is an insert; a lone ybidxbasectid record is the in-place identity
update yb_lsm.c emits for PK updates; other-column-only writes (INCLUDE updates) change
nothing. The identity is the decoded ybidxbasectid value, comparable across packed and
non-packed shapes. Ambiguous or unknown encodings return Inconclusive, never a guess.

State machine: Insert adds (second distinct live identity = Violation; repeated identity =
idempotent retry -- marked writes make chunk retries physically visible as same-identity
versions); Update replaces, or establishes on an empty set (it cannot mask a duplicate: two
window-start identities would both have been re-materialized as inserts); Delete clears the
whole set (unique-index tombstones are DocKey-level).

Violation/Inconclusive results carry value-free reasons and counts only; the keyed diagnostic
fingerprint is deliberately deferred to the observability part, where key management belongs.
Pagination is DocKey-aligned: the scan stops on group budget or deadline with an encoded
resume key; a group's history is never split across pages.

One activation-decision input recorded for the eventual default-on work: packed *V1*
full-row updates carry no flags byte and are indistinguishable from inserts, so verify-time
correctness requires `ysql_mark_update_packed_row` whenever `pack_full_row_update` is
enabled.

The scan's iterators set `fill_cache = false`: a one-shot pass over history that regular
reads never touch should not evict the working set.

No production caller and no daemon changes: pure library + tests, no performance surface.

Stacked on #33403, #33404, #33484, #33544, #33553, #33580, and #33584, based on
`feature-stack/Shopify/uniq-idx-3b-ii-generation-orchestration` per the feature-stack
workflow, so the diff is exactly this PR's own commit. A failing pr-title check on stacked
PRs is a known gap in that check; the stack merges bottom-up and retargets as parents merge.

## Test plan

macOS arm64, release -- all green:

- [x] `unique_index_verifier-test`, 18 cases: empty tablet; single backfill insert; the
      funnel-duplicate shape (two distinct identities at backfill_read_ht under distinct
      marked write IDs) in both the packed and the non-packed (packing-disabled) shapes, with
      the same-identity non-packed variant clean; idempotent retried chunks;
      foreground-before-backfill at an equal hybrid time (same identity clean, distinct
      identities violation); insert-delete-insert clean; transient overlap violation;
      in-place PK update (standalone column shape); packed-V2-with-flag PK update (and
      unflagged packed insert still violating); packed V1 shapes;
      update-establishes-on-empty; INCLUDE-column update preserving the live identity;
      below/above-window records ignored; unknown encoding inconclusive with reason;
      DocKey-aligned pagination with resume; oversized-group fallback (violation found in a
      later group; clean oversized group replayed in correct chronological order).

AlmaLinux (x86_64, clang21), rebased onto master `c7253d204d`:

At this PR's own commit (`5e7f8e08cf`), debug -- all green:

- [x] `unique_index_verifier-test` (full).

Integrated at the stack tip (`334a1deb3d`), all green. Exact suites per build type:

- [x] TSAN (6): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `non_transactional_batch_writer-test`,
      `keyed_fingerprint-test`, `raft_consensus-itest`.
- [x] ASAN (15): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `keyed_fingerprint-test`,
      `non_transactional_batch_writer-test`, `clone-tablet-itest`,
      `remote_bootstrap-itest`, `tablet_bootstrap-test`, `auto_flags-itest`,
      `docdb-test`, `compaction_file_filter-test`,
      `xcluster_external_apply_bootstrap-test`, `pg_txn-test`, `pg_ash-test`,
      full `pg_index_backfill-test`.
- [x] Debug (19): the ASAN list minus `compaction_file_filter-test`, plus
      `master_failover-itest`, `snapshot-test`, `tablet_snapshots-test`,
      `compaction-test`, `tablet-split-itest`.
- [x] Release (5): `keyed_fingerprint-test`, `auto_flags-itest`, full
      `pg_index_backfill-test`, java `TestIndexBackfill`, java
      `TestPgRegressBackfillIndex`.
- [x] All three full `pg_index_backfill-test` runs (ASAN, debug, release) pass with no
      test failures.

Two known-upstream issues surfaced by the tip matrix, both shown not attributable to this
stack:

- TSAN `tablet-split-itest` reports 3 data races in `yb::client::YBTable::~YBTable()`
  (table.cc:81) racing its partition-refresh callback, inside the upstream test
  `AutomaticTabletSplitITest.SizeRatio` (93 cases ran, 0 gtest failures). This stack has zero
  diff under `src/yb/client/`, and that test passes 3/3 isolated at the new master base.
- `wait_states-itest` hangs 9 cases at the 601s timeout (`AshCql`, the `kYCQL_*` group,
  `kBackfillIndex_*`, `kConsensusMeta_Flush`, `kCreatingNewTablet`,
  `kSaveRaftGroupMetadataToDisk`). Reproduced identically on plain master `c7253d204d`
  carrying none of this stack's code: 53 ran, the same 9 failed, same ~600.5s expiries.

Disposition change since the previous revision: the
`PgIndexBackfillBackendsManager.NoAbortTxn/1` flake cited earlier was fixed upstream. It
passes 3/3 at the new base and in all three full `pg_index_backfill-test` runs here, so it is
no longer carried as a known flake.

