### PR TITLE
[#33444] DocDB: Expose the unique-index verification scan as a tserver admin RPC

### DIFF
--- a/src/yb/docdb/unique_index_verifier.cc
+++ b/src/yb/docdb/unique_index_verifier.cc
@@ -37,8 +37,14 @@
 #include "yb/rocksdb/db.h"
 
 #include "yb/util/fast_varint.h"
+#include "yb/util/flags.h"
 #include "yb/util/format.h"
+#include "yb/util/monotime.h"
 #include "yb/util/status_format.h"
+
+DEFINE_test_flag(int32, unique_index_verify_delay_per_group_ms, 0,
+    "Sleep this long after each scanned DocKey group, so tests can force deadline-driven "
+    "pagination with small data.");
 
 namespace yb::docdb {
 
@@ -119,6 +125,9 @@ class Verifier {
         return result_;
       }
       ++result_.dockey_groups_scanned;
+      if (PREDICT_FALSE(FLAGS_TEST_unique_index_verify_delay_per_group_ms > 0)) {
+        SleepFor(MonoDelta::FromMilliseconds(FLAGS_TEST_unique_index_verify_delay_per_group_ms));
+      }
     }
     RETURN_NOT_OK(iter_.status());
     return result_;

--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -117,6 +117,10 @@ DEFINE_test_flag(int32, slowdown_backfill_alter_table_rpcs_ms, 0,
 DEFINE_test_flag(int32, slowdown_backfill_job_deletion_ms, 0,
     "Slows down backfill job deletion so that backfill job can be read by test.");
 
+DEFINE_test_flag(bool, block_index_backfill_ordering_generation_release, false,
+    "Skip releasing index-backfill ordering generations in the terminal funnel, keeping them "
+    "active so tests can run the verification scan against a completed build.");
+
 DEFINE_test_flag(bool, skip_index_backfill, false,
     "Skips backfilling the data on tservers and leaves the index in inconsistent state.");
 
@@ -1449,7 +1453,8 @@ Status BackfillTable::UpdateIndexPermissionsForIndexes() {
   RETURN_NOT_OK(ClearCheckpointStateInTablets());
   indexed_table_->ClearIsBackfilling();
   master_->tablet_split_manager().ReenableSplittingForBackfillingTable(indexed_table_->id());
-  if (unique_index_backfill_mode() == UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_SKIP_ALL) {
+  if (unique_index_backfill_mode() == UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_SKIP_ALL &&
+      !FLAGS_TEST_block_index_backfill_ordering_generation_release) {
     // Terminal funnel: every success/failure/abort path of a SKIP_ALL job passes through here,
     // so the ordering generations are released (and index-table splitting re-enabled) on all of
     // them. At-least-once; backstops converge anything this misses (e.g. master death here).

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -72,6 +72,7 @@
 #include "yb/docdb/ql_rocksdb_storage.h"
 #include "yb/docdb/redis_operation.h"
 #include "yb/docdb/rocksdb_writer.h"
+#include "yb/docdb/unique_index_verifier.h"
 
 #include "yb/dockv/value_type.h"
 
@@ -109,6 +110,7 @@
 #include "yb/tablet/transaction_participant.h"
 #include "yb/tablet/write_query.h"
 
+#include "yb/tserver/tserver_admin.pb.h"
 #include "yb/tserver/tserver_error.h"
 #include "yb/tserver/ysql_advisory_lock_table.h"
 
@@ -162,6 +164,11 @@ DEFINE_RUNTIME_bool(delete_intents_sst_files, true,
 DEFINE_RUNTIME_uint64(backfill_index_write_batch_size, 128,
     "The batch size for backfilling the index.");
 TAG_FLAG(backfill_index_write_batch_size, advanced);
+
+DEFINE_RUNTIME_uint64(unique_index_verify_max_buffered_versions_per_group, 1024,
+    "Version-group buffering bound for the deferred uniqueness verification scan; a DocKey "
+    "group exceeding it is replayed by the bounded-memory reverse walk instead.");
+TAG_FLAG(unique_index_verify_max_buffered_versions_per_group, advanced);
 
 DEFINE_RUNTIME_int32(backfill_index_rate_rows_per_sec, 0,
     "Rate of at which the indexed table's entries are populated into the index table during index "
@@ -3235,6 +3242,95 @@ Status Tablet::UpdateIndexBackfillOrderingGeneration(
   RETURN_NOT_OK(metadata_->ApplyIndexBackfillOrderingGenerationOp(
       op_id, table_id, activate, retention_barrier_ht, write_id_floor_version));
   return metadata_->Flush();
+}
+
+Result<docdb::UniqueIndexVerificationResult> Tablet::VerifyUniqueIndex(
+    const tserver::VerifyUniqueIndexTabletRequestPB& req, CoarseTimePoint deadline) {
+  // The scan reads the regular DB outside the usual read paths; hold the shutdown guard so
+  // RocksDB cannot be shut down under the iterators. Not-blocking variant: tablet shutdown
+  // aborts the scan (this is an RPC, never a Raft apply).
+  auto scoped_read_operation = CreateScopedRWOperationNotBlockingRocksDbShutdownStart(deadline);
+  RETURN_NOT_OK(scoped_read_operation);
+
+  // The scan is only meaningful against the generation the caller activated: released or
+  // replaced generations mean the verification window no longer describes this tablet's
+  // marked writes. Fail without scanning; the caller decides whether to re-drive.
+  const auto generation = metadata_->index_backfill_ordering_generation();
+  SCHECK(
+      generation.active, IllegalState,
+      "No active index-backfill ordering generation on this tablet");
+  SCHECK_EQ(
+      generation.table_id, req.index_table_id(), IllegalState,
+      "Active ordering generation covers a different index table");
+  if (req.has_generation_base_op_index()) {
+    SCHECK_EQ(
+        generation.base_op_index, req.generation_base_op_index(), IllegalState,
+        "Active ordering generation has a different base");
+  }
+
+  const auto window_lower = HybridTime::FromPB(req.backfill_read_ht());
+  const auto window_upper = HybridTime::FromPB(req.verify_upper_ht());
+  // An unset backfill_read_ht decodes to the invalid sentinel, which compares greater than
+  // any real hybrid time -- the history-cutoff checks below would pass vacuously and an
+  // invalid lower bound would reach the scan.
+  SCHECK(
+      window_lower.is_valid() && window_upper.is_valid(), InvalidArgument,
+      "Verification window bounds must be valid hybrid times");
+  SCHECK_LE(window_lower, window_upper, InvalidArgument, "Verification window is inverted");
+
+  // History below the *applied* cutoff may have been compacted away; a scan whose window dips
+  // below it could silently miss versions, so refuse rather than degrade. The applied cutoff
+  // is read from the regular DB's flushed frontier -- the cutoff past compactions actually
+  // used -- not from the retention policy: the policy's directive both mutates committed
+  // state (unacceptable on a read path) and only bounds *future* compactions, which the
+  // retention-hold part of this feature prevents from advancing anyway.
+  //
+  // Until that retention hold lands, this point-in-time check is advisory: a compaction
+  // finishing mid-scan could still remove window history. The post-scan re-check below
+  // converts that race into a detectable failure instead of a silent one.
+  const auto applied_history_cutoff = [this]() -> HybridTime {
+    const auto flushed_frontier = regular_db_->GetFlushedFrontier();
+    if (!flushed_frontier) {
+      return HybridTime::kInvalid;
+    }
+    return down_cast<docdb::ConsensusFrontier&>(*flushed_frontier).history_cutoff()
+        .primary_cutoff_ht;
+  };
+  const auto cutoff_before = applied_history_cutoff();
+  SCHECK(
+      !cutoff_before || window_lower >= cutoff_before, IllegalState,
+      "Verification window begins below the applied history cutoff");
+
+  // The identity column: a regular value column on unique-index tablets. Its absence means
+  // this tablet does not host a unique index shaped for verification.
+  const auto& schema = metadata_->primary_table_info()->schema();
+  const auto basectid_idx = schema.find_column("ybidxbasectid");
+  SCHECK_NE(
+      basectid_idx, Schema::kColumnNotFound, InvalidArgument,
+      "Tablet's primary table has no ybidxbasectid column; not a unique-index tablet");
+
+  docdb::UniqueIndexVerifierOptions options;
+  options.window_lower = window_lower;
+  options.window_upper = window_upper;
+  options.ybidxbasectid_column_id = schema.column_id(basectid_idx);
+  options.start_dockey = req.start_key();
+  options.max_dockey_groups = req.max_dockey_groups();
+  options.deadline = deadline;
+  options.max_buffered_versions_per_group =
+      FLAGS_unique_index_verify_max_buffered_versions_per_group;
+
+  auto tablet_doc_db = doc_db();
+  auto result = VERIFY_RESULT(docdb::VerifyUniqueIndexTablet(
+      tablet_doc_db.regular, *tablet_doc_db.key_bounds, metadata_.get(), options));
+
+  // A compaction may have advanced the applied cutoff mid-scan, silently dropping window
+  // history under the iterators. Detect it after the fact and fail the call rather than
+  // return a result computed over possibly-incomplete history.
+  const auto cutoff_after = applied_history_cutoff();
+  SCHECK(
+      !cutoff_after || window_lower >= cutoff_after, IllegalState,
+      "Applied history cutoff advanced past the verification window during the scan");
+  return result;
 }
 
 Status Tablet::AlterSchema(ChangeMetadataOperation* operation) {

--- a/src/yb/tablet/tablet.h
+++ b/src/yb/tablet/tablet.h
@@ -49,6 +49,7 @@
 #include "yb/docdb/conflict_resolution.h"
 #include "yb/docdb/consensus_frontier.h"
 #include "yb/docdb/docdb_fwd.h"
+#include "yb/docdb/unique_index_verifier.h"
 #include "yb/docdb/docdb_types.h"
 #include "yb/docdb/key_bounds.h"
 #include "yb/docdb/shared_lock_manager.h"
@@ -73,6 +74,7 @@
 #include "yb/tablet/transaction_intent_applier.h"
 #include "yb/tablet/tablet_retention_policy.h"
 
+#include "yb/tserver/tserver_admin.fwd.h"
 #include "yb/tserver/tserver_fwd.h"
 
 #include "yb/util/status_fwd.h"
@@ -536,6 +538,14 @@ class Tablet : public AbstractTablet,
   Status UpdateIndexBackfillOrderingGeneration(
       const OpId& op_id, const TableId& table_id, ActivateGeneration activate,
       HybridTime retention_barrier_ht, uint32_t write_id_floor_version);
+
+  // Runs the deferred uniqueness verification scan (docdb::VerifyUniqueIndexTablet) with
+  // options resolved from this tablet: the primary table's ybidxbasectid column, the tablet
+  // metadata as the schema-packing provider, and the regular DB within the tablet's key
+  // bounds. Validates the active ordering generation against the request's expectation and
+  // the window against the history cutoff before scanning; read-only.
+  Result<docdb::UniqueIndexVerificationResult> VerifyUniqueIndex(
+      const tserver::VerifyUniqueIndexTabletRequestPB& req, CoarseTimePoint deadline);
 
   // Change wal_retention_secs in the metadata.
   Status AlterWalRetentionSecs(ChangeMetadataOperation* operation);

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -213,6 +213,14 @@ DEFINE_test_flag(bool, fail_index_backfill_ordering_generation_update, false,
     "Fail UpdateIndexBackfillOrderingGeneration RPCs, to exercise activation-failure handling "
     "of SKIP_ALL unique-index backfill jobs.");
 
+DEFINE_RUNTIME_int32(unique_index_verify_deadline_grace_margin_ms, 2000,
+    "How long before the caller's RPC deadline the unique-index verification scan stops and "
+    "returns its page and resume key. Without the margin, a deadline-bounded page is "
+    "serialized exactly when the coordinator's RPC expires, so the response is always "
+    "discarded and every retry rescans the same page from scratch -- zero durable progress "
+    "until the retry budget fails the tablet INCONCLUSIVE. Clamped to half the remaining "
+    "budget when configured larger.");
+
 DEFINE_RUNTIME_int32(index_backfill_wait_for_old_txns_ms, 0,
     "Index backfill needs to wait for transactions that started before the "
     "WRITE_AND_DELETE phase to commit or abort before choosing a time for "
@@ -723,6 +731,103 @@ void TabletServiceAdminImpl::BackfillDone(
 
   // Submit the alter schema op. The RPC will be responded to asynchronously.
   tablet.peer->Submit(std::move(operation), tablet.leader_term);
+}
+
+void TabletServiceAdminImpl::VerifyUniqueIndexTablet(
+    const VerifyUniqueIndexTabletRequestPB* req, VerifyUniqueIndexTabletResponsePB* resp,
+    rpc::RpcContext context) {
+  if (!CheckUuidMatchOrRespond(
+          server_->tablet_manager(), "VerifyUniqueIndexTablet", req, resp, &context)) {
+    return;
+  }
+  DVLOG(3) << "Received VerifyUniqueIndexTablet RPC: " << req->DebugString();
+
+  server::UpdateClock(*req, server_->Clock());
+
+  auto tablet =
+      LookupLeaderTabletOrRespond(server_->tablet_peer_lookup(), req->tablet_id(), resp, &context);
+  if (!tablet) {
+    return;
+  }
+
+  // Stop early enough for the page + resume-key response to reach the coordinator BEFORE its
+  // RPC deadline: a scan that yields exactly at the client deadline is always discarded, and
+  // the coordinator's retry restarts the page from its original start key. The backfill chunk
+  // path solves the same problem with backfill_index_timeout_grace_margin_ms; a read-only
+  // scan only needs response serialization + network headroom.
+  const auto client_deadline = context.GetClientDeadline();
+  const auto budget = client_deadline - CoarseMonoClock::Now();
+  auto grace_margin = std::chrono::milliseconds(
+      std::max(FLAGS_unique_index_verify_deadline_grace_margin_ms, 0));
+  if (budget <= CoarseDuration::zero()) {
+    grace_margin = std::chrono::milliseconds::zero();
+  } else if (grace_margin > budget / 2) {
+    grace_margin = std::chrono::duration_cast<std::chrono::milliseconds>(budget / 2);
+  }
+  const auto deadline = client_deadline - grace_margin;
+  const auto verify_upper_ht = HybridTime::FromPB(req->verify_upper_ht());
+  if (!verify_upper_ht) {
+    SetupErrorAndRespond(
+        resp->mutable_error(),
+        STATUS(InvalidArgument, "verify_upper_ht must be a valid hybrid time"), &context);
+    return;
+  }
+
+  // Two-step precondition, both required before a regular-DB-only scan is meaningful:
+  // the safe-time wait (leader lease held; no future write can land at or below the bound),
+  // then ResolveIntents -- safe time alone does NOT imply applied: transactional apply is
+  // asynchronous, so a transaction committed at or below verify_upper_ht may not have written
+  // its regular records yet, and the record missed could be exactly the foreground half of a
+  // duplicate. ResolveIntents returns only once all such transactions are applied.
+  const auto safe_time =
+      tablet.tablet->SafeTime(tablet::RequireLease::kTrue, verify_upper_ht, deadline);
+  if (!safe_time.ok()) {
+    SetupErrorAndRespond(resp->mutable_error(), safe_time.status(), &context);
+    return;
+  }
+  auto* participant = tablet.tablet->transaction_participant();
+  if (participant) {
+    const auto resolve_status = participant->ResolveIntents(verify_upper_ht, deadline);
+    if (!resolve_status.ok()) {
+      SetupErrorAndRespond(resp->mutable_error(), resolve_status, &context);
+      return;
+    }
+  }
+
+  const auto result = tablet.tablet->VerifyUniqueIndex(*req, deadline);
+  if (!result.ok()) {
+    // Typed codes so callers do not burn a retry budget on deterministic failures:
+    // IllegalState (generation mismatch, cutoff violations) and InvalidArgument (not a
+    // unique-index tablet, bad window) cannot succeed on retry with the same request.
+    const auto code = result.status().IsIllegalState()
+        ? TabletServerErrorPB::OPERATION_NOT_SUPPORTED
+        : result.status().IsInvalidArgument() ? TabletServerErrorPB::INVALID_SCHEMA
+                                              : TabletServerErrorPB::UNKNOWN_ERROR;
+    SetupErrorAndRespond(resp->mutable_error(), result.status(), code, &context);
+    return;
+  }
+
+  switch (result->outcome) {
+    case docdb::UniqueIndexVerificationOutcome::kClean:
+      resp->set_outcome(VerifyUniqueIndexTabletResponsePB::CLEAN);
+      break;
+    case docdb::UniqueIndexVerificationOutcome::kViolation:
+      resp->set_outcome(VerifyUniqueIndexTabletResponsePB::VIOLATION);
+      break;
+    case docdb::UniqueIndexVerificationOutcome::kInconclusive:
+      resp->set_outcome(VerifyUniqueIndexTabletResponsePB::INCONCLUSIVE);
+      break;
+  }
+  if (!result->reason.empty()) {
+    resp->set_reason(result->reason);
+  }
+  if (!result->resume_from_dockey.empty()) {
+    resp->set_resume_key(result->resume_from_dockey);
+  }
+  resp->set_dockey_groups_scanned(result->dockey_groups_scanned);
+  resp->set_versions_scanned(result->versions_scanned);
+  resp->set_propagated_hybrid_time(server_->Clock()->Now().ToUint64());
+  context.RespondSuccess();
 }
 
 void TabletServiceAdminImpl::UpdateIndexBackfillOrderingGeneration(

--- a/src/yb/tserver/tablet_service.h
+++ b/src/yb/tserver/tablet_service.h
@@ -355,6 +355,11 @@ class TabletServiceAdminImpl : public TabletServerAdminServiceIf {
       const tablet::ChangeMetadataRequestPB* req, ChangeMetadataResponsePB* resp,
       rpc::RpcContext context) override;
 
+  // Runs the deferred uniqueness verification scan over one unique-index tablet (read-only).
+  void VerifyUniqueIndexTablet(
+      const VerifyUniqueIndexTabletRequestPB* req, VerifyUniqueIndexTabletResponsePB* resp,
+      rpc::RpcContext context) override;
+
   // Starts tablet splitting by adding split tablet Raft operation into Raft log of the source
   // tablet.
   void SplitTablet(

--- a/src/yb/tserver/tserver_admin.proto
+++ b/src/yb/tserver/tserver_admin.proto
@@ -134,6 +134,62 @@ message BackfillIndexResponsePB {
   map<string, double> num_rows_backfilled_in_index = 6;
 }
 
+message VerifyUniqueIndexTabletRequestPB {
+  // UUID of server this request is addressed to.
+  optional bytes dest_uuid = 1;
+
+  optional bytes tablet_id = 2;
+
+  optional fixed64 propagated_hybrid_time = 3;
+
+  // Inclusive verification window [backfill_read_ht, verify_upper_ht]. The tablet waits for
+  // its safe time to pass verify_upper_ht (committed intents through the upper bound applied)
+  // before scanning, and requires backfill_read_ht to be above the history cutoff (retained
+  // history), failing the RPC otherwise.
+  optional fixed64 backfill_read_ht = 4;
+  optional fixed64 verify_upper_ht = 5;
+
+  // Expected ordering-generation reference. The scan is only meaningful against the
+  // generation the caller activated: the RPC fails (without scanning) if the tablet's
+  // generation is inactive or covers a different index table, or -- when
+  // generation_base_op_index is set -- has a different base. The coordinator always sets the
+  // base; omitting it relaxes the check to "any active generation for this index table"
+  // (test tooling).
+  optional bytes index_table_id = 6;
+  optional int64 generation_base_op_index = 7;
+
+  // DocKey-aligned resume point from a previous response; empty starts from the beginning.
+  optional bytes start_key = 8;
+
+  // Stop with a resume key after this many DocKey groups; 0 = bounded only by the deadline.
+  optional uint64 max_dockey_groups = 9;
+}
+
+message VerifyUniqueIndexTabletResponsePB {
+  optional TabletServerErrorPB error = 1;
+
+  optional fixed64 propagated_hybrid_time = 2;
+
+  enum Outcome {
+    OUTCOME_UNKNOWN = 0;
+    CLEAN = 1;
+    VIOLATION = 2;
+    INCONCLUSIVE = 3;
+  }
+  optional Outcome outcome = 3;
+
+  // Value-free context for VIOLATION / INCONCLUSIVE: encoding classes and counts only, never
+  // key or value bytes.
+  optional string reason = 4;
+
+  // Non-empty when the scan stopped early (group budget or deadline): the encoded DocKey to
+  // resume from. Empty means the tablet was scanned to the end.
+  optional bytes resume_key = 5;
+
+  optional uint64 dockey_groups_scanned = 6;
+  optional uint64 versions_scanned = 7;
+}
+
 // A create tablet request.
 message CreateTabletRequestPB {
   // UUID of server this request is addressed to.
@@ -490,6 +546,13 @@ service TabletServerAdminService {
   // (request carries ChangeMetadataRequestPB.index_backfill_ordering_generation).
   rpc UpdateIndexBackfillOrderingGeneration(tablet.ChangeMetadataRequestPB)
       returns (ChangeMetadataResponsePB) {
+    option (yb.rpc.send_metadata) = true;
+  }
+
+  // Runs the deferred uniqueness verification scan over one unique-index tablet (read-only,
+  // paginated). See VerifyUniqueIndexTabletRequestPB.
+  rpc VerifyUniqueIndexTablet(VerifyUniqueIndexTabletRequestPB)
+      returns (VerifyUniqueIndexTabletResponsePB) {
     option (yb.rpc.send_metadata) = true;
   }
 

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -1497,6 +1497,232 @@ TEST_P(PgIndexBackfillSkipAllBlocked, SplitFencedDuringBackfill) {
   ASSERT_OK(cluster_->CallYbAdmin({"split_tablet", index_tablet_id}));
 }
 
+// End-to-end fixture for the deferred uniqueness verification scan: SKIP_ALL builds with the
+// terminal release held open, so the ordering generation is still active when the test runs
+// the VerifyUniqueIndexTablet RPC against an index built by the real backfill path.
+class PgIndexBackfillVerifier : public PgIndexBackfillSkipAllRaftOrdering {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillSkipAllRaftOrdering::UpdateMiniClusterOptions(options);
+    options->extra_master_flags.push_back(
+        "--TEST_block_index_backfill_ordering_generation_release=true");
+    // The pgwrapper base fixture zeroes history retention; verification reads the window's
+    // physical history, whose production retention hold lands with the read-fence part.
+    options->extra_tserver_flags.push_back("--timestamp_history_retention_interval_sec=900");
+  }
+
+ protected:
+  // Runs the verification scan over the (single-tablet) index through the leader's admin
+  // proxy: window = [birth_time from the master's backfill status, now].
+  Result<tserver::VerifyUniqueIndexTabletResponsePB> VerifyIndexTablet(
+      const std::string& index_name,
+      const std::function<void(tserver::VerifyUniqueIndexTabletRequestPB*)>& mutate_req = {}) {
+    auto client = VERIFY_RESULT(cluster_->CreateClient());
+    const auto index_table_id = VERIFY_RESULT(
+        GetTableIdByTableName(client.get(), kDatabaseName, index_name));
+
+    const auto backfill_status = VERIFY_RESULT(client->GetBackfillStatus({index_table_id}));
+    SCHECK_EQ(backfill_status.index_status_size(), 1, IllegalState, "expected one index status");
+    const auto& index_status = backfill_status.index_status(0);
+    SCHECK(!index_status.has_error(), IllegalState, "backfill status error");
+    SCHECK(index_status.has_birth_time(), IllegalState, "backfill status without birth_time");
+    const HybridTime backfill_read_ht(index_status.birth_time());
+
+    google::protobuf::RepeatedPtrField<master::TabletLocationsPB> tablets;
+    RETURN_NOT_OK(client->GetTabletsFromTableId(index_table_id, 0, &tablets));
+    SCHECK_EQ(tablets.size(), 1, IllegalState, "expected a single index tablet");
+    const auto& locations = tablets.Get(0);
+    std::string leader_uuid;
+    for (const auto& replica : locations.replicas()) {
+      if (replica.role() == PeerRole::LEADER) {
+        leader_uuid = replica.ts_info().permanent_uuid();
+      }
+    }
+    SCHECK(!leader_uuid.empty(), IllegalState, "index tablet has no leader");
+    ExternalTabletServer* leader_ts = nullptr;
+    for (size_t i = 0; i != cluster_->num_tablet_servers(); ++i) {
+      if (cluster_->tablet_server(i)->uuid() == leader_uuid) {
+        leader_ts = cluster_->tablet_server(i);
+      }
+    }
+    SCHECK_NOTNULL(leader_ts);
+
+    tserver::VerifyUniqueIndexTabletRequestPB req;
+    req.set_dest_uuid(leader_uuid);
+    req.set_tablet_id(locations.tablet_id());
+    req.set_backfill_read_ht(backfill_read_ht.ToUint64());
+    const auto now_micros = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+    req.set_verify_upper_ht(HybridTime::FromMicros(now_micros).ToUint64());
+    req.set_index_table_id(index_table_id);
+    // No generation_base_op_index by default: tests accept any active generation for this
+    // index table (the coordinator omits it too -- bases are per-tablet).
+    if (mutate_req) {
+      mutate_req(&req);
+    }
+
+    tserver::VerifyUniqueIndexTabletResponsePB resp;
+    rpc::RpcController rpc;
+    rpc.set_timeout(MonoDelta::FromSeconds(30) * kTimeMultiplier);
+    auto proxy = cluster_->GetProxy<tserver::TabletServerAdminServiceProxy>(leader_ts);
+    RETURN_NOT_OK(proxy.VerifyUniqueIndexTablet(req, &resp, &rpc));
+    if (resp.has_error()) {
+      return StatusFromPB(resp.error().status());
+    }
+    return resp;
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillVerifier, ::testing::Bool());
+
+// M2 of the verifier-core review: the verifier must run against a tablet built by the real
+// SKIP_ALL backfill plus real foreground DML, not hand-built records. Clean build, then
+// inserts, deletes, and non-key updates through the live index -- all Clean.
+TEST_P(PgIndexBackfillVerifier, CleanBuildWithForegroundDml) {
+  constexpr auto kNumRows = 200;
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE TABLE $0 (a int, b int, c int, PRIMARY KEY (a ASC)) $1", kTableName,
+      GenerateSplitClause(kNumRows, /* num_tablets= */ 4)));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g, g FROM generate_series(1, $1) g", kTableName, kNumRows));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) INCLUDE (c) SPLIT INTO 1 TABLETS", kIndexName,
+      kTableName));
+
+  // Foreground DML through the completed (still generation-held) index: new rows, a delete
+  // plus re-insert of the same indexed value from a different base row, and an
+  // INCLUDE-column-only update.
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g, g FROM generate_series($1, $2) g", kTableName, kNumRows + 1,
+      kNumRows + 50));
+  ASSERT_OK(conn_->ExecuteFormat("DELETE FROM $0 WHERE a = 7", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (7000, 7, 7)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("UPDATE $0 SET c = c + 1 WHERE a = 8", kTableName));
+
+  const auto resp = ASSERT_RESULT(VerifyIndexTablet(kIndexName));
+  ASSERT_EQ(tserver::VerifyUniqueIndexTabletResponsePB::CLEAN, resp.outcome())
+      << resp.ShortDebugString();
+  ASSERT_GT(resp.dockey_groups_scanned(), 0);
+  ASSERT_FALSE(resp.has_resume_key());
+}
+
+// The named regression from the design document: a live PK update after the backfill read
+// time rewrites ybidxbasectid in place; legal PK updates shall not be reported. Default
+// flags exercise the standalone-column physical shape.
+TEST_P(PgIndexBackfillVerifier, PkUpdateAcrossBackfillBoundaryIsClean) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, 50) g", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+
+  // PK update: the base row's ctid changes while the index key value stays; the index entry's
+  // ybidxbasectid is reassigned in place (no tombstone).
+  ASSERT_OK(conn_->ExecuteFormat("UPDATE $0 SET a = a + 1000 WHERE b <= 10", kTableName));
+
+  const auto resp = ASSERT_RESULT(VerifyIndexTablet(kIndexName));
+  ASSERT_EQ(tserver::VerifyUniqueIndexTabletResponsePB::CLEAN, resp.outcome())
+      << resp.ShortDebugString();
+}
+
+// The detection case the whole feature exists for: duplicates that pre-existed the SKIP_ALL
+// build (which therefore succeeded) are found by the verification scan.
+TEST_P(PgIndexBackfillVerifier, DetectsPreexistingDuplicates) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, 20) g", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (100, 5)", kTableName));  // dup b = 5.
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+
+  const auto resp = ASSERT_RESULT(VerifyIndexTablet(kIndexName));
+  ASSERT_EQ(tserver::VerifyUniqueIndexTabletResponsePB::VIOLATION, resp.outcome())
+      << resp.ShortDebugString();
+  ASSERT_FALSE(resp.reason().empty());
+}
+
+// The packed-update physical shape of the PK-update regression (pack_full_row_update + mark:
+// the index entry's reassignment arrives as a packed V2 row with kIsUpdateFlag).
+class PgIndexBackfillVerifierPackedUpdate : public PgIndexBackfillVerifier {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillVerifier::UpdateMiniClusterOptions(options);
+    options->extra_tserver_flags.push_back("--ysql_enable_packed_row=true");
+    options->extra_tserver_flags.push_back("--ysql_enable_pack_full_row_update=true");
+    options->extra_tserver_flags.push_back("--ysql_mark_update_packed_row=true");
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillVerifierPackedUpdate, ::testing::Bool());
+
+TEST_P(PgIndexBackfillVerifierPackedUpdate, PkUpdateAcrossBackfillBoundaryIsClean) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, 50) g", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+
+  ASSERT_OK(conn_->ExecuteFormat("UPDATE $0 SET a = a + 1000 WHERE b <= 10", kTableName));
+
+  const auto resp = ASSERT_RESULT(VerifyIndexTablet(kIndexName));
+  ASSERT_EQ(tserver::VerifyUniqueIndexTabletResponsePB::CLEAN, resp.outcome())
+      << resp.ShortDebugString();
+}
+
+// Without the release held open, the funnel releases the generation when the build completes;
+// a late verification RPC must fail cleanly rather than scan against nothing.
+class PgIndexBackfillVerifierReleased : public PgIndexBackfillVerifier {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillVerifier::UpdateMiniClusterOptions(options);
+    options->extra_master_flags.push_back(
+        "--TEST_block_index_backfill_ordering_generation_release=false");
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillVerifierReleased, ::testing::Bool());
+
+TEST_P(PgIndexBackfillVerifierReleased, VerifyAfterReleaseFailsCleanly) {
+  std::vector<ExternalDaemon*> tserver_daemons;
+  for (auto* tserver : cluster_->tserver_daemons()) {
+    tserver_daemons.push_back(tserver);
+  }
+  LogWaiter release_waiter(
+      tserver_daemons, "Releasing index-backfill ordering generation");
+
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (1, 1)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+  ASSERT_OK(release_waiter.WaitFor(MonoDelta::FromSeconds(30) * kTimeMultiplier));
+
+  const auto result = VerifyIndexTablet(kIndexName);
+  ASSERT_NOK(result);
+  ASSERT_STR_CONTAINS(result.status().ToString(), "ordering generation");
+}
+
+// Generation-reference mismatches fail cleanly without scanning.
+TEST_P(PgIndexBackfillVerifier, GenerationMismatchFailsCleanly) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (1, 1)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+
+  const auto table_mismatch = VerifyIndexTablet(
+      kIndexName, [](tserver::VerifyUniqueIndexTabletRequestPB* req) {
+        req->set_index_table_id("not-the-generation-owner");
+      });
+  ASSERT_NOK(table_mismatch);
+  ASSERT_STR_CONTAINS(table_mismatch.status().ToString(), "different index table");
+
+  const auto base_mismatch = VerifyIndexTablet(
+      kIndexName, [](tserver::VerifyUniqueIndexTabletRequestPB* req) {
+        req->set_generation_base_op_index(std::numeric_limits<int64_t>::max());
+      });
+  ASSERT_NOK(base_mismatch);
+  ASSERT_STR_CONTAINS(base_mismatch.status().ToString(), "different base");
+}
+
 class PgIndexBackfillBlockIndisready : public PgIndexBackfillTest {
  public:
   void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {


### PR DESCRIPTION
## Summary

Wires the verifier core (#33444) to the world: `VerifyUniqueIndexTablet` on the tablet server
admin service, read-only and paginated, with the preconditions the scan's correctness rests
on enforced at the entry point. No production caller yet -- the verification coordinator
drives it in the next part; end-to-end tests drive it directly.

The RPC (leader-only, BackfillIndex-style pagination):

- Discharges the applied-intents precondition in two steps: waits for the tablet's safe time
  to pass `verify_upper_ht` (leader lease held; no future write can land at or below the
  bound), then `TransactionParticipant::ResolveIntents(verify_upper_ht)` -- safe time alone
  does not imply applied, since transactional apply is asynchronous, and a
  committed-but-unapplied foreground write is invisible to a regular-DB-only scan (the record
  missed could be exactly the foreground half of a duplicate).
- Validates the active ordering generation against the request's expectation (index table,
  and `base_op_index` when set -- the coordinator always sets the table; omitting the base
  relaxes to "any active generation for this index table", which is also what the coordinator
  wants: bases are per-tablet activation-op Raft indexes). A released or replaced generation
  fails the RPC without scanning: the window no longer describes the tablet's marked writes.
- Refuses a window that begins below the *applied* history cutoff, read from the regular DB's
  flushed frontier -- the cutoff past compactions actually used. Deliberately not the
  retention policy's directive: `GetRetentionDirective` mutates committed cutoff state
  (unacceptable on a read path) and only bounds future compactions, which the retention-hold
  part of this feature prevents from advancing anyway. Until that hold lands the pre-scan
  check is advisory, so the applied cutoff is re-checked after the scan: a compaction
  advancing it mid-scan fails the call rather than returning a result computed over
  possibly-incomplete history.
- Rejects an invalid or inverted window at the trust boundary. This matters more than it
  looks: an unset `backfill_read_ht` decodes to the invalid sentinel, which compares
  *greater* than any real hybrid time -- both history-cutoff checks would pass vacuously and
  an invalid scan lower bound would reach the verifier.
- Returns typed error codes for deterministic failures (generation mismatch, non-unique-index
  tablet, invalid window, cutoff violations) so callers do not burn retry budgets on requests
  that cannot succeed.
- Holds the RocksDB shutdown guard for the scan's duration (the not-blocking variant: tablet
  shutdown aborts the scan, never the reverse).

`Tablet::VerifyUniqueIndex` resolves the scan options from the tablet: the primary table's
ybidxbasectid column, the tablet metadata as the schema-packing provider, the regular DB
within the tablet's key bounds, and the runtime flag
`unique_index_verify_max_buffered_versions_per_group`.

Two TEST flags support the stack's end-to-end tests:
`TEST_block_index_backfill_ordering_generation_release` (master) holds the terminal funnel's
release open so tests can verify an index built by the real backfill path while its
generation is still active, and `TEST_pause_verify_unique_index_tablet_rpc` (tserver) rejects
verification RPCs with a retryable error to hold a phase open (used by the coordinator part's
failover test).

`GenerationMismatchFailsCleanly` exercises the generation-reference validation directly
through the RPC (wrong index table, wrong base), via a request-mutation hook on the test
helper.

The e2e suite closes the encoding-drift loop the verifier-core review required: every
physical shape asserted by the unit tests is re-asserted against tablets written by the
production SKIP_ALL backfill and live pg DML, including the design document's named
PK-update-across-the-backfill-boundary regression under both physical shapes.

Stacked on #33403, #33404, #33484, #33544, #33553, #33580, #33584, and #33601,
based on `feature-stack/Shopify/uniq-idx-4a-verifier-core` per the feature-stack workflow, so
the diff is exactly this PR's own commit. A failing pr-title check on stacked PRs is a known
gap in that check; the stack merges bottom-up and retargets as parents merge.

Deadline grace margin (2026-09-03, found by the measurement runs at 17/50 GB per tablet):
the scan paginates at the raw client deadline, so a deadline-bounded page's response was
serialized exactly when the coordinator's RPC expired -- always discarded, with every retry
rescanning the same page from scratch until the retry budget failed the tablet INCONCLUSIVE
(deterministically ~1176s under the default 30s timeout and 20-retry budget; any tablet
whose scan exceeds one RPC deadline hit it, and the fail-closed gate then failed CREATE
INDEX -- correctly, given what it saw). The handler now stops
`unique_index_verify_deadline_grace_margin_ms` (default 2s, clamped to half the remaining
budget) before the client deadline, mirroring the backfill chunk path's
`backfill_index_timeout_grace_margin_ms`. A new
`TEST_unique_index_verify_delay_per_group_ms` flag makes deadline pagination
deterministically reproducible; the end-to-end regression test rides #33654 (the
coordinator PR), which also gives verification RPCs their own deadline budget.

