### PR TITLE
[#33444] DocDB: Gate unique-index publication on the deferred verification outcome

### DIFF
--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -121,6 +121,13 @@ DEFINE_test_flag(bool, block_index_backfill_ordering_generation_release, false,
     "Skip releasing index-backfill ordering generations in the terminal funnel, keeping them "
     "active so tests can run the verification scan against a completed build.");
 
+DEFINE_RUNTIME_bool(ysql_index_backfill_fail_closed_verification, false,
+    "Gate unique-index publication on the deferred verification outcome: after a SKIP_ALL "
+    "backfill completes, an index reaches READ_WRITE_AND_DELETE only if every index tablet "
+    "verifies clean; a violation or an unresolvable inconclusive outcome fails CREATE INDEX "
+    "through the existing backfill failure path. Implies running the verification phase even "
+    "when ysql_index_backfill_shadow_verification is off.");
+
 DEFINE_RUNTIME_bool(ysql_index_backfill_shadow_verification, false,
     "Run the deferred uniqueness verification scan after a SKIP_ALL unique-index backfill "
     "completes. The scan itself runs on the publication critical path (CREATE INDEX waits "
@@ -140,6 +147,10 @@ DEFINE_RUNTIME_int32(index_backfill_verify_rpc_timeout_ms, 60000,
     "A dedicated budget like the backfill chunks' ysql_index_backfill_rpc_timeout_ms rather "
     "than the generic master_ts_rpc_timeout_ms: every page re-establishes iterators, so "
     "sizing pages independently of unrelated master RPCs matters on large tablets.");
+
+DEFINE_test_flag(bool, fail_unique_index_verification_resolution, false,
+    "Fail the verification phase's index-table resolution, exercising the coordinator-failure "
+    "path before any index is selected for verification.");
 
 DEFINE_test_flag(bool, skip_index_backfill, false,
     "Skips backfilling the data on tservers and leaves the index in inconsistent state.");
@@ -725,13 +736,19 @@ BackfillTable::BackfillTable(
   schema_version_ = indexed_table_->metadata().state().pb.version();
 
   const auto& pb = indexed_table_->metadata().state().pb;
-  // The uniqueness-check mode is immutable per job: reuse the persisted value when resuming
-  // an existing job (missing means CHECK_ALL); select it only for a brand-new job. Launch()
-  // persists the selection together with the job.
+  // The uniqueness-check mode and the gating decision are immutable per job: reuse the
+  // persisted values when resuming an existing job (missing means CHECK_ALL/observational);
+  // select them only for a brand-new job. Launch() persists the selection together with the
+  // job, so failover, retries, and runtime flag changes cannot reinterpret an active job.
   if (pb.backfill_jobs_size() > 0) {
     unique_index_backfill_mode_ = pb.backfill_jobs(0).unique_index_backfill_mode();
+    verification_gates_publication_ = pb.backfill_jobs(0).verification_gates_publication();
   } else {
     unique_index_backfill_mode_ = SelectUniqueIndexBackfillMode();
+    verification_gates_publication_ =
+        FLAGS_ysql_index_backfill_fail_closed_verification &&
+        unique_index_backfill_mode_ == UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_SKIP_ALL &&
+        pb.table_type() == TableType::PGSQL_TABLE_TYPE;
   }
   if (pb.backfill_jobs_size() > 0 && pb.backfill_jobs(0).has_backfilling_timestamp() &&
       read_time_for_backfill_.FromUint64(pb.backfill_jobs(0).backfilling_timestamp()).ok()) {
@@ -801,8 +818,12 @@ Status BackfillTable::Launch() {
             {idx_info.table_id(), BackfillJobPB::IN_PROGRESS});
       }
       backfill_job->set_unique_index_backfill_mode(unique_index_backfill_mode_);
+      backfill_job->set_verification_gates_publication(verification_gates_publication_);
       LOG_WITH_PREFIX(INFO) << "Selected unique-index backfill mode "
                             << UniqueIndexBackfillMode_Name(unique_index_backfill_mode_)
+                            << (verification_gates_publication_
+                                    ? " with fail-closed verification"
+                                    : "")
                             << " for backfill job";
       RETURN_NOT_OK_PREPEND(
           master_->catalog_manager_impl()->sys_catalog_->Upsert(
@@ -1258,7 +1279,7 @@ Status BackfillTable::SendRpcToReleaseOrderingGenerations() {
 }
 
 Status BackfillTable::LaunchShadowVerificationOrFinish() {
-  if (!FLAGS_ysql_index_backfill_shadow_verification ||
+  if ((!FLAGS_ysql_index_backfill_shadow_verification && !verification_gates_publication()) ||
       unique_index_backfill_mode() != UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_SKIP_ALL ||
       indexed_table_->GetTableType() != TableType::PGSQL_TABLE_TYPE) {
     return FinishShadowVerification();
@@ -1274,6 +1295,9 @@ Status BackfillTable::LaunchShadowVerificationOrFinish() {
   // verification state is VERIFY_IN_PROGRESS (the structural guard in
   // CatalogManager::GetBackfillStatus).
   auto index_tables_result = GetUniqueIndexTables(RestrictToIndexesToBuild::kFalse);
+  if (PREDICT_FALSE(FLAGS_TEST_fail_unique_index_verification_resolution)) {
+    index_tables_result = STATUS(InternalError, "Injected verification resolution failure");
+  }
   if (!index_tables_result.ok()) {
     ShadowVerificationPhaseFailed(index_tables_result.status(), "resolve index tables");
     return Status::OK();
@@ -1515,19 +1539,35 @@ void BackfillTable::ShadowVerificationTabletDone(
 // INCONCLUSIVE, then always continue into publication.
 void BackfillTable::ShadowVerificationPhaseFailed(
     const Status& status, const char* while_doing) {
-  LOG_WITH_PREFIX(WARNING) << "Shadow verification phase failed (" << while_doing
-                           << "): " << status << "; degrading to INCONCLUSIVE and publishing";
+  const bool gating = verification_gates_publication();
+  LOG_WITH_PREFIX(WARNING) << "Verification phase failed (" << while_doing << "): " << status
+                           << (gating ? "; failing unverified indexes (fail-closed)"
+                                      : "; degrading to INCONCLUSIVE and publishing");
   {
     std::lock_guard l(mutex_);
     shadow_verification_.terminal = true;
     shadow_verification_.pending_tablets.clear();
     shadow_verification_.remaining_indexes.clear();
   }
+  // Records INCONCLUSIVE for the in-flight index; in gating mode that also fails it.
   WARN_NOT_OK(
       RecordShadowVerificationOutcome(
           UniqueIndexVerificationStatePB::VERIFY_INCONCLUSIVE, "coordinator error"),
-      "Failed to record shadow verification outcome");
-  WARN_NOT_OK(FinishShadowVerification(), "Failed to finish backfill after shadow phase");
+      "Failed to record verification outcome");
+  if (gating) {
+    // In gating mode only verified-clean unique indexes have been marked (non-unique ones were
+    // marked when the chunks completed), so whatever is still IN_PROGRESS is exactly the
+    // unverified set: the in-flight index if Record's marking failed, indexes the phase never
+    // reached, and indexes never selected because resolution itself failed. All are equally
+    // unverified; fail them rather than publish.
+    const auto unverified = indexes_to_build();
+    if (!unverified.empty()) {
+      WARN_NOT_OK(
+          MarkIndexesAsFailed(unverified, "unique index verification could not complete"),
+          "Failed to mark unverified indexes as failed");
+    }
+  }
+  WARN_NOT_OK(FinishShadowVerification(), "Failed to finish backfill after verification phase");
 }
 
 Status BackfillTable::RecordShadowVerificationOutcome(
@@ -1549,15 +1589,32 @@ Status BackfillTable::RecordShadowVerificationOutcome(
           state_pb->set_reason(reason);
         }
       }));
-  // SHADOW: the outcome is recorded and logged, never enforced. The fail-closed
-  // verify-before-publication gate is a separate, later capability.
+  const bool gating = verification_gates_publication();
   const auto severity_prefix =
       state == UniqueIndexVerificationStatePB::VERIFY_CLEAN ? "" : "NOT CLEAN: ";
   LOG_WITH_PREFIX(INFO) << "Shadow verification outcome for unique index " << index_table_id
                         << ": " << severity_prefix
                         << UniqueIndexVerificationStatePB::State_Name(state)
-                        << (reason.empty() ? "" : Format(" ($0)", reason));
-  return Status::OK();
+                        << (reason.empty() ? "" : Format(" ($0)", reason))
+                        << (gating ? " [gating]" : " [observational]");
+  if (!gating) {
+    // Observational: the outcome is recorded and logged, never enforced.
+    return Status::OK();
+  }
+  // Fail-closed: the outcome decides publication. Clean marks the (deferred) backfill
+  // success; anything else fails the index through the existing backfill failure path --
+  // never READ_WRITE_AND_DELETE, never indisvalid. Reasons are value-free by construction.
+  // A crash between the verification-state write above and the marking below self-heals:
+  // failover resumes the phase, re-finds every tablet clean, and re-drives this marking.
+  if (state == UniqueIndexVerificationStatePB::VERIFY_CLEAN) {
+    return MarkIndexesAsSuccess({index_table_id});
+  }
+  return MarkIndexesAsFailed(
+      {index_table_id},
+      Format(
+          "unique index verification did not pass: $0$1",
+          UniqueIndexVerificationStatePB::State_Name(state),
+          reason.empty() ? "" : Format(" ($0)", reason)));
 }
 
 Status BackfillTable::FinishShadowVerification() {
@@ -1601,8 +1658,16 @@ Status BackfillTable::Done(const Status& s, const std::unordered_set<TableId>& f
     }
     LOG_WITH_PREFIX(INFO) << "Completed backfilling the index table.";
     StopLivenessMonitor();
-    RETURN_NOT_OK_PREPEND(
-        MarkAllIndexesAsSuccess(), "Failed to mark indexes as successfully backfilled.");
+    if (verification_gates_publication()) {
+      // Fail-closed: success marking for unique indexes is deferred until each verifies
+      // clean (RecordShadowVerificationOutcome); non-unique indexes have nothing to verify.
+      RETURN_NOT_OK_PREPEND(
+          MarkIndexesAsSuccess(NonUniqueIndexesToBuild()),
+          "Failed to mark indexes as successfully backfilled.");
+    } else {
+      RETURN_NOT_OK_PREPEND(
+          MarkAllIndexesAsSuccess(), "Failed to mark indexes as successfully backfilled.");
+    }
     RETURN_NOT_OK_PREPEND(
         LaunchShadowVerificationOrFinish(), "Failed to complete backfill.");
   } else {
@@ -1626,9 +1691,25 @@ Status BackfillTable::MarkAllIndexesAsFailed() {
 }
 
 Status BackfillTable::MarkAllIndexesAsSuccess() {
-  const auto index_ids = indexes_to_build();
+  return MarkIndexesAsSuccess(indexes_to_build());
+}
+
+Status BackfillTable::MarkIndexesAsSuccess(const std::unordered_set<TableId>& index_ids) {
+  if (index_ids.empty()) {
+    return Status::OK();
+  }
   RETURN_NOT_OK(master_->xcluster_manager()->MarkIndexBackfillCompleted(index_ids, epoch_));
   return MarkIndexesAsDesired(index_ids, BackfillJobPB::SUCCESS, "");
+}
+
+std::unordered_set<TableId> BackfillTable::NonUniqueIndexesToBuild() const {
+  auto index_ids = indexes_to_build();
+  for (const auto& index_info : index_infos_) {
+    if (index_info.is_unique()) {
+      index_ids.erase(index_info.table_id());
+    }
+  }
+  return index_ids;
 }
 
 Status BackfillTable::MarkIndexesAsDesired(
@@ -1784,9 +1865,13 @@ Status BackfillTable::UpdateIndexPermissionsForIndexes() {
     for (const auto& kv_pair : indexed_table_pb.backfill_jobs(0).backfill_state()) {
       VLOG(2) << "Reading backfill_state for " << kv_pair.first << " as "
               << BackfillJobPB_State_Name(kv_pair.second);
-      if (PREDICT_TRUE(!FLAGS_TEST_simulate_empty_indexes_during_backfill)) {
-        DCHECK_NE(kv_pair.second, BackfillJobPB::IN_PROGRESS)
-            << __func__ << " is expected to be only called after all indexes are done.";
+      if (kv_pair.second == BackfillJobPB::IN_PROGRESS &&
+          PREDICT_TRUE(!FLAGS_TEST_simulate_empty_indexes_during_backfill)) {
+        // Every path into the funnel marks a terminal state first; reachable only if that
+        // marking itself kept failing (sys-catalog writes failing). The mapping below then
+        // publishes the index as failed -- the safe direction.
+        LOG_WITH_PREFIX(DFATAL) << "Index " << kv_pair.first
+                                << " reached the terminal funnel still IN_PROGRESS";
       }
       const bool success = (kv_pair.second == BackfillJobPB::SUCCESS);
       all_success &= success;

--- a/src/yb/master/backfill_index.h
+++ b/src/yb/master/backfill_index.h
@@ -175,6 +175,14 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
     return unique_index_backfill_mode_;
   }
 
+  // True when the deferred verification outcome decides publication for this job
+  // (fail-closed flag + SKIP_ALL + PGSQL); false means observational (shadow) semantics.
+  // Latched and persisted like unique_index_backfill_mode(): runtime flag flips cannot
+  // reinterpret an active job.
+  bool verification_gates_publication() const {
+    return verification_gates_publication_;
+  }
+
   const std::unordered_set<TableId> indexes_to_build() const;
 
   const TableId& indexed_table_id() const { return indexed_table_->id(); }
@@ -247,8 +255,10 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
       UniqueIndexVerificationStatePB::State state, const std::string& reason) EXCLUDES(mutex_);
   Status FinishShadowVerification();
 
-  // Degrades any shadow-phase coordinator failure to VERIFY_INCONCLUSIVE and continues into
-  // publication: the phase is on the CREATE INDEX critical path and must never strand it.
+  // Coordinator failure: the phase is on the CREATE INDEX critical path and must never
+  // strand it, so this always continues into publication. Observational mode degrades the
+  // in-flight index to VERIFY_INCONCLUSIVE and publishes; gating mode additionally fails
+  // every unique index still unverified (in-flight, never reached, or never selected).
   void ShadowVerificationPhaseFailed(const Status& status, const char* while_doing)
       EXCLUDES(mutex_);
 
@@ -260,6 +270,11 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
 
   Status MarkAllIndexesAsFailed();
   Status MarkAllIndexesAsSuccess();
+  Status MarkIndexesAsSuccess(const std::unordered_set<TableId>& index_ids);
+
+  // The job's non-unique indexes among indexes_to_build(): they have nothing to verify, so
+  // fail-closed mode marks them successful as soon as the chunks complete.
+  std::unordered_set<TableId> NonUniqueIndexesToBuild() const;
 
   Status MarkIndexesAsFailed(
       const std::unordered_set<TableId>& indexes, const std::string& message);
@@ -304,6 +319,7 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
   int32_t schema_version_;
   UniqueIndexBackfillMode unique_index_backfill_mode_ =
       UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_CHECK_ALL;
+  bool verification_gates_publication_ = false;
 
   std::atomic<State> state_{State::kRunning};
   std::atomic_bool timestamp_chosen_{false};

--- a/src/yb/master/catalog_entity_info.proto
+++ b/src/yb/master/catalog_entity_info.proto
@@ -62,6 +62,12 @@ message BackfillJobPB {
   // failover so verification resumes with the same window and does not re-scan tablets
   // already confirmed clean.
   map<string, UniqueIndexVerificationStatePB> unique_index_verification = 7;
+
+  // Whether the deferred verification outcome gates publication (fail-closed) for this job.
+  // Latched from ysql_index_backfill_fail_closed_verification when the job is created and
+  // immutable for the job's lifetime, across master failover, retries, and runtime flag
+  // changes. Missing means observational (shadow) semantics.
+  optional bool verification_gates_publication = 8;
 }
 
 message UniqueIndexVerificationStatePB {

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -225,6 +225,10 @@ DEFINE_test_flag(bool, pause_verify_unique_index_tablet_rpc, false,
     "Reject VerifyUniqueIndexTablet RPCs with a retryable error, holding the shadow "
     "verification phase open for tests (e.g. master failover mid-phase).");
 
+DEFINE_test_flag(bool, force_verify_unique_index_inconclusive, false,
+    "Respond to VerifyUniqueIndexTablet RPCs with an INCONCLUSIVE outcome without scanning, "
+    "to exercise the fail-closed publication gate.");
+
 DEFINE_RUNTIME_int32(index_backfill_wait_for_old_txns_ms, 0,
     "Index backfill needs to wait for transactions that started before the "
     "WRITE_AND_DELETE phase to commit or abort before choosing a time for "
@@ -752,6 +756,14 @@ void TabletServiceAdminImpl::VerifyUniqueIndexTablet(
     SetupErrorAndRespond(
         resp->mutable_error(),
         STATUS(TryAgain, "TEST: verification paused"), &context);
+    return;
+  }
+
+  if (PREDICT_FALSE(FLAGS_TEST_force_verify_unique_index_inconclusive)) {
+    resp->set_outcome(VerifyUniqueIndexTabletResponsePB::INCONCLUSIVE);
+    resp->set_reason("TEST: forced inconclusive");
+    resp->set_propagated_hybrid_time(server_->Clock()->Now().ToUint64());
+    context.RespondSuccess();
     return;
   }
 

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -1831,6 +1831,117 @@ TEST_P(PgIndexBackfillShadowVerificationFailover, ResumesWithPersistedWindowAcro
   ASSERT_OK(CheckIndexConsistency(kIndexName));
 }
 
+// Fail-closed verification: the outcome decides publication. CLEAN publishes; anything else
+// fails CREATE INDEX through the existing backfill failure path -- the index is never
+// READ_WRITE_AND_DELETE and never indisvalid.
+class PgIndexBackfillFailClosedVerification : public PgIndexBackfillSkipAllRaftOrdering {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillSkipAllRaftOrdering::UpdateMiniClusterOptions(options);
+    options->extra_master_flags.push_back(
+        "--ysql_index_backfill_fail_closed_verification=true");
+    // Base-table retention (see the verifier fixture comment; #32565).
+    options->extra_tserver_flags.push_back("--timestamp_history_retention_interval_sec=900");
+  }
+
+ protected:
+  Result<bool> IndexIsValid() {
+    return conn_->FetchRow<bool>(Format(
+        "SELECT indisvalid FROM pg_index WHERE indexrelid = '$0'::regclass", kIndexName));
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillFailClosedVerification, ::testing::Bool());
+
+TEST_P(PgIndexBackfillFailClosedVerification, CleanBuildPublishes) {
+  auto clean_waiter = cluster_->GetMasterLogWaiter(": VERIFY_CLEAN");
+  constexpr auto kNumRows = 200;
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE TABLE $0 (a int, b int, PRIMARY KEY (a ASC)) $1", kTableName,
+      GenerateSplitClause(kNumRows, /* num_tablets= */ 4)));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, $1) g", kTableName, kNumRows));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+  ASSERT_OK(clean_waiter.WaitFor(MonoDelta::FromSeconds(60) * kTimeMultiplier));
+  ASSERT_OK(CheckIndexConsistency(kIndexName));
+  ASSERT_TRUE(ASSERT_RESULT(IndexIsValid()));
+}
+
+TEST_P(PgIndexBackfillFailClosedVerification, ViolationFailsCreateIndex) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, 20) g", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (100, 5)", kTableName));  // dup b = 5.
+
+  const auto status = conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName);
+  ASSERT_NOK(status);
+  ASSERT_STR_CONTAINS(status.message().ToBuffer(), "verification");
+
+  // Never published: the index exists but is invalid; the base table is unaffected and the
+  // invalid index is droppable.
+  ASSERT_FALSE(ASSERT_RESULT(IndexIsValid()));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (200, 200)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("DROP INDEX $0", kIndexName));
+}
+
+// An unresolvable INCONCLUSIVE outcome must fail the build the same way: fail-closed means
+// "not proven clean", not "proven violated".
+class PgIndexBackfillFailClosedInconclusive : public PgIndexBackfillFailClosedVerification {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillFailClosedVerification::UpdateMiniClusterOptions(options);
+    options->extra_tserver_flags.push_back(
+        "--TEST_force_verify_unique_index_inconclusive=true");
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillFailClosedInconclusive, ::testing::Bool());
+
+TEST_P(PgIndexBackfillFailClosedInconclusive, InconclusiveFailsCreateIndex) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, 20) g", kTableName));
+
+  const auto status = conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName);
+  ASSERT_NOK(status);
+  ASSERT_STR_CONTAINS(status.message().ToBuffer(), "verification");
+  ASSERT_FALSE(ASSERT_RESULT(IndexIsValid()));
+  ASSERT_OK(conn_->ExecuteFormat("DROP INDEX $0", kIndexName));
+}
+
+// A coordinator failure (not a per-tablet outcome) must equally fail the build in gating
+// mode: unique indexes the phase never selected are unverified and may not publish.
+class PgIndexBackfillFailClosedPhaseFailure : public PgIndexBackfillFailClosedVerification {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillFailClosedVerification::UpdateMiniClusterOptions(options);
+    options->extra_master_flags.push_back(
+        "--TEST_fail_unique_index_verification_resolution=true");
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillFailClosedPhaseFailure, ::testing::Bool());
+
+TEST_P(PgIndexBackfillFailClosedPhaseFailure, CoordinatorFailureFailsCreateIndex) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT g, g FROM generate_series(1, 20) g", kTableName));
+
+  // The data is clean: only the injected coordinator failure can fail this build, and the
+  // asserted message is produced only by the phase-failure path (never a tablet outcome).
+  const auto status = conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName);
+  ASSERT_NOK(status);
+  ASSERT_STR_CONTAINS(status.message().ToBuffer(), "verification could not complete");
+
+  ASSERT_FALSE(ASSERT_RESULT(IndexIsValid()));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (200, 200)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("DROP INDEX $0", kIndexName));
+}
+
 TEST_P(PgIndexBackfillShadowVerificationPaginated, CleanAcrossManyRpcs) {
   auto clean_waiter = cluster_->GetMasterLogWaiter(": VERIFY_CLEAN");
 


### PR DESCRIPTION
## Summary

The last functional piece of deferred uniqueness verification (#33444): behind
`ysql_index_backfill_fail_closed_verification` (default false), the verification phase's
outcome decides publication instead of merely being recorded. The publication order becomes
the design document's:

```
backfill completes -> stay at DO_BACKFILL -> verify all index tablets
  -> persist the outcome -> RWD -> publish birth_time
  -> release generation + retention -> indisvalid
```

In gating mode, backfill-success marking for unique indexes is deferred from chunk completion
to verification completion: a clean index is then marked successful (including the xCluster
backfill-completed notification, which must not fire for an index that may still fail) and
proceeds through the terminal funnel to `READ_WRITE_AND_DELETE` and birth_time publication. A
`VIOLATION` or unresolvable `INCONCLUSIVE` outcome fails the index through the existing
backfill failure path -- `backfill_error_message` carries a value-free reason, CREATE INDEX
returns it, the index is never `READ_WRITE_AND_DELETE` and never `indisvalid`, and the
existing invalid-index cleanup applies. Coordinator failures fail closed too: whatever is
still `IN_PROGRESS` when the phase fails is exactly the unverified set (the in-flight index,
indexes the phase never reached, and indexes never selected because resolution itself failed)
and is failed rather than published. Non-unique indexes in the job have nothing to verify and
are marked successful at chunk completion as before.

The gating decision is latched per job and persisted in `BackfillJobPB`
(`verification_gates_publication`, field 8), mirroring the uniqueness-check mode: failover,
retries, and runtime flag flips cannot reinterpret an active job. Reading the flag live at
each decision point would misbehave in both directions -- gating->observational after the
deferred marking leaves the index `IN_PROGRESS` at the funnel; observational->gating
mid-phase would fail an index whose success (and xCluster notification) already fired. The
funnel logs DFATAL if it ever sees an `IN_PROGRESS` index (only reachable if terminal-state
marking itself kept failing); the pre-existing mapping publishes such an index as failed.

The gate implies the verification phase runs even when
`ysql_index_backfill_shadow_verification` is off; with both flags off, nothing changes.
Observational mode is untouched -- outcome logs now carry a `[gating]` / `[observational]`
tag. The mode selector remains hardcoded to CHECK_ALL, so the gate is production-unreachable
until activation; tests drive it through the master-side TEST override.

Stacked on #33403, #33404, #33484, #33544, #33553, #33580, #33584, #33601, #33602, #33654,
and #33655, based on `feature-stack/Shopify/uniq-idx-6-read-fence` per the feature-stack
workflow, so the diff is exactly this PR's own commit. A failing pr-title check on stacked
PRs is a known gap in that check; the stack merges bottom-up and retargets as parents merge.

## Upgrade/Rollback safety

Adds the stack's second sys-catalog field: `BackfillJobPB.verification_gates_publication`
(`optional bool`, field 8, in `catalog_entity_info.proto`). The encoding analysis is the same
as #33654's field 7: it is pure data with no apply-time dispatch, an old master parses it as
an unknown field and *preserves* it when rewriting the row (sys-catalog writes serialize the
parsed message and nothing in the master discards unknown fields), and master WAL replay
carries sys-catalog writes as opaque value bytes, so an old binary cannot fail bootstrap on
it. Missing field = false = observational semantics = prior behavior, so the proto2 default
is the safe direction for jobs created before this change.

Job continuity on rollback is the fail-*closed* variant of #33654's story: in gating mode,
unique-index success marking is deferred, so a rollback mid-job leaves those indexes
`IN_PROGRESS` at `DO_BACKFILL` -- a state the old master does not drive further. The build
strands: CREATE INDEX times out, the invalid index is dropped through the existing cleanup
path, and the user retries. No unverified index is ever published by the rollback, which is
the gate's contract.

Flag behavior: `ysql_index_backfill_fail_closed_verification` is default-false, and because
the gating decision is latched and persisted per job, flipping the flag (either direction) at
runtime affects only jobs created afterward -- active jobs keep the semantics they started
with, across master failover.

None of this is reachable in production: the gate additionally requires a SKIP_ALL PGSQL
job, and the production mode selector is hardcoded to CHECK_ALL (#33484), reachable only
through the master-side TEST override. Ships under the same one-release constraint as the
rest of the stack.

## Test plan

macOS arm64, release -- all green (every fail-closed e2e run under both table-locks params):

- [x] New: `PgIndexBackfillFailClosedVerification.ViolationFailsCreateIndex` -- the feature's
      end state: a real pre-existing duplicate survives the SKIP_ALL build and fails CREATE
      INDEX with a verification error; `indisvalid = false`, the base table stays usable, and
      the invalid index is droppable.
- [x] New: `PgIndexBackfillFailClosedVerification.CleanBuildPublishes` -- publication:
      `indisvalid = true` and a consistent index.
- [x] New: `PgIndexBackfillFailClosedInconclusive.InconclusiveFailsCreateIndex` -- fail-closed
      = "not proven clean", pinned via a forced-INCONCLUSIVE tserver response.
- [x] New: `PgIndexBackfillFailClosedPhaseFailure.CoordinatorFailureFailsCreateIndex` -- an
      injected resolution failure fails CREATE INDEX with the unverified-index message on
      clean data; only the phase-failure path produces that message.
- [x] `PgIndexBackfillShadowVerificationFailover.ResumesWithPersistedWindowAcrossFailover`
      (both params) -- now also exercises the persisted gating latch read on resume.
- [x] Regressions: shadow suite (violation still publishes in observational mode; multi-tablet
      clean; paginated), skip_all funnel e2e, `Drop`. Post-review-round retests (accessor
      rename + waiter scaling): `CleanBuildPublishes` x2, `CoordinatorFailureFailsCreateIndex`,
      `ViolationFailsCreateIndex`.

AlmaLinux (x86_64, clang21), rebased onto master `c7253d204d`:

At this PR's own commit (`2a0a4df355`), debug -- all green:

- [x] `tablet_peer-test`, `unique_index_verifier-test`.
- [x] All four fail-closed e2e tests, both params (8 runs).

Integrated at the stack tip (`334a1deb3d`), all green. Exact suites per build type:

- [x] TSAN (6): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `non_transactional_batch_writer-test`,
      `keyed_fingerprint-test`, `raft_consensus-itest`.
- [x] ASAN (15): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `keyed_fingerprint-test`,
      `non_transactional_batch_writer-test`, `clone-tablet-itest`,
      `remote_bootstrap-itest`, `tablet_bootstrap-test`, `auto_flags-itest`,
      `docdb-test`, `compaction_file_filter-test`,
      `xcluster_external_apply_bootstrap-test`, `pg_txn-test`, `pg_ash-test`,
      full `pg_index_backfill-test`.
- [x] Debug (19): the ASAN list minus `compaction_file_filter-test`, plus
      `master_failover-itest`, `snapshot-test`, `tablet_snapshots-test`,
      `compaction-test`, `tablet-split-itest`.
- [x] Release (5): `keyed_fingerprint-test`, `auto_flags-itest`, full
      `pg_index_backfill-test`, java `TestIndexBackfill`, java
      `TestPgRegressBackfillIndex`.
- [x] All three full `pg_index_backfill-test` runs (ASAN, debug, release) pass with no
      test failures.

Two known-upstream issues surfaced by the tip matrix, both shown not attributable to this
stack:

- TSAN `tablet-split-itest` reports 3 data races in `yb::client::YBTable::~YBTable()`
  (table.cc:81) racing its partition-refresh callback, inside the upstream test
  `AutomaticTabletSplitITest.SizeRatio` (93 cases ran, 0 gtest failures). This stack has zero
  diff under `src/yb/client/`, and that test passes 3/3 isolated at the new master base.
- `wait_states-itest` hangs 9 cases at the 601s timeout (`AshCql`, the `kYCQL_*` group,
  `kBackfillIndex_*`, `kConsensusMeta_Flush`, `kCreatingNewTablet`,
  `kSaveRaftGroupMetadataToDisk`). Reproduced identically on plain master `c7253d204d`
  carrying none of this stack's code: 53 ran, the same 9 failed, same ~600.5s expiries.

Disposition change since the previous revision: the
`PgIndexBackfillBackendsManager.NoAbortTxn/1` flake cited earlier was fixed upstream. It
passes 3/3 at the new base and in all three full `pg_index_backfill-test` runs here, so it is
no longer carried as a known flake.

