### PR TITLE
[doc] Replace release note boilerplate with shortcode

### DIFF
--- a/docs/content/stable/releases/yba-releases/v2024.2.md
+++ b/docs/content/stable/releases/yba-releases/v2024.2.md
@@ -31,12 +31,6 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 
 ## v2024.2.11.0 - August 25, 2026 {#v2024.2.11.0}
 
-**Build:** `2024.2.11.0-b36`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.11.0/yugabytedb-2024.2.11.0-b36-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.11.0/yugabytedb-anywhere-2024.2.11.0-b36-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.11.0" build="36" type="yba" >}}
 
 ### Improvements
@@ -52,12 +46,6 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 * Reverts `bootstrapParams` as a required field in Swagger docs for patch releases to avoid confusion. PLAT-21685 
 
 ## v2024.2.10.0 - July 9, 2026 {#v2024.2.10.0}
-
-**Build:** `2024.2.10.0-b62`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.10.0/yugabytedb-2024.2.10.0-b62-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.10.0/yugabytedb-anywhere-2024.2.10.0-b62-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2024.2.10.0" build="62" type="yba" >}}
 
@@ -80,12 +68,6 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 
 ## v2024.2.9.1 - June 3, 2026 {#v2024.2.9.1}
 
-**Build:** `2024.2.9.1-b8`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.9.1/yugabytedb-2024.2.9.1-b8-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.9.1/yugabytedb-anywhere-2024.2.9.1-b8-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.9.1" build="8" type="yba" >}}
 
 ### Improvement
@@ -97,12 +79,6 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 * Pins the pex builder base image to ensure consistent builds. PLAT-20901
 
 ## v2024.2.9.0 - April 29, 2026 {#v2024.2.9.0}
-
-**Build:** `2024.2.9.0-b55`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.9.0/yugabytedb-2024.2.9.0-b55-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.9.0/yugabytedb-anywhere-2024.2.9.0-b55-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2024.2.9.0" build="55" type="yba" >}}
 
@@ -133,12 +109,6 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 
 ## v2024.2.8.0 - February 23, 2026 {#v2024.2.8.0}
 
-**Build:** `2024.2.8.0-b85`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.8.0/yugabytedb-2024.2.8.0-b85-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.8.0/yugabytedb-anywhere-2024.2.8.0-b85-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.8.0" build="85" type="yba" >}}
 
 ### Improvements
@@ -165,23 +135,11 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 
 ## v2024.2.7.3 - February 3, 2026 {#v2024.2.7.3}
 
-**Build:** `2024.2.7.3-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.7.3/yugabytedb-2024.2.7.3-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.7.3/yugabytedb-anywhere-2024.2.7.3-b1-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.7.3" build="1" type="yba" >}}
 
 This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.7.2 - January 16, 2026 {#v2024.2.7.2}
-
-**Build:** `2024.2.7.2-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.7.2/yugabytedb-2024.2.7.2-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.7.2/yugabytedb-anywhere-2024.2.7.2-b1-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2024.2.7.2" build="1" type="yba" >}}
 