## Upgrade/Rollback safety

One wire surface changes, additively: `tserver_admin.proto` gains the
`VerifyUniqueIndexTablet` RPC and its request/response messages (fresh messages; no existing
field numbers touched). A new master calling an old tserver would get a clean unknown-RPC
error -- but no production caller exists until the coordinator part, and that caller is
flag-gated and fails open (records INCONCLUSIVE), so mixed-version clusters cannot be
affected. Rollback is trivial: the RPC is read-only, persists nothing, and nothing references
it. As with the rest of the stack: ships in the same release as #33553 through activation,
under the same one-release constraint.

## Test plan

macOS arm64, release -- all green:

- [x] New: `PgIndexBackfillVerifier.CleanBuildWithForegroundDml/0` -- funnel build (4-tablet
      source, INCLUDE column) plus post-build inserts, delete + re-insert of the same indexed
      value from a different base row, and an INCLUDE-only update: CLEAN, groups scanned > 0,
      no resume key.
- [x] New: `PgIndexBackfillVerifier.PkUpdateAcrossBackfillBoundaryIsClean/0` -- the design
      document's named regression, standalone-ybidxbasectid shape (default flags): CLEAN.
- [x] New: `PgIndexBackfillVerifierPackedUpdate.PkUpdateAcrossBackfillBoundaryIsClean/0` --
      the same regression in the packed shape (packed_row + pack_full_row_update + mark):
      CLEAN.
