### PR TITLE
[#33638] DocDB: Fix LogRollingTest.Rolling on fast hosts

### DIFF
--- a/src/yb/integration-tests/log_version-test.cc
+++ b/src/yb/integration-tests/log_version-test.cc
@@ -91,6 +91,8 @@ TEST_F(LogRollingTest, Rolling) {
   ASSERT_NE(header.GetByPrefix(fingerprint), "");
   const auto& initial_duration = header.GetByPrefix(kDurationPrefix);
   ASSERT_NE(initial_duration, "");
+  // Header duration has 1s granularity; ensure a second elapses so the fresh header differs.
+  SleepFor(MonoDelta::FromMilliseconds(1100));
   // In case of log rolling log_path link will be pointed to newly created file
   const auto initial_target = ASSERT_RESULT(env_->ReadLink(log_path));
   auto prev_size = ASSERT_RESULT(env_->GetFileSize(log_path));


### PR DESCRIPTION
## Summary

`LogRollingTest.Rolling` asserts the fresh log header's `Running duration (h:mm:ss)` line differs from the initial header's after forcing a glog roll with `--max_log_size=1`. The duration has one-second granularity, so on a fast host the roll completes within the master's first second of uptime, both headers read `0:00:00`, and the assert fails deterministically.

Sleep just over one second after reading the initial header, guaranteeing the fresh header's duration differs regardless of machine speed.

## Test plan

- [x] `LogRollingTest.Rolling` passes with the fix on a 192-core host where it previously failed deterministically (in both parallel and serial runs).