@@ -189,23 +147,11 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.7.1 - December 31, 2025 {#v2024.2.7.1}
 
-**Build:** `2024.2.7.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.7.1/yugabytedb-2024.2.7.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.7.1/yugabytedb-anywhere-2024.2.7.1-b1-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.7.1" build="1" type="yba" >}}
 
 This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.7.0 - December 30, 2025 {#v2024.2.7.0}
-
-**Build:** `2024.2.7.0-b62`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.7.0/yugabytedb-2024.2.7.0-b62-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.7.0/yugabytedb-anywhere-2024.2.7.0-b62-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2024.2.7.0" build="62" type="yba" >}}
 
@@ -233,35 +179,17 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.6.2 - December 22, 2025 {#v2024.2.6.2}
 
-**Build:** `2024.2.6.2-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.6.2/yugabytedb-2024.2.6.2-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.6.2/yugabytedb-anywhere-2024.2.6.2-b2-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.6.2" build="2" type="yba" >}}
 
 This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.6.1 - November 11, 2025 {#v2024.2.6.1}
 
-**Build:** `2024.2.6.1-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.6.1/yugabytedb-2024.2.6.1-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.6.1/yugabytedb-anywhere-2024.2.6.1-b2-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.6.1" build="2" type="yba" >}}
 
 This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.6.0 - October 31, 2025 {#v2024.2.6.0}
-
-**Build:** `2024.2.6.0-b94`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.6.0/yugabytedb-2024.2.6.0-b94-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.6.0/yugabytedb-anywhere-2024.2.6.0-b94-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2024.2.6.0" build="94" type="yba" >}}
 
@@ -317,12 +245,6 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.5.1 - September 11, 2025 {#v2024.2.5.1}
 
-**Build:** `2024.2.5.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.5.1/yugabytedb-2024.2.5.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.5.1/yugabytedb-anywhere-2024.2.5.1-b1-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.5.1" build="1" type="yba" >}}
 
 {{< note title="Preflight check requirement for RHEL" >}}
@@ -344,12 +266,6 @@ sudo ln -s /usr/bin/python3 /usr/bin/python
 - Locks certifi version to support Python 3.6, preventing AWS create universe failures. PLAT-17917
 
 ## v2024.2.5.0 - August 29, 2025 {#v2024.2.5.0}
-
-**Build:** `2024.2.5.0-b59`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.5.0/yugabytedb-2024.2.5.0-b59-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.5.0/yugabytedb-anywhere-2024.2.5.0-b59-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2024.2.5.0" build="59" type="yba" >}}
 
@@ -386,12 +302,6 @@ sudo ln -s /usr/bin/python3 /usr/bin/python
 
 ## v2024.2.4.2 - December 16, 2025 {#v2024.2.4.2}
 
-**Build:** `2024.2.4.2-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.4.2/yugabytedb-2024.2.4.2-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.4.2/yugabytedb-anywhere-2024.2.4.2-b2-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.4.2" build="2" type="yba" >}}
 
 ### Improvement
@@ -404,23 +314,11 @@ sudo ln -s /usr/bin/python3 /usr/bin/python
 
 ## v2024.2.4.1 - August 20, 2025 {#v2024.2.4.1}
 
-**Build:** `2024.2.4.1-b4`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.4.1/yugabytedb-2024.2.4.1-b4-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.4.1/yugabytedb-anywhere-2024.2.4.1-b4-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.4.1" build="4" type="yba" >}}
 
 This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.4.0 - July 14, 2025 {#v2024.2.4.0}
-
-**Build:** `2024.2.4.0-b89`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.4.0/yugabytedb-2024.2.4.0-b89-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.4.0/yugabytedb-anywhere-2024.2.4.0-b89-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2024.2.4.0" build="89" type="yba" >}}
 
@@ -487,12 +385,6 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.3.3 - August 11, 2025 {#v2024.2.3.3}
 
-**Build:** `2024.2.3.3-b4`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.3.3/yugabytedb-2024.2.3.3-b4-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.3.3/yugabytedb-anywhere-2024.2.3.3-b4-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.3.3" build="4" type="yba" >}}
 
 ### Bug fixes
@@ -502,23 +394,11 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.3.2 - June 24, 2025 {#v2024.2.3.2}
 
-**Build:** `2024.2.3.2-b6`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.3.2/yugabytedb-2024.2.3.2-b6-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.3.2/yugabytedb-anywhere-2024.2.3.2-b6-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.3.2" build="6" type="yba" >}}
 
 This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.3.1 - June 13, 2025 {#v2024.2.3.1}
-
-**Build:** `2024.2.3.1-b3`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.3.1/yugabytedb-2024.2.3.1-b3-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.3.1/yugabytedb-anywhere-2024.2.3.1-b3-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2024.2.3.1" build="3" type="yba" >}}
 
@@ -528,12 +408,6 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 * Removes the memory preflight check from node agent during node agent provisioning. PLAT-17647
 
 ## v2024.2.3.0 - May 16, 2025 {#v2024.2.3.0}
-
-**Build:** `2024.2.3.0-b116`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.3.0/yugabytedb-2024.2.3.0-b116-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.3.0/yugabytedb-anywhere-2024.2.3.0-b116-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2024.2.3.0" build="116" type="yba" >}}
 
@@ -626,12 +500,6 @@ The use of [cron to start YB services](/v2024.2/yugabyte-platform/upgrade/prepar
 
 ## v2024.2.2.5 - August 5, 2025 {#v2024.2.2.5}
 
-**Build:** `2024.2.2.5-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.2.5/yugabytedb-2024.2.2.5-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.2.5/yugabytedb-anywhere-2024.2.2.5-b2-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.2.5" build="2" type="yba" >}}
 
 ### Bug fix
@@ -639,12 +507,6 @@ The use of [cron to start YB services](/v2024.2/yugabyte-platform/upgrade/prepar
 * Allows specifying full URNs for Azure vnet/subnet to improve resource grouping. PLAT 17115
 
 ## v2024.2.2.4 - May 19, 2025 {#v2024.2.2.4}
-
-**Build:** `2024.2.2.4-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.2.4/yugabytedb-2024.2.2.4-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.2.4/yugabytedb-anywhere-2024.2.2.4-b1-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2024.2.2.4" build="1" type="yba" >}}
 
@@ -661,12 +523,6 @@ The use of [cron to start YB services](/v2024.2/yugabyte-platform/upgrade/prepar
 
 ## v2024.2.2.3 - May 6, 2025 {#v2024.2.2.3}
 
-**Build:** `2024.2.2.3-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.2.3/yugabytedb-2024.2.2.3-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.2.3/yugabytedb-anywhere-2024.2.2.3-b1-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.2.3" build="1" type="yba" >}}
 
 ### Change log
@@ -682,35 +538,17 @@ The use of [cron to start YB services](/v2024.2/yugabyte-platform/upgrade/prepar
 
 ## v2024.2.2.2 - April 9, 2025 {#v2024.2.2.2}
 
-**Build:** `2024.2.2.2-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.2.2/yugabytedb-2024.2.2.2-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.2.2/yugabytedb-anywhere-2024.2.2.2-b2-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.2.2" build="2" type="yba" >}}
 
 This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.2.1 - March 11, 2025 {#v2024.2.2.1}
 
-**Build:** `2024.2.2.1-b6`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.2.1/yugabytedb-2024.2.2.1-b6-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.2.1/yugabytedb-anywhere-2024.2.2.1-b6-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.2.1" build="6" type="yba" >}}
 
 This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2024.2.2.0 - February 28, 2025 {#v2024.2.2.0}
-
-**Build:** `2024.2.2.0-b70`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.2.0/yugabytedb-2024.2.2.0-b70-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.2.0/yugabytedb-anywhere-2024.2.2.0-b70-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2024.2.2.0" build="70" type="yba" >}}
 
@@ -773,12 +611,6 @@ If you previously had OIDC configured for YugabyteDB Anywhere, check the **Scope
 
 ## v2024.2.1.0 - January 30, 2025 {#v2024.2.1.0}
 
-**Build:** `2024.2.1.0-b185`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.1.0/yugabytedb-2024.2.1.0-b185-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.1.0/yugabytedb-anywhere-2024.2.1.0-b185-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2024.2.1.0" build="185" type="yba" >}}
 
 ### Known issue
@@ -837,12 +669,6 @@ If you previously had OIDC configured for YugabyteDB Anywhere, check the **Scope
 </details>
 
 ## v2024.2.0.0 - December 9, 2024 {#v2024.2.0.0}
-
-**Build:** `2024.2.0.0-b145`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.0.0/yugabytedb-2024.2.0.0-b145-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.0.0/yugabytedb-anywhere-2024.2.0.0-b145-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2024.2.0.0" build="145" type="yba" >}}
 

--- a/docs/content/stable/releases/yba-releases/v2025.1.md
+++ b/docs/content/stable/releases/yba-releases/v2025.1.md
@@ -31,12 +31,6 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 
 ## v2025.1.4.0 - April 20, 2026 {#v2025.1.4.0}
 
-**Build:** `2025.1.4.0-b103`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.4.0/yugabytedb-2025.1.4.0-b103-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.4.0/yugabytedb-anywhere-2025.1.4.0-b103-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.1.4.0" build="103" type="yba" >}}
 
 ### Improvements
@@ -84,12 +78,6 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 
 ## v2025.1.3.2 - February 26, 2026 {#v2025.1.3.2}
 
-**Build:** `2025.1.3.2-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.3.2/yugabytedb-2025.1.3.2-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.3.2/yugabytedb-anywhere-2025.1.3.2-b1-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.1.3.2" build="1" type="yba" >}}
 
 ### Bug fix
@@ -98,23 +86,11 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 
 ## v2025.1.3.1 - February 5, 2026 {#v2025.1.3.1}
 
-**Build:** `2025.1.3.1-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.3.1/yugabytedb-2025.1.3.1-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.3.1/yugabytedb-anywhere-2025.1.3.1-b2-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.1.3.1" build="2" type="yba" >}}
 
 This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2025.1.3.0 - January 16, 2026 {#v2025.1.3.0}
-
-**Build:** `2025.1.3.0-b75`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.3.0/yugabytedb-2025.1.3.0-b75-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.3.0/yugabytedb-anywhere-2025.1.3.0-b75-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2025.1.3.0" build="75" type="yba" >}}
 
@@ -161,12 +137,6 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2025.1.2.2 - December 17, 2025 {#v2025.1.2.2}
 
-**Build:** `2025.1.2.2-b5`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.2.2/yugabytedb-2025.1.2.2-b5-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.2.2/yugabytedb-anywhere-2025.1.2.2-b5-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.1.2.2" build="5" type="yba" >}}
 
 ### Bug fixes
@@ -177,12 +147,6 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2025.1.2.1 - December 2, 2025 {#v2025.1.2.1}
 
-**Build:** `2025.1.2.1-b4`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.2.1/yugabytedb-2025.1.2.1-b4-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.2.1/yugabytedb-anywhere-2025.1.2.1-b4-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.1.2.1" build="4" type="yba" >}}
 
 ### Bug fix
@@ -190,12 +154,6 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 * Enables a pre-check to ensure the Yugabyte home directory in the on-prem provider matches that on the DB node. PLAT-18366
 
 ## v2025.1.2.0 - November 20, 2025 {#v2025.1.2.0}
-
-**Build:** `2025.1.2.0-b110`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.2.0/yugabytedb-2025.1.2.0-b110-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.2.0/yugabytedb-anywhere-2025.1.2.0-b110-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2025.1.2.0" build="110" type="yba" >}}
 
@@ -262,23 +220,11 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2025.1.1.2 - October 20, 2025 {#v2025.1.1.2}
 
-**Build:** `2025.1.1.2-b3`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.1.2/yugabytedb-2025.1.1.2-b3-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.1.2/yugabytedb-anywhere-2025.1.1.2-b3-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.1.1.2" build="3" type="yba" >}}
 
 This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2025.1.1.1 - October 3, 2025 {#v2025.1.1.1}
-
-**Build:** `2025.1.1.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.1.1/yugabytedb-2025.1.1.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.1.1/yugabytedb-anywhere-2025.1.1.1-b1-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2025.1.1.1" build="1" type="yba" >}}
 
@@ -425,12 +371,6 @@ Note: Support for [legacy node provisioning](/v2025.1/yugabyte-platform/prepare/
 
 ## v2025.1.0.1 - August 5, 2025 {#v2025.1.0.1}
 
-**Build:** `2025.1.0.1-b3`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.0.1/yugabytedb-2025.1.0.1-b3-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.0.1/yugabytedb-anywhere-2025.1.0.1-b3-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.1.0.1" build="3" type="yba" >}}
 
 ### Bug fixes
@@ -441,12 +381,6 @@ Note: Support for [legacy node provisioning](/v2025.1/yugabyte-platform/prepare/
 * Ensures safer K8s rollbacks by tracking TServer upgrades and flag settings. PLAT-18178
 
 ## v2025.1.0.0 - July 23, 2025 {#v2025.1.0.0}
-
-**Build:** `2025.1.0.0-b168`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.0.0/yugabytedb-2025.1.0.0-b168-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.0.0/yugabytedb-anywhere-2025.1.0.0-b168-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2025.1.0.0" build="168" type="yba" >}}
 

--- a/docs/content/stable/releases/yba-releases/v2025.2.md
+++ b/docs/content/stable/releases/yba-releases/v2025.2.md
@@ -35,12 +35,6 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 
 ## v2025.2.5.2 - August 3, 2026 {#v2025.2.5.2}
 
-**Build:** `2025.2.5.2-b5`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.5.2/yugabytedb-2025.2.5.2-b5-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.5.2/yugabytedb-anywhere-2025.2.5.2-b5-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.2.5.2" build="5" type="yba" >}}
 
 #### Bug fix
@@ -48,12 +42,6 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 - Enables AuditLog functionality regardless of differing software and user home paths. PLAT-21731
 
 ## v2025.2.5.1 - July 23, 2026 {#v2025.2.5.0}
-
-**Build:** `2025.2.5.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.5.1/yugabytedb-2025.2.5.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.5.1/yugabytedb-anywhere-2025.2.5.1-b1-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2025.2.5.1" build="1" type="yba" >}}
 
@@ -98,12 +86,6 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 
 ## v2025.2.4.1 - July 16, 2026 {#v2025.2.4.1}
 
-**Build:** `2025.2.4.1-b4`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.4.1/yugabytedb-2025.2.4.1-b4-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.4.1/yugabytedb-anywhere-2025.2.4.1-b4-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.2.4.1" build="4" type="yba" >}}
 
 ### Bug fixes
@@ -114,12 +96,6 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 * Ensures master nodes do not unexpectedly restart during scale-up operations after upgrades. PLAT-21412
 
 ## v2025.2.4.0 - June 22, 2026 {#v2025.2.4.0}
-
-**Build:** `2025.2.4.0-b122`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.4.0/yugabytedb-2025.2.4.0-b122-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.4.0/yugabytedb-anywhere-2025.2.4.0-b122-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2025.2.4.0" build="122" type="yba" >}}
 
@@ -194,35 +170,17 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 
 ## v2025.2.3.2 - June 4, 2026 {#v2025.2.3.2}
 
-**Build:** `2025.2.3.2-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.3.2/yugabytedb-2025.2.3.2-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.3.2/yugabytedb-anywhere-2025.2.3.2-b1-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.2.3.2" build="1" type="yba" >}}
 
 This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2025.2.3.1 - June 2, 2026 {#v2025.2.3.1}
 
-**Build:** `2025.2.3.1-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.3.1/yugabytedb-2025.2.3.1-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.3.1/yugabytedb-anywhere-2025.2.3.1-b2-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.2.3.1" build="2" type="yba" >}}
 
 This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2025.2.3.0 - May 14, 2026 {#v2025.2.3.0}
-
-**Build:** `2025.2.3.0-b149`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.3.0/yugabytedb-2025.2.3.0-b149-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.3.0/yugabytedb-anywhere-2025.2.3.0-b149-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2025.2.3.0" build="149" type="yba" >}}
 
@@ -316,12 +274,6 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2025.2.2.2 - April 7, 2026 {#v2025.2.2.2}
 
-**Build:** `2025.2.2.2-b11`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.2.2/yugabytedb-2025.2.2.2-b11-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.2.2/yugabytedb-anywhere-2025.2.2.2-b11-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.2.2.2" build="11" type="yba" >}}
 
 ### Bug fix
@@ -330,12 +282,6 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 
 ## v2025.2.2.1 - April 3, 2026 {#v2025.2.2.1}
 
-**Build:** `2025.2.2.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.2.1/yugabytedb-2025.2.2.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.2.1/yugabytedb-anywhere-2025.2.2.1-b1-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.2.2.1" build="1" type="yba" >}}
 
 ### Bug fix
@@ -343,8 +289,6 @@ This is a YugabyteDB-only release, with no changes to YugabyteDB Anywhere.
 * Reverted PLAT-18364: Hides LDAP passwords in API responses to enhance security.
 
 ## v2025.2.2.0 - March 12, 2026 {#v2025.2.2.0}
-
-### Download
 
 {{< warning title="Use v2025.2.2.1.">}}
 v2025.2.2.0 includes an issue affecting LDAP in YugabyteDB Anywhere. In some circumstances, redacted values in `ysql_hba_conf_csv` can be overwritten during YBA-based universe operations, potentially leading to misconfigured database LDAP settings or authentication failures. Use [v2025.2.2.1](#v2025.2.2.1).
@@ -430,12 +374,6 @@ v2025.2.2.0 includes an issue affecting LDAP in YugabyteDB Anywhere. In some cir
 </details>
 
 ## v2025.2.1.0 - February 12, 2026 {#v2025.2.1.0}
-
-**Build:** `2025.2.1.0-b141`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.1.0/yugabytedb-2025.2.1.0-b141-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.1.0/yugabytedb-anywhere-2025.2.1.0-b141-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2025.2.1.0" build="141" type="yba" >}}
 
@@ -572,12 +510,6 @@ If a node with Master process fails unexpectedly (reducing health, but not causi
 
 ## v2025.2.0.1 - January 26, 2026 {#v2025.2.0.1}
 
-**Build:** `2025.2.0.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.0.1/yugabytedb-2025.2.0.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.0.1/yugabytedb-anywhere-2025.2.0.1-b1-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2025.2.0.1" build="1" type="yba" >}}
 
 ### Bug fixes
@@ -587,12 +519,6 @@ If a node with Master process fails unexpectedly (reducing health, but not causi
 * Corrected function scope in Helm templates to resolve errors when `createServicePerPod` is enabled. PLAT-19206
 
 ## v2025.2.0.0 - December 11, 2025 {#v2025.2.0.0}
-
-**Build:** `2025.2.0.0-b131`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.0.0/yugabytedb-2025.2.0.0-b131-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.0.0/yugabytedb-anywhere-2025.2.0.0-b131-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2025.2.0.0" build="131" type="yba" >}}
 

--- a/docs/content/stable/releases/yba-releases/v2025.2.md
+++ b/docs/content/stable/releases/yba-releases/v2025.2.md
@@ -37,7 +37,7 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 
 {{< release-downloads version="2025.2.5.2" build="5" type="yba" >}}
 
-#### Bug fix
+### Bug fix
 
 - Enables AuditLog functionality regardless of differing software and user home paths. PLAT-21731
 

--- a/docs/content/stable/releases/yba-releases/v2026.1.md
+++ b/docs/content/stable/releases/yba-releases/v2026.1.md
@@ -17,12 +17,6 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 
 ## v2026.1.1.1 - August 18, 2026 {#v2026.1.1.1}
 
-**Build:** `2026.1.1.1-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2026.1.1.1/yugabytedb-2026.1.1.1-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2026.1.1.1/yugabytedb-anywhere-2026.1.1.1-b2-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2026.1.1.1" build="2" type="yba" >}}
 
 ### Update
@@ -30,12 +24,6 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 - Update postgres to version 14.23. PLAT-21546
 
 ## v2026.1.1.0 - August 13, 2026 {#v2026.1.1.0}
-
-**Build:** `2026.1.1.0-b91`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2026.1.1.0/yugabytedb-2026.1.1.0-b91-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2026.1.1.0/yugabytedb-anywhere-2026.1.1.0-b91-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2026.1.1.0" build="91" type="yba" >}}
 
@@ -125,12 +113,6 @@ YugabyteDB and YugabyteDB Anywhere supports FIPS 140-2–compliant encryption wh
 
 ## v2026.1.0.1 - July 22, 2026 {#v2026.1.0.1}
 
-**Build:** `2026.1.0.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2026.1.0.1/yugabytedb-2026.1.0.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2026.1.0.1/yugabytedb-anywhere-2026.1.0.1-b1-third-party-licenses.html)
-
-### Download
-
 {{< release-downloads version="2026.1.0.1" build="1" type="yba" >}}
 
 ### Bug fix
@@ -138,12 +120,6 @@ YugabyteDB and YugabyteDB Anywhere supports FIPS 140-2–compliant encryption wh
 - Restores the ability to upload self-signed CA certificates affected by FIPS changes. PLAT-21332
 
 ## v2026.1.0.0 - June 29, 2026 {#v2026.1.0.0}
-
-**Build:** `2026.1.0.0-b118`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2026.1.0.0/yugabytedb-2026.1.0.0-b118-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2026.1.0.0/yugabytedb-anywhere-2026.1.0.0-b118-third-party-licenses.html)
-
-### Download
 
 {{< release-downloads version="2026.1.0.0" build="118" type="yba" >}}
 

--- a/docs/content/stable/releases/ybdb-releases/v2024.2.md
+++ b/docs/content/stable/releases/ybdb-releases/v2024.2.md
@@ -25,12 +25,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 
 ## v2024.2.11.0 - August 25, 2026 {#v2024.2.11.0}
 
-**Build:** `2024.2.11.0-b36`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.11.0/yugabytedb-2024.2.11.0-b36-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.11.0/yugabytedb-anywhere-2024.2.11.0-b36-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.11.0" build="36" >}}
 
 ### Improvements
@@ -80,12 +74,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 * Eliminates silent stalling in the slot by restoring loud failure when a walsender requests WAL operations whose segments were garbage collected and the TServer has been restarted since the garbage collection. {{<issue 33198>}} 
 
 ## v2024.2.10.0 - July 9, 2026 {#v2024.2.10.0}
-
-**Build:** `2024.2.10.0-b62`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.10.0/yugabytedb-2024.2.10.0-b62-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.10.0/yugabytedb-anywhere-2024.2.10.0-b62-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.10.0" build="62" >}}
 
@@ -165,12 +153,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 
 ## v2024.2.9.1 - June 3, 2026 {#v2024.2.9.1}
 
-**Build:** `2024.2.9.1-b8`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.9.1/yugabytedb-2024.2.9.1-b8-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.9.1/yugabytedb-anywhere-2024.2.9.1-b8-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.9.1" build="8" >}}
 
 ### Improvements
@@ -193,12 +175,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 * Cleans up stale entries effectively in the cdc_state table to ensure consistent replication and system resources management. {{<issue 23497>}}
 
 ## v2024.2.9.0 - April 29, 2026 {#v2024.2.9.0}
-
-**Build:** `2024.2.9.0-b55`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.9.0/yugabytedb-2024.2.9.0-b55-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.9.0/yugabytedb-anywhere-2024.2.9.0-b55-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.9.0" build="55" >}}
 
@@ -269,12 +245,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 * Eliminates empty BEGIN+COMMIT pairs in multi-shard transactions after tablet splits. {{<issue 30980>}}
 
 ## v2024.2.8.0 - February 23, 2026 {#v2024.2.8.0}
-
-**Build:** `2024.2.8.0-b85`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.8.0/yugabytedb-2024.2.8.0-b85-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.8.0/yugabytedb-anywhere-2024.2.8.0-b85-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.8.0" build="85" >}}
 
@@ -384,12 +354,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 
 ## v2024.2.7.3 - February 3, 2026 {#v2024.2.7.3}
 
-**Build:** `2024.2.7.3-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.7.3/yugabytedb-2024.2.7.3-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.7.3/yugabytedb-anywhere-2024.2.7.3-b1-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.7.3" build="1" >}}
 
 ### Bug fixes
@@ -404,12 +368,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 
 ## v2024.2.7.2 - January 16, 2026 {#v2024.2.7.2}
 
-**Build:** `2024.2.7.2-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.7.2/yugabytedb-2024.2.7.2-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.7.2/yugabytedb-anywhere-2024.2.7.2-b1-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.7.2" build="1" >}}
 
 ### Bug fix
@@ -420,12 +378,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 
 ## v2024.2.7.1 - December 31, 2025 {#v2024.2.7.1}
 
-**Build:** `2024.2.7.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.7.1/yugabytedb-2024.2.7.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.7.1/yugabytedb-anywhere-2024.2.7.1-b1-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.7.1" build="1" >}}
 
 ### Bug fix
@@ -435,12 +387,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 - Add flag for parameter yb_ignore_bool_cond_for_legacy_estimate. {{<issue 29831>}}
 
 ## v2024.2.7.0 - December 30, 2025 {#v2024.2.7.0}
-
-**Build:** `2024.2.7.0-b62`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.7.0/yugabytedb-2024.2.7.0-b62-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.7.0/yugabytedb-anywhere-2024.2.7.0-b62-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.7.0" build="62" >}}
 
@@ -518,12 +464,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 
 ## v2024.2.6.2 - December 22, 2025 {#v2024.2.6.2}
 
-**Build:** `2024.2.6.2-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.6.2/yugabytedb-2024.2.6.2-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.6.2/yugabytedb-anywhere-2024.2.6.2-b2-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.6.2" build="2" >}}
 
 ### Bug fix
@@ -534,12 +474,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 
 ## v2024.2.6.1 - November 11, 2025 {#v2024.2.6.1}
 
-**Build:** `2024.2.6.1-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.6.1/yugabytedb-2024.2.6.1-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.6.1/yugabytedb-anywhere-2024.2.6.1-b2-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.6.1" build="2" >}}
 
 ### Bug fixes
@@ -549,12 +483,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 * Fix issue with virtual WAL restart after DDL. {{<issue 29136>}}
 
 ## v2024.2.6.0 - October 31, 2025 {#v2024.2.6.0}
-
-**Build:** `2024.2.6.0-b94`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.6.0/yugabytedb-2024.2.6.0-b94-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.6.0/yugabytedb-anywhere-2024.2.6.0-b94-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.6.0" build="94" >}}
 
@@ -644,12 +572,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 
 ## v2024.2.5.1 - September 11, 2025 {#v2024.2.5.1}
 
-**Build:** `2024.2.5.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.5.1/yugabytedb-2024.2.5.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.5.1/yugabytedb-anywhere-2024.2.5.1-b1-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.5.1" build="1" >}}
 
 ### Bug fix
@@ -657,12 +579,6 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 - Enforces TLS v1.2 for secure webserver connections. {{<issue 28417>}}
 
 ## v2024.2.5.0 - August 29, 2025 {#v2024.2.5.0}
-
-**Build:** `2024.2.5.0-b59`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.5.0/yugabytedb-2024.2.5.0-b59-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.5.0/yugabytedb-anywhere-2024.2.5.0-b59-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.5.0" build="59" >}}
 
@@ -747,23 +663,11 @@ YugabyteDB v2024.2 requires gRPC Connector dz.1.9.5.yb.grpc.2024.2.3 or later.
 
 ## v2024.2.4.2 - December 16, 2025 {#v2024.2.4.2}
 
-**Build:** `2024.2.4.2-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.4.2/yugabytedb-2024.2.4.2-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.4.2/yugabytedb-anywhere-2024.2.4.2-b2-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.4.2" build="2" >}}
 
 This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 
 ## v2024.2.4.1 - August 20, 2025 {#v2024.2.4.1}
-
-**Build:** `2024.2.4.1-b4`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.4.1/yugabytedb-2024.2.4.1-b4-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.4.1/yugabytedb-anywhere-2024.2.4.1-b4-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.4.1" build="4" >}}
 
@@ -791,12 +695,6 @@ This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 * Ensures CDC streams data for non-transactional YCQL tables correctly. {{<issue 28034>}}
 
 ## v2024.2.4.0 - July 14, 2025 {#v2024.2.4.0}
-
-**Build:** `2024.2.4.0-b89`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.4.0/yugabytedb-2024.2.4.0-b89-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.4.0/yugabytedb-anywhere-2024.2.4.0-b89-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.4.0" build="89" >}}
 
@@ -900,12 +798,6 @@ This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 
 ## v2024.2.3.3 - August 11, 2025 {#v2024.2.3.3}
 
-**Build:** `2024.2.3.3-b4`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.3.3/yugabytedb-2024.2.3.3-b4-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.3.3/yugabytedb-anywhere-2024.2.3.3-b4-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.3.3" build="4" >}}
 
 ### Bug fix
@@ -915,12 +807,6 @@ This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 * Ensures CDC streams data for non-transactional YCQL tables correctly. {{<issue 28034>}}
 
 ## v2024.2.3.2 - June 24, 2025 {#v2024.2.3.2}
-
-**Build:** `2024.2.3.2-b6`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.3.2/yugabytedb-2024.2.3.2-b6-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.3.2/yugabytedb-anywhere-2024.2.3.2-b6-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.3.2" build="6" >}}
 
@@ -937,12 +823,6 @@ This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 
 ## v2024.2.3.1 - June 13, 2025 {#v2024.2.3.1}
 
-**Build:** `2024.2.3.1-b3`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.3.1/yugabytedb-2024.2.3.1-b3-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.3.1/yugabytedb-anywhere-2024.2.3.1-b3-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.3.1" build="3" >}}
 
 ### Improvement
@@ -958,12 +838,6 @@ This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 * Ensures accurate replication for transactional writes on xCluster range partitioned tables. {{<issue 27380>}}
 
 ## v2024.2.3.0 - May 16, 2025 {#v2024.2.3.0}
-
-**Build:** `2024.2.3.0-b116`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.3.0/yugabytedb-2024.2.3.0-b116-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.3.0/yugabytedb-anywhere-2024.2.3.0-b116-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.3.0" build="116" >}}
 
@@ -1119,12 +993,6 @@ YugabyteDB now includes the [PostgreSQL Anonymizer extension](/v2024.2/additiona
 
 ## v2024.2.2.5 - August 5, 2025 {#v2024.2.2.5}
 
-**Build:** `2024.2.2.5-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.2.5/yugabytedb-2024.2.2.5-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.2.5/yugabytedb-anywhere-2024.2.2.5-b2-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.2.5" build="2" >}}
 
 ### Bug fix
@@ -1135,35 +1003,17 @@ YugabyteDB now includes the [PostgreSQL Anonymizer extension](/v2024.2/additiona
 
 ## v2024.2.2.4 - May 19, 2025 {#v2024.2.2.4}
 
-**Build:** `2024.2.2.4-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.2.4/yugabytedb-2024.2.2.4-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.2.4/yugabytedb-anywhere-2024.2.2.4-b1-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.2.4" build="1" >}}
 
 This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 
 ## v2024.2.2.3 - May 6, 2025 {#v2024.2.2.3}
 
-**Build:** `2024.2.2.3-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.2.3/yugabytedb-2024.2.2.3-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.2.3/yugabytedb-anywhere-2024.2.2.3-b1-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.2.3" build="1" >}}
 
 This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 
 ## v2024.2.2.2 - April 9, 2025 {#v2024.2.2.2}
-
-**Build:** `2024.2.2.2-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.2.2/yugabytedb-2024.2.2.2-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.2.2/yugabytedb-anywhere-2024.2.2.2-b2-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.2.2" build="2" >}}
 
@@ -1181,12 +1031,6 @@ This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 </details>
 
 ## v2024.2.2.1 - March 11, 2025 {#v2024.2.2.1}
-
-**Build:** `2024.2.2.1-b6`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.2.1/yugabytedb-2024.2.2.1-b6-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.2.1/yugabytedb-anywhere-2024.2.2.1-b6-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.2.1" build="6" >}}
 
@@ -1214,12 +1058,6 @@ This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 </details>
 
 ## v2024.2.2.0 - February 28, 2025 {#v2024.2.2.0}
-
-**Build:** `2024.2.2.0-b70`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.2.0/yugabytedb-2024.2.2.0-b70-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.2.0/yugabytedb-anywhere-2024.2.2.0-b70-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.2.0" build="70" >}}
 
@@ -1320,12 +1158,6 @@ yugabyted does not work under Docker in v2024.2.2.0.
 
 ## v2024.2.1.0 - January 30, 2025 {#v2024.2.1.0}
 
-**Build:** `2024.2.1.0-b185`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.1.0/yugabytedb-2024.2.1.0-b185-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.1.0/yugabytedb-anywhere-2024.2.1.0-b185-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2024.2.1.0" build="185" >}}
 
 ### New features
@@ -1418,12 +1250,6 @@ yugabyted does not work under Docker in v2024.2.2.0.
 </details>
 
 ## v2024.2.0.0 - December 9, 2024 {#v2024.2.0.0}
-
-**Build:** `2024.2.0.0-b145`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2024.2.0.0/yugabytedb-2024.2.0.0-b145-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2024.2.0.0/yugabytedb-anywhere-2024.2.0.0-b145-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2024.2.0.0" build="145" >}}
 

--- a/docs/content/stable/releases/ybdb-releases/v2025.1.md
+++ b/docs/content/stable/releases/ybdb-releases/v2025.1.md
@@ -19,12 +19,6 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 
 ## v2025.1.4.0 - April 20, 2026 {#v2025.1.4.0}
 
-**Build:** `2025.1.4.0-b103`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.4.0/yugabytedb-2025.1.4.0-b103-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.4.0/yugabytedb-anywhere-2025.1.4.0-b103-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2025.1.4.0" build="103" >}}
 
 ### Improvements
@@ -148,23 +142,11 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 
 ## v2025.1.3.2 - February 26, 2026 {#v2025.1.3.2}
 
-**Build:** `2025.1.3.2-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.3.2/yugabytedb-2025.1.3.2-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.3.2/yugabytedb-anywhere-2025.1.3.2-b1-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2025.1.3.2" build="1" >}}
 
 This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 
 ## v2025.1.3.1 - February 5, 2026 {#v2025.1.3.1}
-
-**Build:** `2025.1.3.1-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.3.1/yugabytedb-2025.1.3.1-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.3.1/yugabytedb-anywhere-2025.1.3.1-b2-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2025.1.3.1" build="2" >}}
 
@@ -179,12 +161,6 @@ This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 * Fixes tablet split validation to handle 0x0000 as an empty key for hash partitions. {{<issue 30062>}}
 
 ## v2025.1.3.0 - January 16, 2026 {#v2025.1.3.0}
-
-**Build:** `2025.1.3.0-b75`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.3.0/yugabytedb-2025.1.3.0-b75-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.3.0/yugabytedb-anywhere-2025.1.3.0-b75-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2025.1.3.0" build="75" >}}
 
@@ -275,35 +251,17 @@ This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 
 ## v2025.1.2.2 - December 17, 2025 {#v2025.1.2.2}
 
-**Build:** `2025.1.2.2-b5`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.2.2/yugabytedb-2025.1.2.2-b5-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.2.2/yugabytedb-anywhere-2025.1.2.2-b5-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2025.1.2.2" build="5" >}}
 
 This is a YugabyteDB Anywhere-only release, with no significant changes to YugabyteDB.
 
 ## v2025.1.2.1 - December 2, 2025 {#v2025.1.2.1}
 
-**Build:** `2025.1.2.1-b4`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.2.1/yugabytedb-2025.1.2.1-b4-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.2.1/yugabytedb-anywhere-2025.1.2.1-b4-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2025.1.2.1" build="4" >}}
 
 This is a YugabyteDB Anywhere-only release, with no significant changes to YugabyteDB.
 
 ## v2025.1.2.0 - November 20, 2025 {#v2025.1.2.0}
-
-**Build:** `2025.1.2.0-b110`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.2.0/yugabytedb-2025.1.2.0-b110-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.2.0/yugabytedb-anywhere-2025.1.2.0-b110-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2025.1.2.0" build="110" >}}
 
@@ -433,12 +391,6 @@ Alleviate restore failures by adjusting the 'enable_export_snapshot_using_relfil
 
 ## v2025.1.1.2 - October 20, 2025 {#v2025.1.1.2}
 
-**Build:** `2025.1.1.2-b3`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.1.2/yugabytedb-2025.1.1.2-b3-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.1.2/yugabytedb-anywhere-2025.1.1.2-b3-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2025.1.1.2" build="3" >}}
 
 ### Improvements
@@ -460,12 +412,6 @@ Alleviate restore failures by adjusting the 'enable_export_snapshot_using_relfil
 * Eliminates stale hashmap entries on parse errors, enhancing protocol-level prepared statement handling. {{<issue 28576>}}
 
 ## v2025.1.1.1 - October 3, 2025 {#v2025.1.1.1}
-
-**Build:** `2025.1.1.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.1.1/yugabytedb-2025.1.1.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.1.1/yugabytedb-anywhere-2025.1.1.1-b1-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2025.1.1.1" build="1" >}}
 
@@ -721,12 +667,6 @@ For more information, refer to [xCluster replication](/v2025.1/architecture/docd
 
 ## v2025.1.0.1 - August 5, 2025 {#v2025.1.0.1}
 
-**Build:** `2025.1.0.1-b3`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.0.1/yugabytedb-2025.1.0.1-b3-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.0.1/yugabytedb-anywhere-2025.1.0.1-b3-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2025.1.0.1" build="3" >}}
 
 ### Bug fixes
@@ -738,12 +678,6 @@ For more information, refer to [xCluster replication](/v2025.1/architecture/docd
 * Enhances Kubernetes compatibility by using RPC bind address as hostname in masters. {{<issue 28084>}}
 
 ## v2025.1.0.0 - July 23, 2025 {#v2025.1.0.0}
-
-**Build:** `2025.1.0.0-b168`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.1.0.0/yugabytedb-2025.1.0.0-b168-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.1.0.0/yugabytedb-anywhere-2025.1.0.0-b168-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2025.1.0.0" build="168" >}}
 

--- a/docs/content/stable/releases/ybdb-releases/v2025.2.md
+++ b/docs/content/stable/releases/ybdb-releases/v2025.2.md
@@ -19,12 +19,6 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 
 ## v2025.2.5.2 - August 3, 2026 {#v2025.2.5.2}
 
-**Build:** `2025.2.5.2-b5`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.5.2/yugabytedb-2025.2.5.2-b5-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.5.2/yugabytedb-anywhere-2025.2.5.2-b5-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2025.2.5.2" build="5" >}}
 
 ### Improvements
@@ -50,12 +44,6 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 * Preserves client prepared-statement state during YSQL sync errors. {{<issue 32809>}}
 
 ## v2025.2.5.1 - July 23, 2026 {#v2025.2.5.0}
-
-**Build:** `2025.2.5.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.5.1/yugabytedb-2025.2.5.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.5.1/yugabytedb-anywhere-2025.2.5.1-b1-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2025.2.5.1" build="1" >}}
 
@@ -183,12 +171,6 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 
 ## v2025.2.4.1 - July 16, 2026 {#v2025.2.4.1}
 
-**Build:** `2025.2.4.1-b4`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.4.1/yugabytedb-2025.2.4.1-b4-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.4.1/yugabytedb-anywhere-2025.2.4.1-b4-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2025.2.4.1" build="4" >}}
 
 ### Bug fixes
@@ -205,12 +187,6 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 * Prevents blacklisted TServers from handling read/write operations during planned restarts. {{<issue 32353>}}
 
 ## v2025.2.4.0 - June 22, 2026 {#v2025.2.4.0}
-
-**Build:** `2025.2.4.0-b122`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.4.0/yugabytedb-2025.2.4.0-b122-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.4.0/yugabytedb-anywhere-2025.2.4.0-b122-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2025.2.4.0" build="122" >}}
 
@@ -410,12 +386,6 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 
 ## v2025.2.3.2 - June 4, 2026 {#v2025.2.3.2}
 
-**Build:** `2025.2.3.2-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.3.2/yugabytedb-2025.2.3.2-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.3.2/yugabytedb-anywhere-2025.2.3.2-b1-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2025.2.3.2" build="1" >}}
 
 ### Improvement
@@ -425,12 +395,6 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 * Reverts a change to address index creation inconsistency when `enable_ysql_operation_lease` is false. {{<issue 27863>}}
 
 ## v2025.2.3.1 - June 2, 2026 {#v2025.2.3.1}
-
-**Build:** `2025.2.3.1-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.3.1/yugabytedb-2025.2.3.1-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.3.1/yugabytedb-anywhere-2025.2.3.1-b2-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2025.2.3.1" build="2" >}}
 
@@ -444,12 +408,6 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 * Enhances data correctness by safely merging column updates during compaction. {{<issue 30837>}}
 
 ## v2025.2.3.0 - May 14, 2026 {#v2025.2.3.0}
-
-**Build:** `2025.2.3.0-b149`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.3.0/yugabytedb-2025.2.3.0-b149-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.3.0/yugabytedb-anywhere-2025.2.3.0-b149-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2025.2.3.0" build="149" >}}
 
@@ -653,12 +611,6 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 
 ## v2025.2.2.2 - April 7, 2026 {#v2025.2.2.2}
 
-**Build:** `2025.2.2.2-b11`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.2.2/yugabytedb-2025.2.2.2-b11-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.2.2/yugabytedb-anywhere-2025.2.2.2-b11-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2025.2.2.2" build="11" >}}
 
 ### Bug fixes
@@ -678,19 +630,11 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 
 ## v2025.2.2.1 - March 23, 2026 {#v2025.2.2.1}
 
-**Build:** `2025.2.2.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.2.1/yugabytedb-2025.2.2.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.2.1/yugabytedb-anywhere-2025.2.2.1-b1-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2025.2.2.1" build="1" >}}
 
 This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 
 ## v2025.2.2.0 - March 12, 2026 {#v2025.2.2.0}
-
-### Downloads
 
 {{< warning title="Use v2025.2.2.1.">}}
 v2025.2.2.0 includes an issue affecting LDAP in YugabyteDB Anywhere. In some circumstances, redacted values in `ysql_hba_conf_csv` can be overwritten during YBA-based universe operations, potentially leading to misconfigured database LDAP settings or authentication failures. Use [v2025.2.2.1](#v2025.2.2.1).
@@ -823,12 +767,6 @@ v2025.2.2.0 includes an issue affecting LDAP in YugabyteDB Anywhere. In some cir
 </details>
 
 ## v2025.2.1.0 - February 12, 2026 {#v2025.2.1.0}
-
-**Build:** `2025.2.1.0-b141`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.1.0/yugabytedb-2025.2.1.0-b141-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.1.0/yugabytedb-anywhere-2025.2.1.0-b141-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2025.2.1.0" build="141" >}}
 
@@ -1083,12 +1021,6 @@ Reduces latency by leveraging authentication passthrough mechanism for acquiring
 
 ## v2025.2.0.1 - January 26, 2026 {#v2025.2.0.1}
 
-**Build:** `2025.2.0.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.0.1/yugabytedb-2025.2.0.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.0.1/yugabytedb-anywhere-2025.2.0.1-b1-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2025.2.0.1" build="1" >}}
 
 ### Bug fix
@@ -1098,12 +1030,6 @@ Reduces latency by leveraging authentication passthrough mechanism for acquiring
 * Disables graceful shutdown to prevent data corruption. {{<issue 30047>}}
 
 ## v2025.2.0.0 - December 11, 2025 {#v2025.2.0.0}
-
-**Build:** `2025.2.0.0-b131`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2025.2.0.0/yugabytedb-2025.2.0.0-b131-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2025.2.0.0/yugabytedb-anywhere-2025.2.0.0-b131-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2025.2.0.0" build="131" >}}
 

--- a/docs/content/stable/releases/ybdb-releases/v2026.1.md
+++ b/docs/content/stable/releases/ybdb-releases/v2026.1.md
@@ -19,23 +19,11 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 
 ## v2026.1.1.1 - August 18, 2026 {#v2026.1.1.1}
 
-**Build:** `2026.1.1.1-b2`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2026.1.1.1/yugabytedb-2026.1.1.1-b2-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2026.1.1.1/yugabytedb-anywhere-2026.1.1.1-b2-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2026.1.1.1" build="2" >}}
 
 This is a YugabyteDB Anywhere-only release, with no changes to YugabyteDB.
 
 ## v2026.1.1.0 - August 13, 2026 {#v2026.1.1.0}
-
-**Build:** `2026.1.1.0-b91`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2026.1.1.0/yugabytedb-2026.1.1.0-b91-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2026.1.1.0/yugabytedb-anywhere-2026.1.1.0-b91-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2026.1.1.0" build="91" >}}
 
@@ -270,12 +258,6 @@ Enhances ANALYZE on large tables to avoid errors related to outdated snapshots. 
 
 ## v2026.1.0.1 - July 22, 2026 {#v2026.1.0.1}
 
-**Build:** `2026.1.0.1-b1`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2026.1.0.1/yugabytedb-2026.1.0.1-b1-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2026.1.0.1/yugabytedb-anywhere-2026.1.0.1-b1-third-party-licenses.html)
-
-### Downloads
-
 {{< release-downloads version="2026.1.0.1" build="1" >}}
 
 ### Bug fixes
@@ -291,12 +273,6 @@ Enhances ANALYZE on large tables to avoid errors related to outdated snapshots. 
 * Resolves race conditions between Remote Bootstrap and config changes, effectively managing the deletion of outdated tablet replicas. {{<issue 31930>}},{{<issue 31241>}}
 
 ## v2026.1.0.0 - June 29, 2026 {#v2026.1.0.0}
-
-**Build:** `2026.1.0.0-b118`
-
-**Third-party licenses:** [YugabyteDB](https://downloads.yugabyte.com/releases/2026.1.0.0/yugabytedb-2026.1.0.0-b118-third-party-licenses.html), [YugabyteDB Anywhere](https://downloads.yugabyte.com/releases/2026.1.0.0/yugabytedb-anywhere-2026.1.0.0-b118-third-party-licenses.html)
-
-### Downloads
 
 {{< release-downloads version="2026.1.0.0" build="118" >}}
 

--- a/docs/layouts/_shortcodes/release-downloads.html
+++ b/docs/layouts/_shortcodes/release-downloads.html
@@ -1,5 +1,5 @@
 {{/*
-Renders a tabbed download section for a YugabyteDB release.
+Renders the per-release header (build, licenses, downloads) for a YugabyteDB or YBA release.
 
 Parameters:
   version  - full 4-part version, e.g. "2026.1.0.0"
@@ -20,6 +20,12 @@ Usage:
 {{- $bver     := printf "%s-b%s" $version $build -}}
 {{- $base     := printf "https://software.yugabyte.com/releases/%s" $version -}}
 {{- $ybaBase  := printf "https://downloads.yugabyte.com/releases/%s" $version -}}
+{{- $dlLabel  := "Downloads" -}}
+{{- if eq $type "yba" -}}{{- $dlLabel = "Download" -}}{{- end -}}
+{{- $ybdbLicense := printf "https://downloads.yugabyte.com/releases/%s/yugabytedb-%s-third-party-licenses.html" $version $bver -}}
+{{- $ybaLicense  := printf "https://downloads.yugabyte.com/releases/%s/yugabytedb-anywhere-%s-third-party-licenses.html" $version $bver -}}
+{{- $headerMd := printf "**Build:** `%s`\n\n**Third-party licenses:** [YugabyteDB](%s), [YugabyteDB Anywhere](%s)\n\n**%s**" $bver $ybdbLicense $ybaLicense $dlLabel -}}
+{{ $headerMd | .Page.RenderString }}
 
 {{- $tabs := slice -}}
 {{- if eq $type "ybdb" -}}


### PR DESCRIPTION
Expands release-downloads shorcode to incorporate the boilerplate at the top of release note sections