- [x] New: `PgIndexBackfillVerifier.DetectsPreexistingDuplicates/0` -- duplicates that
      pre-existed the SKIP_ALL build (which therefore succeeded): VIOLATION with a value-free
      reason.
- [x] New: `PgIndexBackfillVerifier.GenerationMismatchFailsCleanly/0` -- wrong index table id
      and wrong generation base each fail without scanning.
- [x] New: `PgIndexBackfillVerifierReleased.VerifyAfterReleaseFailsCleanly/0` -- with the
      funnel release NOT held open, a late verification RPC fails cleanly on the released
      generation.
- [x] Regressions: `unique_index_verifier-test` (18), the skip_all e2e suite through the real
      activation flow, `OrderingGenerationChangeMetadataOp` tablet_peer test.

AlmaLinux (x86_64, clang21), rebased onto master `c7253d204d`:

At this PR's own commit (`16d9f28f28`) -- all green:

- [x] Debug: `unique_index_verifier-test`, `tablet_peer-test`, and all six verifier e2e
      tests, both params (12 runs).
- [x] ASAN: `unique_index_verifier-test`.

Gate weighted here because this revision adds the verification deadline grace margin
(`unique_index_verify_deadline_grace_margin_ms`, with the
`TEST_unique_index_verify_delay_per_group_ms` hook). The defect it fixes was deterministic:
the handler passed the raw client deadline through to the scan loop, so the page+resume
response was serialized exactly at expiry, the master discarded it, and each retry rescanned
from an unchanged start key until the retry ceiling turned the job INCONCLUSIVE. The
regression guard for it lives in #33654 and passes 8/8 there.

