### PR TITLE
[BACKPORT 2026.1][#33175] DocDB: Fence writes past ignore_after_hybrid_time (#33507)

### DIFF
--- a/src/yb/common/pgsql_protocol.proto
+++ b/src/yb/common/pgsql_protocol.proto
@@ -335,6 +335,17 @@ message PgsqlWriteRequestPB {
   //
   // Like skip_intents_write this is a client-side signal; docdb does not read it.
   optional bool read_at_in_txn_limit = 31;
+
+  // Fences the write against a caller-held lease: the leader rejects the op if this hybrid time has
+  // already passed when the op is about to be assigned its own. An RPC deadline cannot express
+  // this -- nothing cancels an operation once it is handed to Raft, so a write the caller saw time
+  // out can still commit. 0 means no fence.
+  //
+  // Each leader evaluates the fence independently, so a batch spanning tablets can be partially
+  // applied when it straddles the boundary; non-transactional single-shard writes have no
+  // all-or-nothing to fall back on. Like any hybrid time comparison it is only as tight as
+  // max_clock_skew_usec.
+  optional fixed64 ignore_after_hybrid_time = 32;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -1344,6 +1344,26 @@ Status RaftConsensus::AppendNewRoundsToQueueUnlocked(
   return status;
 }
 
+Status RaftConsensus::CheckWriteFenceUnlocked(const ConsensusRoundPtr& round) {
+  const auto& msg = *round->replicate_msg();
+  if (msg.op_type() != OperationType::WRITE_OP) {
+    return Status::OK();
+  }
+  const auto fence = HybridTime::FromPB(msg.write().ignore_after_hybrid_time());
+  if (!fence) {
+    return Status::OK();
+  }
+  // clock_, not the op's own hybrid time, which AddLeaderPending has not assigned yet. Nor
+  // state_->Clock(), which is the coarse clock and not in the fence's time domain.
+  const auto now = clock_->Now();
+  if (fence > now) {
+    return Status::OK();
+  }
+  return STATUS_EC_FORMAT(
+      Expired, tserver::TabletServerError(TabletServerErrorPB::WRITE_FENCE_EXPIRED),
+      "Write is fenced: ignore_after_hybrid_time $0 is not after $1", fence, now);
+}
+
 Status RaftConsensus::DoAppendNewRoundsToQueueUnlocked(
     const ConsensusRounds& rounds, size_t* processed_rounds,
     std::vector<ReplicateMsgPtr>* replicate_msgs) {
@@ -1351,6 +1371,15 @@ Status RaftConsensus::DoAppendNewRoundsToQueueUnlocked(
 
   for (const auto& round : rounds) {
     ++*processed_rounds;
+
+    // Must precede RegisterRetryableRequest, whose entry is only ever removed by
+    // ReplicationFinished -- which this rejection does not reach -- and NotifyAddedToLeader, whose
+    // side effects rolling back the op id does not undo.
+    if (auto s = CheckWriteFenceUnlocked(round); !s.ok()) {
+      round->NotifyReplicationFinished(s, round->bound_term(), /* applied_op_ids = */ nullptr);
+      round->BindToTerm(OpId::kUnknownTerm);  // Mark round as non replicating.
+      continue;
+    }
 
     if (round->replicate_msg()->op_type() == OperationType::WRITE_OP) {
       DCHECK_EQ(state_->GetActiveRoleUnlocked(), PeerRole::LEADER);

--- a/src/yb/consensus/raft_consensus.h
+++ b/src/yb/consensus/raft_consensus.h
@@ -407,6 +407,11 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
         const ConsensusRounds& rounds, size_t* processed_rounds,
         std::vector<ReplicateMsgPtr>* replicate_msgs);
 
+  // Rejects a write whose WritePB::ignore_after_hybrid_time has already passed, letting a client
+  // with a time-bounded lease stop its writes landing once the lease is gone. Must run before the
+  // round is registered or added as pending -- see the call site.
+  Status CheckWriteFenceUnlocked(const ConsensusRoundPtr& round);
+
   // Control whether printing of log messages should be done for a particular
   // function call.
   enum AllowLogging {

--- a/src/yb/tablet/operations.proto
+++ b/src/yb/tablet/operations.proto
@@ -107,6 +107,9 @@ message WritePB {
   optional uint64 start_time_micros = 21;
 
   optional uint32 xrepl_origin_id = 22;
+
+  // Earliest PgsqlWriteRequestPB.ignore_after_hybrid_time over this batch; 0 means no fence.
+  optional fixed64 ignore_after_hybrid_time = 24;
 }
 
 message ChangeMetadataRequestPB {

--- a/src/yb/tablet/write_query.cc
+++ b/src/yb/tablet/write_query.cc
@@ -13,6 +13,8 @@
 
 #include "yb/tablet/write_query.h"
 
+#include <algorithm>
+
 #include "yb/ash/wait_state.h"
 
 #include <boost/logic/tribool.hpp>
@@ -120,6 +122,20 @@ void SetupKeyValueBatch(const tserver::WriteRequestMsg& client_request, LWWriteP
     out_request->set_xrepl_origin_id(client_request.xrepl_origin_id());
   }
   out_request->set_batch_idx(client_request.batch_idx());
+  // Lift the ops' write fence into the replicated message, which is all RaftConsensus sees. The
+  // earliest fence wins; the ops share a hybrid time, so they cannot be fenced apart.
+  HybridTime ignore_after_hybrid_time;
+  for (const auto& op : client_request.pgsql_write_batch()) {
+    const auto fence = HybridTime::FromPB(op.ignore_after_hybrid_time());
+    if (!fence) {  // Not set for this op.
+      continue;
+    }
+    ignore_after_hybrid_time =
+        ignore_after_hybrid_time ? std::min(ignore_after_hybrid_time, fence) : fence;
+  }
+  if (ignore_after_hybrid_time) {
+    out_request->set_ignore_after_hybrid_time(ignore_after_hybrid_time.ToPB());
+  }
   // Actually, in production code, we could check for external hybrid time only when there are
   // no ql, pgsql, redis operations.
   // But in CDCServiceTest we have ql write batch with external time.

--- a/src/yb/thin_client/yb_thin_client-itest.cc
+++ b/src/yb/thin_client/yb_thin_client-itest.cc
@@ -27,10 +27,18 @@
 
 #include "yb/thin_client/yb_thin_client.h"
 
+#include "yb/consensus/raft_consensus.h"
+#include "yb/consensus/retryable_requests.h"
+
 #include "yb/integration-tests/mini_cluster.h"
+#include "yb/tablet/tablet_peer.h"
 #include "yb/tserver/mini_tablet_server.h"
 
+#include "yb/common/hybrid_time.h"
+
+#include "yb/util/backoff_waiter.h"
 #include "yb/util/format.h"
+#include "yb/util/monotime.h"
 #include "yb/util/net/net_util.h"
 #include "yb/util/path_util.h"
 #include "yb/util/result.h"
@@ -211,7 +219,8 @@ TEST_F(PgThinClientTest, OpenUpsertReadPaged) {
     keys[row_idx] = {I32(kHashKey), I32(row_idx)};      // (k HASH, v RANGE) in schema order
     values[row_idx] = Bytea(payload);
     rows[row_idx] = ybthin_upsert_row{
-        table, keys[row_idx].data(), 2, &value_ids[row_idx], &values[row_idx], 1};
+        table, keys[row_idx].data(), 2, &value_ids[row_idx], &values[row_idx], 1,
+        /* ignore_after_hybrid_time= */ 0};
   }
   {
     std::promise<WriteOutcome> promise;
@@ -433,7 +442,8 @@ TEST_F(PgThinClientTest, RangeShardedTable) {
     keys[row_idx] = {I32(row_idx)};
     values[row_idx] = Bytea(payload);
     rows[row_idx] = ybthin_upsert_row{
-        table, keys[row_idx].data(), 1, &value_ids[row_idx], &values[row_idx], 1};
+        table, keys[row_idx].data(), 1, &value_ids[row_idx], &values[row_idx], 1,
+        /* ignore_after_hybrid_time= */ 0};
   }
   {
     std::promise<WriteOutcome> promise;
@@ -584,7 +594,7 @@ TEST_F(PgThinClientTest, RangeShardedTable) {
     ybthin_bind no_keys[] = {I32(0)};
     int32_t vid = payload_id;
     ybthin_bind val = Bytea(payload);
-    ybthin_upsert_row bad = {table, no_keys, 0, &vid, &val, 1};  // n_keys == 0
+    ybthin_upsert_row bad = {table, no_keys, 0, &vid, &val, 1, 0};  // n_keys == 0
     std::promise<WriteOutcome> promise;
     auto future = promise.get_future();
     ybthin_upsert_batch_async(client, &bad, 1, &OnWriteDone, &promise);
@@ -1247,7 +1257,7 @@ TEST_F(PgThinClientTest, AlreadyReplicatedWriteReportsSuccess) {
   ybthin_bind key[] = {I32(7)};
   ybthin_bind value[] = {Bytea(payload)};
   int32_t value_ids[] = {v_id};
-  ybthin_upsert_row row = {table, key, 1, value_ids, value, 1};
+  ybthin_upsert_row row = {table, key, 1, value_ids, value, 1, /* no fence */ 0};
 
   std::promise<WriteOutcome> promise;
   auto future = promise.get_future();
@@ -1268,6 +1278,84 @@ TEST_F(PgThinClientTest, AlreadyReplicatedWriteReportsSuccess) {
   ASSERT_EQ(1, ASSERT_RESULT(conn.FetchRow<PGUint64>("SELECT count(*) FROM dup_w WHERE k = 7")));
   ASSERT_EQ(payload, ASSERT_RESULT(conn.FetchRow<std::string>(
                          "SELECT encode(v, 'escape') FROM dup_w WHERE k = 7")));
+
+  ybthin_columns_free(info.columns, info.n_columns);
+  ybthin_table_close(table);
+  ybthin_client_destroy(client);
+}
+
+// A write whose fence has passed must be rejected AND must not take effect -- hence the assertions
+// on table contents, not just the status code. Also checks the rejection leaves no
+// retryable-request registration behind, which is why the fence is checked before registration.
+TEST_F(PgThinClientTest, WriteFencedByIgnoreAfterHybridTime) {
+  auto conn = ASSERT_RESULT(Connect());
+  ASSERT_OK(conn.Execute("CREATE TABLE fenced (k int, v bytea, PRIMARY KEY(k ASC))"));
+
+  const auto db_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT oid FROM pg_database "
+                                                     "WHERE datname = current_database()"));
+  const auto table_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT 'fenced'::regclass::oid"));
+
+  const auto addr = TServerAddr();
+  const char* addrs[] = {addr.c_str()};
+  ybthin_client* client = nullptr;
+  {
+    auto st = ybthin_client_create(
+        addrs, 1, /* tls= */ nullptr, /* pool= */ nullptr, /* rpc_timeout_ms= */ 60000,
+        /* num_reactors= */ 0, &client);
+    ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  }
+  ybthin_table* table = nullptr;
+  ybthin_table_info info = {};
+  {
+    auto st = ybthin_table_open(client, db_oid, table_oid, &table, &info);
+    ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  }
+  const int32_t v_id = info.columns[1].id;
+
+  const std::string payload = "fence";
+  int32_t value_ids[] = {v_id};
+
+  auto upsert = [&](int32_t k, uint64_t fence) -> ybthin_status_code {
+    ybthin_bind key[] = {I32(k)};
+    ybthin_bind value[] = {Bytea(payload)};
+    ybthin_upsert_row row = {table, key, 1, value_ids, value, 1, fence};
+    std::promise<WriteOutcome> promise;
+    auto future = promise.get_future();
+    ybthin_upsert_batch_async(client, &row, 1, &OnWriteDone, &promise);
+    return future.get().code;
+  };
+
+  // HybridTime 1 is behind any clock reading the leader can take.
+  ASSERT_EQ(upsert(1, 1), YBTHIN_FENCED) << "a write past its fence must be rejected";
+  ASSERT_EQ(0, ASSERT_RESULT(conn.FetchRow<PGUint64>(
+                   "SELECT count(*) FROM fenced WHERE k = 1")))
+      << "a fenced write must not take effect";
+
+  // Compared against the leader's clock, so it has to be a hybrid time, not a micro count.
+  const auto far_future = HybridTime::FromMicros(
+      static_cast<uint64_t>(GetCurrentTimeMicros()) + 3600 * 1000000ULL).ToPB();
+  ASSERT_EQ(upsert(2, far_future), YBTHIN_OK) << "a write inside its fence must be applied";
+  ASSERT_EQ(1, ASSERT_RESULT(conn.FetchRow<PGUint64>(
+                   "SELECT count(*) FROM fenced WHERE k = 2")));
+
+  // No fence at all behaves as before.
+  ASSERT_EQ(upsert(3, 0), YBTHIN_OK);
+  ASSERT_EQ(1, ASSERT_RESULT(conn.FetchRow<PGUint64>(
+                   "SELECT count(*) FROM fenced WHERE k = 3")));
+
+  // A leaked entry from the fenced round at k = 1 never drains, so this would never hold. Waiting
+  // rather than sampling absorbs the cluster's unrelated background writes.
+  ASSERT_OK(WaitFor(
+      [this]() -> Result<bool> {
+        for (const auto& peer : ListTabletPeers(cluster_.get(), ListPeersFilter::kAll)) {
+          auto raft_consensus = VERIFY_RESULT(peer->GetRaftConsensus());
+          if (raft_consensus->TEST_CountRetryableRequests().running != 0) {
+            return false;
+          }
+        }
+        return true;
+      },
+      10s, "fenced write left a retryable-request registration behind"));
 
   ybthin_columns_free(info.columns, info.n_columns);
   ybthin_table_close(table);
@@ -1391,7 +1479,7 @@ TEST_F(PgThinClientExternalTlsTest, UpsertAndReadOverTls) {
   std::vector<ybthin_upsert_row> rows(kNumRows);
   for (int row_idx = 0; row_idx < kNumRows; ++row_idx) {
     keys[row_idx] = {I32(kHashKey), I32(row_idx)};
-    rows[row_idx] = ybthin_upsert_row{table, keys[row_idx].data(), 2, nullptr, nullptr, 0};
+    rows[row_idx] = ybthin_upsert_row{table, keys[row_idx].data(), 2, nullptr, nullptr, 0, 0};
   }
   {
     std::promise<WriteOutcome> promise;

--- a/src/yb/thin_client/yb_thin_client.cc
+++ b/src/yb/thin_client/yb_thin_client.cc
@@ -38,6 +38,7 @@
 #include "yb/common/common.pb.h"
 #include "yb/common/common_types.pb.h"
 #include "yb/common/entity_ids.h"
+#include "yb/common/hybrid_time.h"
 #include "yb/common/pgsql_protocol.pb.h"
 #include "yb/common/pgsql_error.h"
 #include "yb/common/ql_type.h"
@@ -63,6 +64,7 @@
 
 #include "yb/tserver/thin_client.pb.h"
 #include "yb/tserver/thin_client.proxy.h"
+#include "yb/tserver/tserver_error.h"
 
 #include "yb/yql/pggate/util/pg_doc_data.h"
 #include "yb/yql/pggate/util/pg_wire.h"
@@ -80,6 +82,7 @@
 using yb::DataType;
 using yb::faststring;
 using yb::HostPort;
+using yb::HybridTime;
 using yb::MonoDelta;
 using yb::RefCntSlice;
 using yb::Result;
@@ -197,6 +200,12 @@ ybthin_status_code ClassifyStatus(const Status& status) {
   }
   if (status.IsInvalidArgument() || status.IsNotSupported()) {
     return YBTHIN_INVALID;
+  }
+  // The fence's own code, not the Expired category -- which a read deadline and a stale retryable
+  // request id also produce, on writes that may well have replicated.
+  const auto ts_error = tserver::TabletServerError::ValueFromStatus(status);
+  if (ts_error == tserver::TabletServerErrorPB::WRITE_FENCE_EXPIRED) {
+    return YBTHIN_FENCED;
   }
   return YBTHIN_OTHER;
 }
@@ -1301,6 +1310,9 @@ void ybthin_upsert_batch_async(
     }
     if (build.ok()) {
       build = dockv::InitPartitionKey(table->schema, table->partition_schema, write);
+    }
+    if (const auto fence = HybridTime::FromPB(row.ignore_after_hybrid_time)) {
+      write->set_ignore_after_hybrid_time(fence.ToPB());
     }
     for (size_t col_idx = 0; col_idx < row.n_values && build.ok(); ++col_idx) {
       auto* cv = write->add_column_values();

--- a/src/yb/thin_client/yb_thin_client.h
+++ b/src/yb/thin_client/yb_thin_client.h
@@ -48,6 +48,7 @@ typedef enum {
   YBTHIN_READ_RESTART = 4, // restart_read_time: caller restarts the scan
   YBTHIN_SCHEMA = 5,       // schema-version mismatch -- reopen the table
   YBTHIN_OTHER = 6,        // anything else -- fatal
+  YBTHIN_FENCED = 7,       // ignore_after_hybrid_time had passed; the write did NOT take effect
 } ybthin_status_code;
 
 // `message` is owned (free with ybthin_string_free) and NULL when code == YBTHIN_OK.
@@ -225,6 +226,11 @@ typedef struct {
   const int32_t* value_ids;
   const ybthin_bind* values;
   size_t n_values;
+  // Fences this row against a lease the caller holds: the leader rejects the write with
+  // YBTHIN_FENCED if this hybrid time has already passed by the time the op is assigned its own.
+  // 0 means no fence. Judged per tablet, so a batch straddling the boundary can be partly applied.
+  // Build it from a physical time; the logical component is always 0 here.
+  uint64_t ignore_after_hybrid_time;
 } ybthin_upsert_row;
 
 // Completion callbacks may run on a YB reactor thread, so they MUST be cheap and non-blocking

--- a/src/yb/tserver/tserver_types.proto
+++ b/src/yb/tserver/tserver_types.proto
@@ -131,6 +131,11 @@ message TabletServerErrorPB {
     // The tablet server either does not have a live ysql lease or it does not have the expected
     // lease epoch. It cannot service a lock acquire / release request.
     INVALID_YSQL_LEASE = 32;
+
+    // The write's ignore_after_hybrid_time had already passed when the leader was about to append
+    // it. Distinct from a bare Expired, which also covers causes that may have replicated: a
+    // fenced write definitively did not take effect.
+    WRITE_FENCE_EXPIRED = 34;
   }
 
   // The error code.


### PR DESCRIPTION
## Summary

A lease lets one component be the sole writer to some data for a bounded window without
coordinating on every write: while it holds the lease it writes freely, and once the lease expires
another holder may take over. That is only safe if the outgoing holder's writes cannot take effect
after its window ends -- otherwise a delayed write from a former owner lands on top of the new
owner's data.

There is currently no way for a client to express that bound. An RPC deadline bounds how long the
caller waits, not whether the write eventually applies: nothing cancels an operation once it has
been handed to Raft, so a write the caller gave up on can still commit afterwards. A lease holder
cannot tell a write that failed from one that will land later. The primitive exists for object
locks (`AcquireObjectLockRequestPB`) but not for writes.

This adds a per-write fence. The caller states the hybrid time after which the write must not take
effect, and the tablet leader checks it when admitting the write, rejecting it if that moment has
already passed. The check happens before the operation can have any effect, so a rejected write
definitively did not apply -- the property a timeout cannot give. It is reported as `Expired`
carrying `TabletServerErrorPB::WRITE_FENCE_EXPIRED`, distinguishable from the failures that may
still have landed; the thin client surfaces it as `YBTHIN_FENCED`.

The fence rides on `PgsqlWriteRequestPB.ignore_after_hybrid_time` per op, and is lifted onto
`WritePB` as the earliest fence over the batch, that being the only message the leader's admission
path sees. 0 means no fence.

Two limits, both noted on the request field: each tablet leader judges the fence independently, so a
batch spanning tablets can be partly applied if it straddles the boundary; and being a hybrid time
comparison, the fence is only as tight as `max_clock_skew_usec`.

## Upgrade/Rollback safety

The feature can only be used after the upgrade is completed.

## Merge conflicts

Both conflicts were context-only -- the neighbouring field that master's hunk carried as context
does not exist on 2026.1. No content differs from the original commit; the added fields keep the
same tag numbers as master, deliberately leaving a gap rather than renumbering, so a tag means the
same thing on both branches.

- `src/yb/tablet/operations.proto:113` — `WritePB` ends at 22 here; master has
  `xcluster_target_applied = 23`. `ignore_after_hybrid_time` stays at **24**, 23 left unused.
- `src/yb/tserver/tserver_types.proto:135` — `TabletServerErrorPB.Code` ends at 32 here; master has
  `READ_TIME_NOT_REACHED = 33`. `WRITE_FENCE_EXPIRED` stays at **34**, 33 left unused.

`src/yb/common/pgsql_protocol.proto` applied cleanly: 2026.1 already carries
`read_at_in_txn_limit = 31`, so the fence is at 32 as on master.

Original commit: 26d436e257aea2d2142333484c643aeee751e367 / #33507

## Test plan

`yb_thin_client-itest` -- full suite on 2026.1, 11/11.

`PgThinClientTest.WriteFencedByIgnoreAfterHybridTime` asserts on table contents as well as status: a
past fence is rejected and leaves no row, a far-future fence applies, no fence behaves as before, and
every peer reports zero running retryable requests afterwards.
