### PR TITLE
[#33444] DocDB: Add the shadow verification coordinator with durable job state

### DIFF
--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -121,6 +121,26 @@ DEFINE_test_flag(bool, block_index_backfill_ordering_generation_release, false,
     "Skip releasing index-backfill ordering generations in the terminal funnel, keeping them "
     "active so tests can run the verification scan against a completed build.");
 
+DEFINE_RUNTIME_bool(ysql_index_backfill_shadow_verification, false,
+    "Run the deferred uniqueness verification scan after a SKIP_ALL unique-index backfill "
+    "completes. The scan itself runs on the publication critical path (CREATE INDEX waits "
+    "for it), but its outcome is only persisted and logged -- it never gates publication "
+    "(the fail-closed gate is a separate, later capability).");
+
+DEFINE_RUNTIME_uint32(index_backfill_shadow_verification_max_concurrent_tablets, 4,
+    "Bound on concurrently verified tablets per index during shadow verification.");
+
+DEFINE_RUNTIME_uint64(index_backfill_shadow_verification_dockey_groups_per_rpc, 0,
+    "DocKey-group budget per verification RPC (0 = bounded only by the RPC deadline); the "
+    "coordinator resumes a paginated tablet from the returned resume key.");
+
+DEFINE_RUNTIME_int32(index_backfill_verify_rpc_timeout_ms, 60000,
+    "Deadline for one unique-index verification RPC, i.e. one deadline-bounded page of the "
+    "verification scan (the tserver stops a grace margin early and returns a resume key). "
+    "A dedicated budget like the backfill chunks' ysql_index_backfill_rpc_timeout_ms rather "
+    "than the generic master_ts_rpc_timeout_ms: every page re-establishes iterators, so "
+    "sizing pages independently of unrelated master RPCs matters on large tablets.");
+
 DEFINE_test_flag(bool, skip_index_backfill, false,
     "Skips backfilling the data on tservers and leaves the index in inconsistent state.");
 
@@ -1093,6 +1113,20 @@ Status BackfillTable::DoBackfill() {
 }
 
 Status BackfillTable::LaunchBackfillTablets() {
+  if (indexes_to_build().empty()) {
+    // Post-success resume: a master failover after every index reached SUCCESS but before the
+    // terminal funnel (e.g. during the shadow verification phase) re-drives the persisted job
+    // with nothing left to backfill. Chunks would carry empty index sets and spin; jump to
+    // the completion path instead, which re-enters shadow verification (resuming its
+    // persisted window) and the funnel.
+    LOG_WITH_PREFIX(INFO)
+        << "All job indexes already backfilled; resuming the completion phase";
+    State expected = State::kRunning;
+    state_.compare_exchange_strong(expected, State::kSuccess, std::memory_order_acq_rel);
+    RETURN_NOT_OK_PREPEND(
+        MarkAllIndexesAsSuccess(), "Failed to mark indexes as successfully backfilled.");
+    return LaunchShadowVerificationOrFinish();
+  }
   auto tablets = VERIFY_RESULT(indexed_table_->GetTablets());
   num_tablets_.store(tablets.size(), std::memory_order_release);
   tablets_pending_.store(tablets.size(), std::memory_order_release);
@@ -1223,6 +1257,329 @@ Status BackfillTable::SendRpcToReleaseOrderingGenerations() {
   return Status::OK();
 }
 
+Status BackfillTable::LaunchShadowVerificationOrFinish() {
+  if (!FLAGS_ysql_index_backfill_shadow_verification ||
+      unique_index_backfill_mode() != UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_SKIP_ALL ||
+      indexed_table_->GetTableType() != TableType::PGSQL_TABLE_TYPE) {
+    return FinishShadowVerification();
+  }
+  // Not restricted to indexes_to_build(): that filters to IN_PROGRESS backfill states, and
+  // this phase runs after MarkAllIndexesAsSuccess. Verification targets the job's unique
+  // indexes as built.
+  //
+  // Ordering note the tserver metadata validator depends on: index *permissions* stay at
+  // DO_BACKFILL until FinishShadowVerification runs the terminal funnel, and the validator's
+  // generation-release backstop triggers off GetBackfillStatus, which maps from permissions
+  // -- so the backstop cannot release generations while this phase is scanning.
+  auto index_tables_result = GetUniqueIndexTables(RestrictToIndexesToBuild::kFalse);
+  if (!index_tables_result.ok()) {
+    ShadowVerificationPhaseFailed(index_tables_result.status(), "resolve index tables");
+    return Status::OK();
+  }
+  auto index_tables = std::move(*index_tables_result);
+  if (index_tables.empty()) {
+    return FinishShadowVerification();
+  }
+  {
+    std::lock_guard l(mutex_);
+    shadow_verification_.remaining_indexes = std::move(index_tables);
+  }
+  auto status = StartShadowVerificationForNextIndex();
+  if (!status.ok()) {
+    ShadowVerificationPhaseFailed(status, "start verification");
+  }
+  return Status::OK();
+}
+
+Status BackfillTable::StartShadowVerificationForNextIndex() {
+  scoped_refptr<TableInfo> index_table;
+  {
+    std::lock_guard l(mutex_);
+    auto& sv = shadow_verification_;
+    if (sv.remaining_indexes.empty()) {
+      sv.current_index = nullptr;
+      index_table = nullptr;
+    } else {
+      index_table = sv.remaining_indexes.back();
+      sv.remaining_indexes.pop_back();
+      sv.current_index = index_table;
+      sv.pending_tablets.clear();
+      sv.in_flight = 0;
+      sv.terminal = false;
+    }
+  }
+  if (!index_table) {
+    return FinishShadowVerification();
+  }
+
+  // The window's upper bound is chosen ONCE, from cluster hybrid time (never wall clock),
+  // and persisted: retries and failover resume verify the same window. Tablets already
+  // confirmed clean by a previous incarnation are not re-scanned.
+  HybridTime verify_upper_ht;
+  std::unordered_set<TabletId> clean_tablets;
+  bool resumed = false;
+  const auto now = master_->clock()->Now();
+  RETURN_NOT_OK(MutateVerificationState(
+      index_table->id(),
+      [now, &verify_upper_ht, &clean_tablets, &resumed](UniqueIndexVerificationStatePB* state) {
+        if (state->state() == UniqueIndexVerificationStatePB::VERIFY_NONE) {
+          state->set_state(UniqueIndexVerificationStatePB::VERIFY_IN_PROGRESS);
+          state->set_verify_upper_ht(now.ToUint64());
+        } else {
+          resumed = true;
+        }
+        verify_upper_ht = HybridTime(state->verify_upper_ht());
+        for (const auto& tablet_id : state->clean_tablet_ids()) {
+          clean_tablets.insert(tablet_id);
+        }
+      }));
+  LOG_WITH_PREFIX(INFO) << (resumed ? "Resuming" : "Starting") << " shadow verification for "
+                        << "unique index " << index_table->id() << ", window upper "
+                        << verify_upper_ht << ", " << clean_tablets.size()
+                        << " tablet(s) already clean";
+
+  auto tablets = VERIFY_RESULT(index_table->GetTablets());
+  if (tablets.empty()) {
+    // An empty tablet *set* is not evidence of uniqueness -- there was nothing to scan.
+    RETURN_NOT_OK(RecordShadowVerificationOutcome(
+        UniqueIndexVerificationStatePB::VERIFY_INCONCLUSIVE, "index has no tablets to verify"));
+    return StartShadowVerificationForNextIndex();
+  }
+
+  std::vector<TabletInfoPtr> to_launch;
+  {
+    std::lock_guard l(mutex_);
+    auto& sv = shadow_verification_;
+    sv.verify_upper_ht = verify_upper_ht;
+    for (auto& tablet : tablets) {
+      if (clean_tablets.count(tablet->tablet_id()) == 0) {
+        sv.pending_tablets.push_back(tablet);
+      }
+    }
+    const size_t bound = std::max<size_t>(
+        1, FLAGS_index_backfill_shadow_verification_max_concurrent_tablets);
+    while (!sv.pending_tablets.empty() && sv.in_flight < bound) {
+      to_launch.push_back(sv.pending_tablets.front());
+      sv.pending_tablets.pop_front();
+      ++sv.in_flight;
+    }
+    if (to_launch.empty()) {
+      sv.terminal = true;  // Everything was already clean.
+    }
+  }
+  if (to_launch.empty()) {
+    RETURN_NOT_OK(RecordShadowVerificationOutcome(
+        UniqueIndexVerificationStatePB::VERIFY_CLEAN, std::string()));
+    return StartShadowVerificationForNextIndex();
+  }
+  for (const auto& tablet : to_launch) {
+    RETURN_NOT_OK(LaunchShadowVerificationTablet(tablet, std::string()));
+  }
+  return Status::OK();
+}
+
+Status BackfillTable::LaunchShadowVerificationTablet(
+    const TabletInfoPtr& tablet, const std::string& start_key) {
+  TableId index_table_id;
+  HybridTime verify_upper_ht;
+  {
+    std::lock_guard l(mutex_);
+    index_table_id = shadow_verification_.current_index->id();
+    verify_upper_ht = shadow_verification_.verify_upper_ht;
+  }
+  auto task = std::make_shared<VerifyUniqueIndexForTablet>(
+      shared_from_this(), tablet, index_table_id, read_time_for_backfill(), verify_upper_ht,
+      start_key, epoch_);
+  return task->Launch();
+}
+
+void BackfillTable::ShadowVerificationTabletDone(
+    const TabletInfoPtr& tablet, const Status& status,
+    const tserver::VerifyUniqueIndexTabletResponsePB& resp) {
+  // The shadow phase runs entirely in the kSuccess state (Done() transitions before
+  // launching verification), so done() would swallow every callback; only a failed/aborted
+  // job stops the phase.
+  if (state_.load(std::memory_order_acquire) != State::kSuccess) {
+    return;
+  }
+
+  const bool clean = status.ok() &&
+                     resp.outcome() == tserver::VerifyUniqueIndexTabletResponsePB::CLEAN;
+
+  // Single-winner protocol: the terminal check and the launch-next / index-done decision are
+  // one critical section, so a CLEAN callback racing a short-circuiting VIOLATION can neither
+  // overwrite the recorded outcome nor double-advance to the next index. Exactly one callback
+  // per index performs a kIndexClean or kTerminalOutcome action.
+  enum class Action { kIgnore, kResume, kLaunchNext, kIndexClean, kTerminalOutcome };
+  Action action = Action::kIgnore;
+  TabletInfoPtr next;
+  TableId index_table_id;
+  {
+    std::lock_guard l(mutex_);
+    auto& sv = shadow_verification_;
+    if (sv.terminal || !sv.current_index) {
+      return;  // A winner already recorded this index's outcome; late responses are ignored.
+    }
+    index_table_id = sv.current_index->id();
+    if (clean && resp.has_resume_key()) {
+      action = Action::kResume;  // Pagination: same tablet continues; join counts untouched.
+    } else if (clean) {
+      --sv.in_flight;
+      if (!sv.pending_tablets.empty()) {
+        next = sv.pending_tablets.front();
+        sv.pending_tablets.pop_front();
+        ++sv.in_flight;
+        action = Action::kLaunchNext;
+      } else if (sv.in_flight == 0) {
+        sv.terminal = true;
+        action = Action::kIndexClean;
+      }  // else: other tablets still in flight; this callback only contributes its clean id.
+    } else {
+      sv.terminal = true;
+      sv.pending_tablets.clear();
+      action = Action::kTerminalOutcome;
+    }
+  }
+
+  switch (action) {
+    case Action::kResume: {
+      auto s = LaunchShadowVerificationTablet(tablet, resp.resume_key());
+      if (!s.ok()) {
+        ShadowVerificationPhaseFailed(s, "resume paginated verification");
+      }
+      return;
+    }
+    case Action::kIgnore:  [[fallthrough]];
+    case Action::kLaunchNext: [[fallthrough]];
+    case Action::kIndexClean: {
+      // Persist the clean tablet after the join decision: the sys-catalog write is slow, and
+      // holding the decision open across it is what created the false-clean race. Losing a
+      // clean id on a failure here only costs an idempotent re-scan on resume.
+      WARN_NOT_OK(MutateVerificationState(
+          index_table_id,
+          [&tablet](UniqueIndexVerificationStatePB* state) {
+            state->add_clean_tablet_ids(tablet->tablet_id());
+          }), "Failed to persist clean tablet");
+      if (action == Action::kLaunchNext) {
+        auto s = LaunchShadowVerificationTablet(next, std::string());
+        if (!s.ok()) {
+          ShadowVerificationPhaseFailed(s, "launch next tablet");
+        }
+      } else if (action == Action::kIndexClean) {
+        auto s = RecordShadowVerificationOutcome(
+            UniqueIndexVerificationStatePB::VERIFY_CLEAN, std::string());
+        if (s.ok()) {
+          s = StartShadowVerificationForNextIndex();
+        }
+        if (!s.ok()) {
+          ShadowVerificationPhaseFailed(s, "advance after clean index");
+        }
+      }
+      return;
+    }
+    case Action::kTerminalOutcome: {
+      UniqueIndexVerificationStatePB::State outcome;
+      std::string reason;
+      if (!status.ok()) {
+        // Exhausted retries on a tablet: the window was not fully verified. Value-free by
+        // construction -- every status on this path carries encoding classes and counts only.
+        outcome = UniqueIndexVerificationStatePB::VERIFY_INCONCLUSIVE;
+        reason = status.message().ToBuffer();
+      } else if (resp.outcome() == tserver::VerifyUniqueIndexTabletResponsePB::VIOLATION) {
+        outcome = UniqueIndexVerificationStatePB::VERIFY_VIOLATION;
+        reason = resp.reason();
+      } else if (resp.outcome() == tserver::VerifyUniqueIndexTabletResponsePB::INCONCLUSIVE) {
+        outcome = UniqueIndexVerificationStatePB::VERIFY_INCONCLUSIVE;
+        reason = resp.reason();
+      } else {
+        outcome = UniqueIndexVerificationStatePB::VERIFY_INCONCLUSIVE;
+        reason = "response without an outcome";
+      }
+      auto s = RecordShadowVerificationOutcome(outcome, reason);
+      if (s.ok()) {
+        s = StartShadowVerificationForNextIndex();
+      }
+      if (!s.ok()) {
+        ShadowVerificationPhaseFailed(s, "advance after terminal outcome");
+      }
+      return;
+    }
+  }
+  FATAL_INVALID_ENUM_VALUE(Action, action);
+}
+
+// The shadow phase is on the publication critical path (CREATE INDEX waits for it), so no
+// coordinator failure may strand the job short of the terminal funnel. Best-effort-record
+// INCONCLUSIVE, then always continue into publication.
+void BackfillTable::ShadowVerificationPhaseFailed(
+    const Status& status, const char* while_doing) {
+  LOG_WITH_PREFIX(WARNING) << "Shadow verification phase failed (" << while_doing
+                           << "): " << status << "; degrading to INCONCLUSIVE and publishing";
+  {
+    std::lock_guard l(mutex_);
+    shadow_verification_.terminal = true;
+    shadow_verification_.pending_tablets.clear();
+    shadow_verification_.remaining_indexes.clear();
+  }
+  WARN_NOT_OK(
+      RecordShadowVerificationOutcome(
+          UniqueIndexVerificationStatePB::VERIFY_INCONCLUSIVE, "coordinator error"),
+      "Failed to record shadow verification outcome");
+  WARN_NOT_OK(FinishShadowVerification(), "Failed to finish backfill after shadow phase");
+}
+
+Status BackfillTable::RecordShadowVerificationOutcome(
+    UniqueIndexVerificationStatePB::State state, const std::string& reason) {
+  TableId index_table_id;
+  {
+    std::lock_guard l(mutex_);
+    if (!shadow_verification_.current_index) {
+      // Phase failure before any index was selected (e.g. index-table resolution failed):
+      // there is nothing to record per index.
+      return Status::OK();
+    }
+    index_table_id = shadow_verification_.current_index->id();
+  }
+  RETURN_NOT_OK(MutateVerificationState(
+      index_table_id, [state, &reason](UniqueIndexVerificationStatePB* state_pb) {
+        state_pb->set_state(state);
+        if (!reason.empty()) {
+          state_pb->set_reason(reason);
+        }
+      }));
+  // SHADOW: the outcome is recorded and logged, never enforced. The fail-closed
+  // verify-before-publication gate is a separate, later capability.
+  const auto severity_prefix =
+      state == UniqueIndexVerificationStatePB::VERIFY_CLEAN ? "" : "NOT CLEAN: ";
+  LOG_WITH_PREFIX(INFO) << "Shadow verification outcome for unique index " << index_table_id
+                        << ": " << severity_prefix
+                        << UniqueIndexVerificationStatePB::State_Name(state)
+                        << (reason.empty() ? "" : Format(" ($0)", reason));
+  return Status::OK();
+}
+
+Status BackfillTable::FinishShadowVerification() {
+  return UpdateIndexPermissionsForIndexes();
+}
+
+Status BackfillTable::MutateVerificationState(
+    const TableId& index_table_id,
+    const std::function<void(UniqueIndexVerificationStatePB*)>& mutator) {
+  auto l = indexed_table_->LockForWrite();
+  auto& indexed_table_pb = l.mutable_data()->pb;
+  if (indexed_table_pb.backfill_jobs_size() == 0) {
+    return STATUS(IllegalState, "Backfill job is gone; cannot record verification state");
+  }
+  auto* verification_map =
+      indexed_table_pb.mutable_backfill_jobs(0)->mutable_unique_index_verification();
+  mutator(&(*verification_map)[index_table_id]);
+  RETURN_NOT_OK_PREPEND(
+      master_->catalog_manager_impl()->sys_catalog_->Upsert(epoch_, indexed_table_),
+      "Failed to persist verification state");
+  l.Commit();
+  return Status::OK();
+}
+
 Status BackfillTable::Done(const Status& s, const std::unordered_set<TableId>& failed_indexes) {
   if (!s.ok()) {
     LOG_WITH_PREFIX(WARNING) << "failed to backfill the index: " << AsString(failed_indexes)
@@ -1244,7 +1601,8 @@ Status BackfillTable::Done(const Status& s, const std::unordered_set<TableId>& f
     StopLivenessMonitor();
     RETURN_NOT_OK_PREPEND(
         MarkAllIndexesAsSuccess(), "Failed to mark indexes as successfully backfilled.");
-    RETURN_NOT_OK_PREPEND(UpdateIndexPermissionsForIndexes(), "Failed to complete backfill.");
+    RETURN_NOT_OK_PREPEND(
+        LaunchShadowVerificationOrFinish(), "Failed to complete backfill.");
   } else {
     VLOG_WITH_PREFIX(1) << "Still backfilling " << tablets_pending_ << " more tablets.";
   }
@@ -1918,6 +2276,122 @@ void UpdateOrderingGenerationForTablet::UnregisterAsyncTaskCallback() {
     status = STATUS_FORMAT(InternalError, "$0 in state $1", description(), state());
   }
   backfill_table_->OrderingGenerationUpdateDone(status, tablet_->tablet_id());
+}
+
+VerifyUniqueIndexForTablet::VerifyUniqueIndexForTablet(
+    std::shared_ptr<BackfillTable> backfill_table,
+    const TabletInfoPtr& tablet,
+    const TableId& index_table_id,
+    HybridTime backfill_read_ht,
+    HybridTime verify_upper_ht,
+    std::string start_key,
+    LeaderEpoch epoch)
+    : RetryingTSRpcTaskWithTable(
+          backfill_table->master(), backfill_table->threadpool(),
+          std::unique_ptr<TSPicker>(new PickLeaderReplica(tablet)), tablet->table(),
+          std::move(epoch),
+          /* async_task_throttler */ nullptr),
+      backfill_table_(backfill_table),
+      tablet_(tablet),
+      index_table_id_(index_table_id),
+      backfill_read_ht_(backfill_read_ht),
+      verify_upper_ht_(verify_upper_ht),
+      start_key_(std::move(start_key)) {
+  deadline_ = MonoTime::Max();  // Single-attempt deadline comes from ComputeDeadline().
+}
+
+Status VerifyUniqueIndexForTablet::Launch() {
+  tablet_->table()->AddTask(shared_from_this());
+  RETURN_NOT_OK_PREPEND(
+      Run(),
+      Substitute("Failed to send VerifyUniqueIndex request for $0. ", tablet_->ToString()));
+  VLOG(3) << "Started VerifyUniqueIndexForTablet : " << this->description();
+  return Status::OK();
+}
+
+std::string VerifyUniqueIndexForTablet::description() const {
+  return Format("Verify unique index $0 tablet $1", index_table_id_, tablet_id());
+}
+
+MonoTime VerifyUniqueIndexForTablet::ComputeDeadline() const {
+  // One deadline-bounded page per attempt (BackfillChunk::ComputeDeadline is the pattern):
+  // the tserver stops a grace margin early and returns a resume key, so the deadline sizes
+  // the page, not the whole tablet scan.
+  MonoTime timeout = MonoTime::Now();
+  timeout.AddDelta(MonoDelta::FromMilliseconds(FLAGS_index_backfill_verify_rpc_timeout_ms));
+  return MonoTime::Earliest(timeout, deadline_);
+}
+
+TabletId VerifyUniqueIndexForTablet::tablet_id() const { return tablet_->id(); }
+
+bool VerifyUniqueIndexForTablet::SendRequest(int attempt) {
+  ADOPT_WAIT_STATE(backfill_table_->wait_state());
+  tserver::VerifyUniqueIndexTabletRequestPB req;
+  req.set_dest_uuid(permanent_uuid());
+  req.set_tablet_id(tablet_->tablet_id());
+  req.set_propagated_hybrid_time(master_->clock()->Now().ToUint64());
+  req.set_backfill_read_ht(backfill_read_ht_.ToUint64());
+  req.set_verify_upper_ht(verify_upper_ht_.ToUint64());
+  req.set_index_table_id(index_table_id_);
+  // No generation_base_op_index on purpose: the base is per-tablet (the activation op's own
+  // Raft index) and a re-activated generation's higher base is still the generation this
+  // job's marked writes live under. The active + index-table check is the semantic guard.
+  if (!start_key_.empty()) {
+    req.set_start_key(start_key_);
+  }
+  if (FLAGS_index_backfill_shadow_verification_dockey_groups_per_rpc > 0) {
+    req.set_max_dockey_groups(FLAGS_index_backfill_shadow_verification_dockey_groups_per_rpc);
+  }
+
+  ts_admin_proxy_->VerifyUniqueIndexTabletAsync(req, &resp_, &rpc_, BindRpcCallback());
+  VLOG(1) << "Send " << description() << " to " << permanent_uuid()
+          << " (attempt " << attempt << "):\n" << req.DebugString();
+  return true;
+}
+
+void VerifyUniqueIndexForTablet::HandleResponse(int attempt) {
+  ADOPT_WAIT_STATE(backfill_table_->wait_state());
+  Status status = Status::OK();
+  if (resp_.has_error()) {
+    status = StatusFromPB(resp_.error().status());
+    switch (resp_.error().code()) {
+      case TabletServerErrorPB::TABLET_NOT_FOUND:
+      case TabletServerErrorPB::OPERATION_NOT_SUPPORTED:
+      case TabletServerErrorPB::INVALID_SCHEMA:
+        LOG(WARNING) << "TS " << permanent_uuid() << ": " << description()
+                     << " failed, no further retry: " << status;
+        TransitionToFailedState(MonitoredTaskState::kRunning, status);
+        break;
+      default:
+        LOG(WARNING) << "TS " << permanent_uuid() << ": " << description() << " failed: "
+                     << status << " code " << resp_.error().code();
+        break;
+    }
+  } else {
+    TransitionToCompleteState();
+    VLOG(1) << "TS " << permanent_uuid() << ": " << description() << " complete";
+  }
+
+  server::UpdateClock(resp_, master_->clock());
+}
+
+void VerifyUniqueIndexForTablet::UnregisterAsyncTaskCallback() {
+  ADOPT_WAIT_STATE(backfill_table_->wait_state());
+  if (state() == MonitoredTaskState::kAborted) {
+    // Deliberately no join notification (same shape as GetSafeTimeForTablet): external task
+    // aborts accompany leadership loss or table teardown, where the job object is dying with
+    // us; notifying could double-drive a job that is already unwinding.
+    VLOG(1) << " was aborted";
+    return;
+  }
+
+  Status status;
+  if (resp_.has_error()) {
+    status = StatusFromPB(resp_.error().status());
+  } else if (state() != MonitoredTaskState::kComplete) {
+    status = STATUS_FORMAT(InternalError, "$0 in state $1", description(), state());
+  }
+  backfill_table_->ShadowVerificationTabletDone(tablet_, status, resp_);
 }
 
 BackfillChunk::BackfillChunk(std::shared_ptr<BackfillTablet> backfill_tablet,

--- a/src/yb/master/backfill_index.h
+++ b/src/yb/master/backfill_index.h
@@ -16,6 +16,8 @@
 #include <float.h>
 
 #include <chrono>
+#include <deque>
+#include <functional>
 #include <set>
 #include <sstream>
 #include <string>
@@ -200,6 +202,12 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
   // the last success launches the backfill chunks.
   void OrderingGenerationUpdateDone(const Status& status, const TabletId& tablet_id);
 
+  // Join point for shadow verification: called by VerifyUniqueIndexForTablet once per
+  // completed RPC (a paginated tablet may complete through several calls).
+  void ShadowVerificationTabletDone(
+      const TabletInfoPtr& tablet, const Status& status,
+      const tserver::VerifyUniqueIndexTabletResponsePB& resp) EXCLUDES(mutex_);
+
  private:
   void LaunchBackfillOrAbort();
   Status WaitForTabletSplitting();
@@ -224,6 +232,31 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
   // tablet; runs in the terminal funnel. Stragglers converge via the tserver metadata
   // validator and master reload reconciliation.
   Status SendRpcToReleaseOrderingGenerations();
+
+  // Observational (never publication-gating) verification phase, run after a successful
+  // SKIP_ALL backfill while the ordering generations are still active, and gated behind
+  // FLAGS_ysql_index_backfill_shadow_verification. Verifies one unique index at a time with
+  // bounded per-tablet concurrency, short-circuits on the first non-clean outcome, persists
+  // durable progress in BackfillJobPB.unique_index_verification, and always continues into
+  // UpdateIndexPermissionsForIndexes.
+  Status LaunchShadowVerificationOrFinish() EXCLUDES(mutex_);
+  Status StartShadowVerificationForNextIndex() EXCLUDES(mutex_);
+  Status LaunchShadowVerificationTablet(
+      const TabletInfoPtr& tablet, const std::string& start_key) EXCLUDES(mutex_);
+  Status RecordShadowVerificationOutcome(
+      UniqueIndexVerificationStatePB::State state, const std::string& reason) EXCLUDES(mutex_);
+  Status FinishShadowVerification();
+
+  // Degrades any shadow-phase coordinator failure to VERIFY_INCONCLUSIVE and continues into
+  // publication: the phase is on the CREATE INDEX critical path and must never strand it.
+  void ShadowVerificationPhaseFailed(const Status& status, const char* while_doing)
+      EXCLUDES(mutex_);
+
+  // Reads (or initializes and persists) the verification state of the given index in the
+  // job's BackfillJobPB, applying `mutator` under the indexed table's write lock.
+  Status MutateVerificationState(
+      const TableId& index_table_id,
+      const std::function<void(UniqueIndexVerificationStatePB*)>& mutator);
 
   Status MarkAllIndexesAsFailed();
   Status MarkAllIndexesAsSuccess();
@@ -278,6 +311,17 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
   std::atomic<size_t> num_tablets_;
   std::atomic<size_t> activation_tablets_pending_{0};
   std::atomic_bool ordering_generation_activated_{false};
+
+  // Shadow verification progress; guarded by mutex_. One index is verified at a time.
+  struct ShadowVerificationState {
+    std::vector<scoped_refptr<TableInfo>> remaining_indexes;
+    scoped_refptr<TableInfo> current_index;
+    HybridTime verify_upper_ht;
+    std::deque<TabletInfoPtr> pending_tablets;
+    size_t in_flight = 0;
+    bool terminal = false;  // Current index reached an outcome; late responses are ignored.
+  };
+  ShadowVerificationState shadow_verification_ GUARDED_BY(mutex_);
   std::atomic_bool using_table_locks_{false};
   std::shared_ptr<BackfillTableJob> backfill_job_;
   mutable simple_spinlock mutex_;
@@ -477,6 +521,50 @@ class UpdateOrderingGenerationForTablet : public RetryingTSRpcTaskWithTable {
   const TableId index_table_id_;
   const tablet::ActivateGeneration activate_;
   const NotifyBackfillTable notify_backfill_table_;
+};
+
+// Runs one deferred-uniqueness-verification RPC against one index tablet on behalf of the
+// shadow verification phase; completion (including per-page completion when the tablet is
+// paginated) joins back into BackfillTable::ShadowVerificationTabletDone.
+class VerifyUniqueIndexForTablet : public RetryingTSRpcTaskWithTable {
+ public:
+  VerifyUniqueIndexForTablet(
+      std::shared_ptr<BackfillTable> backfill_table,
+      const TabletInfoPtr& tablet,
+      const TableId& index_table_id,
+      HybridTime backfill_read_ht,
+      HybridTime verify_upper_ht,
+      std::string start_key,
+      LeaderEpoch epoch);
+
+  Status Launch();
+
+  server::MonitoredTaskType type() const override {
+    return server::MonitoredTaskType::kVerifyUniqueIndexTablet;
+  }
+
+  std::string type_name() const override { return "Verify unique index tablet"; }
+
+  std::string description() const override;
+
+  MonoTime ComputeDeadline() const override;
+
+ private:
+  TabletId tablet_id() const override;
+
+  void HandleResponse(int attempt) override;
+
+  bool SendRequest(int attempt) override;
+
+  void UnregisterAsyncTaskCallback() override;
+
+  tserver::VerifyUniqueIndexTabletResponsePB resp_;
+  const std::shared_ptr<BackfillTable> backfill_table_;
+  const TabletInfoPtr tablet_;
+  const TableId index_table_id_;
+  const HybridTime backfill_read_ht_;
+  const HybridTime verify_upper_ht_;
+  const std::string start_key_;
 };
 
 // A background task which is responsible for backfilling rows in the partitions

--- a/src/yb/master/catalog_entity_info.proto
+++ b/src/yb/master/catalog_entity_info.proto
@@ -56,6 +56,35 @@ message BackfillJobPB {
   // created and immutable for the job's lifetime, across master failover, retries, and
   // runtime flag changes. Missing means UNIQUE_INDEX_BACKFILL_CHECK_ALL.
   optional UniqueIndexBackfillMode unique_index_backfill_mode = 6;
+
+  // Deferred uniqueness verification state, keyed by unique-index TableId. Written by the
+  // shadow verification coordinator after a SKIP_ALL backfill completes; survives master
+  // failover so verification resumes with the same window and does not re-scan tablets
+  // already confirmed clean.
+  map<string, UniqueIndexVerificationStatePB> unique_index_verification = 7;
+}
+
+message UniqueIndexVerificationStatePB {
+  enum State {
+    VERIFY_NONE = 0;
+    VERIFY_IN_PROGRESS = 1;
+    VERIFY_CLEAN = 2;
+    VERIFY_VIOLATION = 3;
+    VERIFY_INCONCLUSIVE = 4;
+  }
+  optional State state = 1;
+
+  // Chosen once from cluster hybrid time when verification starts; never changes for the
+  // job's lifetime -- retries and failover resume verify the same window.
+  optional fixed64 verify_upper_ht = 2;
+
+  // Tablets confirmed clean (tablet-granularity durable progress). Finer intra-tablet resume
+  // keys are deliberately not persisted: re-scanning one tablet after failover is idempotent.
+  repeated bytes clean_tablet_ids = 3;
+
+  // Value-free context for VERIFY_VIOLATION / VERIFY_INCONCLUSIVE: encoding classes and
+  // counts only, never key or value bytes.
+  optional string reason = 4;
 }
 
   message YsqlDdlTxnVerifierStatePB {

--- a/src/yb/server/monitored_task.h
+++ b/src/yb/server/monitored_task.h
@@ -102,7 +102,8 @@ YB_DEFINE_ENUM(MonitoredTaskType,
   (kXClusterInboundReplicationGroupSetup)
   (kXClusterTableSetup)
   (kXClusterFailover)
-  (kUpdateIndexBackfillOrderingGeneration));
+  (kUpdateIndexBackfillOrderingGeneration)
+  (kVerifyUniqueIndexTablet));
 
 class MonitoredTask : public std::enable_shared_from_this<MonitoredTask> {
  public:

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -221,6 +221,10 @@ DEFINE_RUNTIME_int32(unique_index_verify_deadline_grace_margin_ms, 2000,
     "until the retry budget fails the tablet INCONCLUSIVE. Clamped to half the remaining "
     "budget when configured larger.");
 
+DEFINE_test_flag(bool, pause_verify_unique_index_tablet_rpc, false,
+    "Reject VerifyUniqueIndexTablet RPCs with a retryable error, holding the shadow "
+    "verification phase open for tests (e.g. master failover mid-phase).");
+
 DEFINE_RUNTIME_int32(index_backfill_wait_for_old_txns_ms, 0,
     "Index backfill needs to wait for transactions that started before the "
     "WRITE_AND_DELETE phase to commit or abort before choosing a time for "
@@ -741,6 +745,15 @@ void TabletServiceAdminImpl::VerifyUniqueIndexTablet(
     return;
   }
   DVLOG(3) << "Received VerifyUniqueIndexTablet RPC: " << req->DebugString();
+
+  if (PREDICT_FALSE(FLAGS_TEST_pause_verify_unique_index_tablet_rpc)) {
+    // Retryable rejection: keeps the coordinator's task alive while a test arranges a master
+    // failover (or similar) around an in-flight verification phase.
+    SetupErrorAndRespond(
+        resp->mutable_error(),
+        STATUS(TryAgain, "TEST: verification paused"), &context);
+    return;
+  }
 
   server::UpdateClock(*req, server_->Clock());
 

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -1723,6 +1723,161 @@ TEST_P(PgIndexBackfillVerifier, GenerationMismatchFailsCleanly) {
   ASSERT_STR_CONTAINS(base_mismatch.status().ToString(), "different base");
 }
 
+// Shadow verification: the coordinator runs the scan observationally after a SKIP_ALL build,
+// records the outcome durably, and never gates publication.
+class PgIndexBackfillShadowVerification : public PgIndexBackfillSkipAllRaftOrdering {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillSkipAllRaftOrdering::UpdateMiniClusterOptions(options);
+    options->extra_master_flags.push_back("--ysql_index_backfill_shadow_verification=true");
+    options->extra_tserver_flags.push_back("--timestamp_history_retention_interval_sec=900");
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillShadowVerification, ::testing::Bool());
+
+TEST_P(PgIndexBackfillShadowVerification, CleanOutcomeRecordedMultiTablet) {
+  auto clean_waiter = cluster_->GetMasterLogWaiter(": VERIFY_CLEAN");
+
+  constexpr auto kNumRows = 300;
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE TABLE $0 (a int, b int, PRIMARY KEY (a ASC)) $1", kTableName,
+      GenerateSplitClause(kNumRows, /* num_tablets= */ 4)));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, $1) g", kTableName, kNumRows));
+  // Multiple index tablets: the coordinator fans out and joins per tablet.
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 3 TABLETS", kIndexName, kTableName));
+
+  ASSERT_OK(clean_waiter.WaitFor(MonoDelta::FromSeconds(60) * kTimeMultiplier));
+  ASSERT_OK(CheckIndexConsistency(kIndexName));
+}
+
+TEST_P(PgIndexBackfillShadowVerification, ViolationRecordedButDoesNotBlockPublication) {
+  auto violation_waiter = cluster_->GetMasterLogWaiter("NOT CLEAN: VERIFY_VIOLATION");
+
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, 20) g", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (100, 5)", kTableName));  // dup b = 5.
+
+  // Shadow semantics: the build still succeeds and the index is published; the violation is
+  // recorded and logged. The fail-closed gate is a later part.
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+  ASSERT_OK(violation_waiter.WaitFor(MonoDelta::FromSeconds(60) * kTimeMultiplier));
+
+  ASSERT_OK(conn_->Execute("SET enable_seqscan = off"));
+  ASSERT_RESULT(conn_->FetchRow<int32_t>(
+      Format("SELECT a FROM $0 WHERE b = 3", kTableName)));
+}
+
+// L1 pagination pass-through: one DocKey group per RPC forces the coordinator through the
+// resume-key path on every tablet.
+class PgIndexBackfillShadowVerificationPaginated : public PgIndexBackfillShadowVerification {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillShadowVerification::UpdateMiniClusterOptions(options);
+    options->extra_master_flags.push_back(
+        "--index_backfill_shadow_verification_dockey_groups_per_rpc=1");
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillShadowVerificationPaginated, ::testing::Bool());
+
+// Failover mid-phase: the durable verification state (persisted window, clean-tablet set) is
+// what makes resume-with-the-same-window possible; this pins it end to end.
+class PgIndexBackfillShadowVerificationFailover : public PgIndexBackfillShadowVerification {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillShadowVerification::UpdateMiniClusterOptions(options);
+    options->num_masters = 3;
+  }
+
+  int GetNumMasters() const override { return 3; }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillShadowVerificationFailover, ::testing::Bool());
+
+TEST_P(PgIndexBackfillShadowVerificationFailover, ResumesWithPersistedWindowAcrossFailover) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, 50) g", kTableName));
+
+  // Hold the verification RPCs open (retryable rejection) so the phase is durably
+  // IN_PROGRESS when the master leader steps down.
+  ASSERT_OK(cluster_->SetFlagOnTServers("TEST_pause_verify_unique_index_tablet_rpc", "true"));
+  {
+    // Scoped: a daemon holds one log listener, and the resume waiter below must be attached
+    // BEFORE the stepdown -- the new leader resumes within seconds of election.
+    auto start_waiter = cluster_->GetMasterLogWaiter("Starting shadow verification");
+    thread_holder_.AddThreadFunctor([this] {
+      auto create_conn = ASSERT_RESULT(Connect());
+      ASSERT_OK(create_conn.ExecuteFormat(
+          "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+    });
+    ASSERT_OK(start_waiter.WaitFor(MonoDelta::FromSeconds(60) * kTimeMultiplier));
+  }
+
+  // The new leader resumes the persisted job: same window, previously clean tablets skipped.
+  auto resume_waiter = cluster_->GetMasterLogWaiter("Resuming shadow verification");
+  ASSERT_OK(cluster_->StepDownMasterLeaderAndWaitForNewLeader());
+  ASSERT_OK(cluster_->SetFlagOnTServers("TEST_pause_verify_unique_index_tablet_rpc", "false"));
+  ASSERT_OK(resume_waiter.WaitFor(MonoDelta::FromSeconds(120) * kTimeMultiplier));
+
+  thread_holder_.JoinAll();
+  ASSERT_OK(CheckIndexConsistency(kIndexName));
+}
+
+TEST_P(PgIndexBackfillShadowVerificationPaginated, CleanAcrossManyRpcs) {
+  auto clean_waiter = cluster_->GetMasterLogWaiter(": VERIFY_CLEAN");
+
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, 50) g", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+
+  ASSERT_OK(clean_waiter.WaitFor(MonoDelta::FromSeconds(60) * kTimeMultiplier));
+  ASSERT_OK(CheckIndexConsistency(kIndexName));
+}
+
+// Deadline-driven pagination: shrink the verify RPC budget and slow each group so a clean
+// build must complete through several deadline-bounded pages. Regression for the v1 defect
+// where a deadline-bounded page's response was serialized exactly at the coordinator's RPC
+// deadline -- always discarded, every retry rescanned the same page from its original start
+// key, and the retry budget failed the tablet INCONCLUSIVE deterministically.
+class PgIndexBackfillShadowVerificationDeadlinePaginated
+    : public PgIndexBackfillShadowVerification {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillShadowVerification::UpdateMiniClusterOptions(options);
+    options->extra_master_flags.push_back("--index_backfill_verify_rpc_timeout_ms=3000");
+    options->extra_tserver_flags.push_back(
+        "--unique_index_verify_deadline_grace_margin_ms=1000");
+    options->extra_tserver_flags.push_back(
+        "--TEST_unique_index_verify_delay_per_group_ms=300");
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(
+    , PgIndexBackfillShadowVerificationDeadlinePaginated, ::testing::Bool());
+
+TEST_P(PgIndexBackfillShadowVerificationDeadlinePaginated, CleanAcrossDeadlinePages) {
+  auto clean_waiter = cluster_->GetMasterLogWaiter(": VERIFY_CLEAN");
+
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  // 40 groups x 300ms delay is ~12s of scan against 2s effective pages (3s budget minus the
+  // 1s margin): several deadline pages, each returning its resume key inside the margin.
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, 40) g", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+
+  ASSERT_OK(clean_waiter.WaitFor(MonoDelta::FromSeconds(120) * kTimeMultiplier));
+  ASSERT_OK(CheckIndexConsistency(kIndexName));
+}
+
 class PgIndexBackfillBlockIndisready : public PgIndexBackfillTest {
  public:
   void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {


### PR DESCRIPTION
## Summary

The first production caller of the verification RPC (#33444): after a SKIP_ALL unique-index
backfill completes -- while the ordering generations are still active, before the terminal
funnel releases them -- the master runs the deferred uniqueness verification scan
observationally. The outcome is persisted and logged but never gates index publication; the
fail-closed verify-before-publication gate is a separate, later capability. Disabled by
default (`ysql_index_backfill_shadow_verification`).

Durable state (`BackfillJobPB.unique_index_verification`, keyed by unique-index table id):
verification state, `verify_upper_ht`, tablets confirmed clean, and a value-free reason.
`verify_upper_ht` is chosen **once** from cluster hybrid time (never wall clock) and persisted
before any scan -- retries and failover resume verify the same window. Clean tablets are
durable progress at tablet granularity; finer intra-tablet resume keys are deliberately not
persisted, since re-scanning one tablet after failover is idempotent. All persistence goes
through the indexed table's write lock and a sys-catalog upsert under the job's leader epoch.

Coordinator mechanics (`VerifyUniqueIndexForTablet`, the `GetSafeTimeForTablet` task shape):

- One index at a time; bounded per-tablet concurrency
  (`index_backfill_shadow_verification_max_concurrent_tablets`).
- Pagination: `index_backfill_shadow_verification_dockey_groups_per_rpc` caps each RPC's group
  budget; a tablet resumes from the returned resume key without touching the join counts.
- Short-circuit under a single-winner protocol: the terminal check and the launch-next /
  index-done decision are one critical section, so a CLEAN callback racing a short-circuiting
  VIOLATION can neither overwrite the recorded outcome nor double-advance the phase; the slow
  clean-tablet persist happens after the join decision. Late responses cannot change a
  recorded outcome. The join guards on job failure, not `done()` -- the whole phase runs in
  the job's `kSuccess` state.
- Fail-open on coordinator errors: the phase is on the CREATE INDEX critical path, so every
  coordinator failure (task launch, persistence, pagination resume) degrades to
  `VERIFY_INCONCLUSIVE` and continues into publication -- no failure may strand the job short
  of the terminal funnel.
- An index with no tablets records `VERIFY_INCONCLUSIVE`: an empty tablet set is not evidence
  of uniqueness.
- No `generation_base_op_index` in the requests, on purpose: the base is per-tablet (the
  activation op's own Raft index) and a re-activated generation's higher base is still the
  generation this job's marked writes live under; active + index-table match is the semantic
  guard.

Master failover mid-phase resumes with the persisted window. Generic lost-backfill resume
(load-time enqueue, resuming a job whose table has left `ALTERING`) is upstream since
#33207: this PR originally carried equivalent machinery and now relies on upstream's,
adding only the verification-phase awareness -- a resumed job whose indexes are all SUCCESS
skips straight to the completion phase (and from there into verification) instead of
relaunching empty backfill chunks. Upstream's test covers chunk-phase resume; this PR's
failover test covers verification-phase resume, and passes through upstream's resume path.

Two deadline changes close the defect the measurement runs found (a tablet whose scan
exceeds one RPC deadline deterministically failed INCONCLUSIVE; see #33602 for the
tserver-side grace margin): each verification RPC gets its own budget,
`index_backfill_verify_rpc_timeout_ms` (default 60s, mirroring the backfill chunks'
dedicated timeout rather than inheriting the generic 30s `master_ts_rpc_timeout_ms`), and a
new deadline-pagination e2e forces a clean build through several deadline-bounded pages --
before the margin and budget existed, the page response always arrived after the
coordinator's deadline and the build failed at the retry ceiling.

Stacked on #33403, #33404, #33484, #33544, #33553, #33580, #33584, #33601, and #33602, based
on `feature-stack/Shopify/uniq-idx-4b-verifier-rpc` per the feature-stack workflow, so the
diff is exactly this PR's own commit. A failing pr-title check on stacked PRs is a known gap
in that check; the stack merges bottom-up and retargets as parents merge.

## Upgrade/Rollback safety

This is the stack's first change to **sys-catalog** persisted state:
`BackfillJobPB.unique_index_verification` (new map field 7 in
`catalog_entity_info.proto`, inside `SysTablesEntryPB.backfill_jobs`). Unlike the earlier
tablet-superblock and WAL-operation surfaces, these bytes live in the master's replicated
catalog, so a rolled-back master must be able to read rows a new master wrote.

**Parsing and retention are safe, in both directions.** The field is *data*, not a new
operation variant -- there is no apply-time dispatch that can reject it. An old master
parses a row containing field 7 as an unknown field and ignores it; sys-catalog writes
serialize the parsed message (`pb_util::SerializeToString` in `sys_catalog_writer.cc`) and
nothing in the master discards unknown fields, so an old master that rewrites the row
*preserves* field 7. A rollback followed by a re-upgrade therefore resumes with the
verification state intact. (Were it dropped instead, the re-upgraded master would simply
re-verify the window from scratch -- also safe, just slower.) Master WAL replay is likewise
unaffected: sys-catalog writes replay as opaque value bytes, so an old binary cannot fail
bootstrap on this field -- in contrast to the ChangeMetadata *variant* in #33584, where an
unknown operation shape does fail replay.

**The demanding part is job continuity, not encoding.** The state describes an in-flight
multi-phase job, and an old master has no verification phase to drive. If a rollback lands
while a job is mid-verification, that job's indexes sit at `DO_BACKFILL` with
`backfill_state = SUCCESS` -- a combination the old master's heartbeat-driven resume does not
re-drive (it fires only on schema-version mismatches, which no longer occur once the chunks
are done; this PR adds the load-time resume queue that closes that gap, and the old binary
lacks it). The practical outcome is a stranded index build: CREATE INDEX hangs to the client
deadline, then the invalid index is dropped through the existing cleanup path and the user
retries. No corruption, no silently-published unverified index, no wrong answers -- the
ordering generations left active on the index tablets are inert on rolled-back tservers,
which do not enforce the retention barrier, the split fence, or marked-write gating.

**None of this is reachable in production.** Field 7 is only ever written by the shadow
coordinator, which requires both the default-off `ysql_index_backfill_shadow_verification`
flag *and* a SKIP_ALL job -- and the production mode selector is hardcoded to CHECK_ALL
(#33484), reachable only through the master-side TEST override. As with the rest of the
stack, this ships in the same release as #33553 through activation, under the same
one-release constraint.

No gflag default changes: the three new flags are default-off or bounds-only
(`ysql_index_backfill_shadow_verification` = false,
`index_backfill_shadow_verification_max_concurrent_tablets` = 4,
`index_backfill_shadow_verification_dockey_groups_per_rpc` = 0 meaning deadline-bounded).

## Test plan

macOS arm64, release -- all green:

- [x] New: `PgIndexBackfillShadowVerification.ViolationRecordedButDoesNotBlockPublication/0`
      -- the shadow-semantics pin: a real pre-existing duplicate is recorded
      (`NOT CLEAN: VERIFY_VIOLATION` in the master log) while CREATE INDEX still succeeds and
      the index serves reads.
- [x] New: `PgIndexBackfillShadowVerification.CleanOutcomeRecordedMultiTablet/0` -- 4-tablet
      source into a 3-tablet index: the fan-out and per-tablet join, clean outcome recorded,
      index consistent.
- [x] New: `PgIndexBackfillShadowVerificationPaginated.CleanAcrossManyRpcs/0` -- one DocKey
      group per RPC forces every tablet through the resume-key path.
- [x] New: `PgIndexBackfillShadowVerificationFailover.ResumesWithPersistedWindowAcrossFailover/0`
      -- verification RPCs held open with a retryable rejection, master leader stepped down
      mid-phase; the new leader logs `Resuming shadow verification` with the *persisted*
      window and the build completes.
- [x] New: `PgIndexBackfillShadowVerificationDeadlinePaginated.CleanAcrossDeadlinePages/0`
      -- the measurement-run defect's regression: a slowed scan against a 3s verify budget
      and 1s grace margin completes CLEAN through several deadline-bounded pages.
- [x] Regressions: the skip_all e2e suite and marker canary, `PgIndexBackfillTest.Drop/0`
      (the permissions-mapping path), the CHECK_ALL mode tests, and the flag-off path (with
      `ysql_index_backfill_shadow_verification` unset nothing changes).

AlmaLinux (x86_64, clang21), rebased onto master `c7253d204d`:

At this PR's own commit (`16f12873df`) -- all green:

- [x] `PgIndexBackfillShadowVerificationDeadlinePaginated.CleanAcrossDeadlinePages`: 3
      repetitions x both params under debug, plus both params under ASAN -- 8/8 CLEAN.
- [x] `PgIndexBackfillShadowVerificationFailover.ResumesWithPersistedWindowAcrossFailover`:
      3 repetitions x both params.
- [x] `CleanOutcomeRecordedMultiTablet`, `ViolationRecordedButDoesNotBlockPublication`,
      `CleanAcrossManyRpcs` (both params each); `master_failover-itest`.

`CleanAcrossDeadlinePages` is the regression guard for the verification deadline defect: a
short verify RPC budget, a small grace margin, and a per-group delay force a clean build
through several deadline-paginated pages. Before the fix this reproduces the field failure
deterministically (VERIFY_INCONCLUSIVE at the retry ceiling). It is repeated 3x because a
flaky guard over a deterministic defect would be worse than none.

The failover runs also cover this PR's #33207 deduplication: with the stack's
`catalog_loaders.cc` hunk and `catalog_manager_bg_tasks.cc` branch deleted, verification-phase
resume now rides upstream's `EnqueuePendingBackfillsAfterLoad` recovery path, and persisted-
window resume still works across master failover.

Integrated at the stack tip (`334a1deb3d`), all green. Exact suites per build type:

- [x] TSAN (6): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `non_transactional_batch_writer-test`,
      `keyed_fingerprint-test`, `raft_consensus-itest`.
- [x] ASAN (15): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `keyed_fingerprint-test`,
      `non_transactional_batch_writer-test`, `clone-tablet-itest`,
      `remote_bootstrap-itest`, `tablet_bootstrap-test`, `auto_flags-itest`,
      `docdb-test`, `compaction_file_filter-test`,
      `xcluster_external_apply_bootstrap-test`, `pg_txn-test`, `pg_ash-test`,
      full `pg_index_backfill-test`.
- [x] Debug (19): the ASAN list minus `compaction_file_filter-test`, plus
      `master_failover-itest`, `snapshot-test`, `tablet_snapshots-test`,
      `compaction-test`, `tablet-split-itest`.
- [x] Release (5): `keyed_fingerprint-test`, `auto_flags-itest`, full
      `pg_index_backfill-test`, java `TestIndexBackfill`, java
      `TestPgRegressBackfillIndex`.
- [x] All three full `pg_index_backfill-test` runs (ASAN, debug, release) pass with no
      test failures.

Two known-upstream issues surfaced by the tip matrix, both shown not attributable to this
stack:

- TSAN `tablet-split-itest` reports 3 data races in `yb::client::YBTable::~YBTable()`
  (table.cc:81) racing its partition-refresh callback, inside the upstream test
  `AutomaticTabletSplitITest.SizeRatio` (93 cases ran, 0 gtest failures). This stack has zero
  diff under `src/yb/client/`, and that test passes 3/3 isolated at the new master base.
- `wait_states-itest` hangs 9 cases at the 601s timeout (`AshCql`, the `kYCQL_*` group,
  `kBackfillIndex_*`, `kConsensusMeta_Flush`, `kCreatingNewTablet`,
  `kSaveRaftGroupMetadataToDisk`). Reproduced identically on plain master `c7253d204d`
  carrying none of this stack's code: 53 ran, the same 9 failed, same ~600.5s expiries.

Disposition change since the previous revision: the
`PgIndexBackfillBackendsManager.NoAbortTxn/1` flake cited earlier was fixed upstream. It
passes 3/3 at the new base and in all three full `pg_index_backfill-test` runs here, so it is
no longer carried as a known flake.