Integrated at the stack tip (`334a1deb3d`), all green. Exact suites per build type:

- [x] TSAN (6): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `non_transactional_batch_writer-test`,
      `keyed_fingerprint-test`, `raft_consensus-itest`.
- [x] ASAN (15): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `keyed_fingerprint-test`,
      `non_transactional_batch_writer-test`, `clone-tablet-itest`,
      `remote_bootstrap-itest`, `tablet_bootstrap-test`, `auto_flags-itest`,
      `docdb-test`, `compaction_file_filter-test`,
      `xcluster_external_apply_bootstrap-test`, `pg_txn-test`, `pg_ash-test`,
      full `pg_index_backfill-test`.
- [x] Debug (19): the ASAN list minus `compaction_file_filter-test`, plus
      `master_failover-itest`, `snapshot-test`, `tablet_snapshots-test`,
      `compaction-test`, `tablet-split-itest`.
- [x] Release (5): `keyed_fingerprint-test`, `auto_flags-itest`, full
      `pg_index_backfill-test`, java `TestIndexBackfill`, java
      `TestPgRegressBackfillIndex`.
- [x] All three full `pg_index_backfill-test` runs (ASAN, debug, release) pass with no
      test failures.

Two known-upstream issues surfaced by the tip matrix, both shown not attributable to this
stack:

- TSAN `tablet-split-itest` reports 3 data races in `yb::client::YBTable::~YBTable()`
  (table.cc:81) racing its partition-refresh callback, inside the upstream test
  `AutomaticTabletSplitITest.SizeRatio` (93 cases ran, 0 gtest failures). This stack has zero
  diff under `src/yb/client/`, and that test passes 3/3 isolated at the new master base.
- `wait_states-itest` hangs 9 cases at the 601s timeout (`AshCql`, the `kYCQL_*` group,
  `kBackfillIndex_*`, `kConsensusMeta_Flush`, `kCreatingNewTablet`,
  `kSaveRaftGroupMetadataToDisk`). Reproduced identically on plain master `c7253d204d`
  carrying none of this stack's code: 53 ran, the same 9 failed, same ~600.5s expiries.

Disposition change since the previous revision: the
`PgIndexBackfillBackendsManager.NoAbortTxn/1` flake cited earlier was fixed upstream. It
passes 3/3 at the new base and in all three full `pg_index_backfill-test` runs here, so it is
no longer carried as a known flake.

