### PR TITLE
[#33444] DocDB: Add retention-barrier observability for index-backfill ordering generations

### DIFF
--- a/src/yb/integration-tests/fixed_hybrid_time_write_id-itest.cc
+++ b/src/yb/integration-tests/fixed_hybrid_time_write_id-itest.cc
@@ -55,6 +55,7 @@
 #include "yb/util/backoff_waiter.h"
 #include "yb/util/format.h"
 #include "yb/util/memory/arena.h"
+#include "yb/util/metrics.h"
 #include "yb/util/monotime.h"
 #include "yb/util/result.h"
 #include "yb/util/status_log.h"
@@ -68,6 +69,11 @@ DECLARE_bool(enable_load_balancing);
 DECLARE_int32(timestamp_history_retention_interval_sec);
 
 namespace yb {
+
+namespace tserver {
+METRIC_DECLARE_gauge_uint32(ts_index_backfill_retention_barrier_tablets);
+METRIC_DECLARE_gauge_uint64(ts_index_backfill_oldest_retention_barrier_age_ms);
+}  // namespace tserver
 
 using dockv::DocKey;
 using dockv::MakeKeyEntryValues;
@@ -629,6 +635,73 @@ TEST_F(FixedHybridTimeWriteIdITest, MissingBarrierBlocksAllHistoryGC) {
       ASSERT_EQ(HybridTime::kMin, cutoff.primary_cutoff_ht)
           << "on " << peer->permanent_uuid();
     }
+  }
+}
+
+// Retention-barrier observability: the ts_index_backfill_* gauges surface active
+// generations (held-tablet count) and the oldest barrier's age, so a stuck barrier is
+// findable without reading superblocks. Each tserver hosts one replica of the single tablet
+// here, so the per-server count is 0 or 1.
+TEST_F(FixedHybridTimeWriteIdITest, RetentionBarrierMetricsTrackActiveGenerations) {
+  auto leaders = ASSERT_RESULT(WaitForTableActiveTabletLeadersPeers(
+      cluster_.get(), table_.table()->id(), /* num_active_leaders= */ 1));
+  const auto tablet_id = leaders.front()->tablet_id();
+
+  const auto barrier_tablets = [this](size_t ts_idx) -> Result<uint32_t> {
+    const auto metric =
+        cluster_->mini_tablet_server(ts_idx)->metric_entity().FindOrNull<AtomicGauge<uint32_t>>(
+            tserver::METRIC_ts_index_backfill_retention_barrier_tablets);
+    SCHECK_NOTNULL(metric.get());
+    return metric->value();
+  };
+  const auto oldest_age_ms = [this](size_t ts_idx) -> Result<uint64_t> {
+    const auto metric =
+        cluster_->mini_tablet_server(ts_idx)->metric_entity().FindOrNull<AtomicGauge<uint64_t>>(
+            tserver::METRIC_ts_index_backfill_oldest_retention_barrier_age_ms);
+    SCHECK_NOTNULL(metric.get());
+    return metric->value();
+  };
+
+  for (size_t i = 0; i != cluster_->num_tablet_servers(); ++i) {
+    ASSERT_EQ(0, ASSERT_RESULT(barrier_tablets(i)));
+    ASSERT_EQ(0, ASSERT_RESULT(oldest_age_ms(i)));
+  }
+
+  // Activate with a barrier chosen in the past: once the gauge shows the pin, the reported
+  // age must be at least that far back (minus generous slack for coarse clock steps).
+  constexpr int kBarrierAgeSec = 5;
+  const auto barrier =
+      cluster_->mini_tablet_server(0)->server()->Clock()->Now().AddSeconds(-kBarrierAgeSec);
+  ASSERT_OK(SetOrderingGenerationOnAllReplicas(
+      tablet_id, MakeActiveOrderingGeneration(barrier)));
+  for (size_t i = 0; i != cluster_->num_tablet_servers(); ++i) {
+    ASSERT_OK(LoggedWaitFor(
+        [&]() -> Result<bool> { return VERIFY_RESULT(barrier_tablets(i)) == 1; },
+        MonoDelta::FromSeconds(15) * kTimeMultiplier,
+        Format("barrier-tablet gauge to reach 1 on ts-$0", i)));
+    ASSERT_GE(ASSERT_RESULT(oldest_age_ms(i)), kBarrierAgeSec * 1000ULL - 500);
+  }
+
+  // Active without a barrier still counts as held (it blocks all history GC) but
+  // contributes no age -- the documented missing-barrier edge.
+  ASSERT_OK(SetOrderingGenerationOnAllReplicas(tablet_id, MakeActiveOrderingGeneration()));
+  for (size_t i = 0; i != cluster_->num_tablet_servers(); ++i) {
+    ASSERT_OK(LoggedWaitFor(
+        [&]() -> Result<bool> { return VERIFY_RESULT(oldest_age_ms(i)) == 0; },
+        MonoDelta::FromSeconds(15) * kTimeMultiplier,
+        Format("age gauge to drop to 0 on ts-$0", i)));
+    ASSERT_EQ(1, ASSERT_RESULT(barrier_tablets(i)));
+  }
+
+  // Release: both gauges return to zero.
+  ASSERT_OK(SetOrderingGenerationOnAllReplicas(
+      tablet_id, tablet::IndexBackfillOrderingGeneration()));
+  for (size_t i = 0; i != cluster_->num_tablet_servers(); ++i) {
+    ASSERT_OK(LoggedWaitFor(
+        [&]() -> Result<bool> { return VERIFY_RESULT(barrier_tablets(i)) == 0; },
+        MonoDelta::FromSeconds(15) * kTimeMultiplier,
+        Format("barrier-tablet gauge to return to 0 on ts-$0", i)));
+    ASSERT_EQ(0, ASSERT_RESULT(oldest_age_ms(i)));
   }
 }
 

--- a/src/yb/tablet/tablet_metadata.h
+++ b/src/yb/tablet/tablet_metadata.h
@@ -32,6 +32,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -346,6 +347,13 @@ struct IndexBackfillOrderingGeneration {
 
   friend bool operator==(
       const IndexBackfillOrderingGeneration&, const IndexBackfillOrderingGeneration&) = default;
+
+  // Age of the retention barrier relative to `now`, clamped at zero: the barrier derives
+  // from a master-chosen read time, which clock skew can put slightly ahead of this
+  // server's clock right after activation. Requires a valid retention_barrier_ht.
+  int64_t RetentionBarrierAgeMs(HybridTime now) const {
+    return std::max<int64_t>(now.PhysicalDiff(retention_barrier_ht).ToMilliseconds(), 0);
+  }
 
   std::string ToString() const {
     return YB_STRUCT_TO_STRING(active, table_id, base_op_index, retention_barrier_ht,

--- a/src/yb/tserver/ts_tablet_manager.cc
+++ b/src/yb/tserver/ts_tablet_manager.cc
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -415,6 +416,20 @@ METRIC_DEFINE_gauge_uint64(server, num_tablet_peers_undergoing_rbs,
     "Number of Tablet Peers on the TServer undergoing remote bootstrap", MetricUnit::kUnits,
     "Number of Tablet Peers on the TServer undergoing remote bootstrap i.e actively RBSing peers.");
 
+METRIC_DEFINE_gauge_uint32(server, ts_index_backfill_retention_barrier_tablets,
+    "Tablets Held by an Index-Backfill Retention Barrier", MetricUnit::kUnits,
+    "Number of tablet peers on this TServer whose history GC is held by an active "
+    "index-backfill ordering generation (deferred unique-index verification). Nonzero only "
+    "while a SKIP_ALL unique-index build or its verification is in flight; a value that "
+    "persists after backfills finish indicates a stuck retention barrier.");
+
+METRIC_DEFINE_gauge_uint64(server, ts_index_backfill_oldest_retention_barrier_age_ms,
+    "Oldest Index-Backfill Retention Barrier Age", MetricUnit::kMilliseconds,
+    "Age of the oldest active index-backfill retention barrier on this TServer -- an upper "
+    "bound on how much extra history the most-held-back tablet is retaining. 0 when no "
+    "generation is active or no active generation carries a barrier hybrid time (the "
+    "missing-barrier state blocks all history GC on its tablet and logs a warning).");
+
 THREAD_POOL_METRICS_DEFINE(server, admin_triggered_compaction_pool,
     "Thread pool for admin-triggered tablet compaction jobs.");
 
@@ -502,6 +517,31 @@ void TSTabletManager::VerifyTabletData() {
 void TSTabletManager::EmitMetrics() {
   ts_live_tablet_peers_metric_->set_value(GetNumLiveTablets());
   ts_supportable_tablet_peers_metric_->set_value(GetNumSupportableTabletPeers());
+  EmitIndexBackfillRetentionMetrics();
+}
+
+// Retention-barrier observability (#33444): with the verification barrier enforced in
+// AllowedHistoryCutoff, an orphaned active generation pins all history GC on its tablet, so a
+// stuck barrier must be findable without reading superblocks. Counts every peer with an active
+// generation regardless of peer state -- the barrier is on-disk metadata, not runtime state.
+void TSTabletManager::EmitIndexBackfillRetentionMetrics() {
+  uint32_t barrier_tablets = 0;
+  std::optional<tablet::IndexBackfillOrderingGeneration> oldest;
+  for (const auto& peer : GetTabletPeers()) {
+    auto generation = peer->tablet_metadata()->index_backfill_ordering_generation();
+    if (!generation.active) {
+      continue;
+    }
+    ++barrier_tablets;
+    if (generation.retention_barrier_ht &&
+        (!oldest || generation.retention_barrier_ht < oldest->retention_barrier_ht)) {
+      oldest = std::move(generation);
+    }
+  }
+  index_backfill_retention_barrier_tablets_metric_->set_value(barrier_tablets);
+  index_backfill_oldest_barrier_age_ms_metric_->set_value(
+      oldest ? static_cast<uint64_t>(oldest->RetentionBarrierAgeMs(server_->Clock()->Now()))
+             : 0);
 }
 
 void TSTabletManager::CleanupOldMetrics() {
@@ -634,6 +674,11 @@ TSTabletManager::TSTabletManager(FsManager* fs_manager,
   ts_data_size_metrics_ = std::make_unique<TsDataSizeMetrics>(this);
   num_tablet_peers_undergoing_rbs_ = METRIC_num_tablet_peers_undergoing_rbs.Instantiate(
       server->metric_entity(), 0);
+  index_backfill_retention_barrier_tablets_metric_ =
+      METRIC_ts_index_backfill_retention_barrier_tablets.Instantiate(server_->metric_entity(), 0);
+  index_backfill_oldest_barrier_age_ms_metric_ =
+      METRIC_ts_index_backfill_oldest_retention_barrier_age_ms.Instantiate(
+          server_->metric_entity(), 0);
 
   mem_manager_ = std::make_shared<TabletMemoryManager>(
       &tablet_options_,

--- a/src/yb/tserver/ts_tablet_manager.h
+++ b/src/yb/tserver/ts_tablet_manager.h
@@ -454,6 +454,10 @@ class TSTabletManager : public tserver::TabletPeerLookupIf, public tablet::Table
   // Background task that emits metrics.
   void EmitMetrics();
 
+  // Updates the index-backfill retention-barrier gauges (held-tablet count, oldest
+  // barrier age) from the current tablet metadata; called from EmitMetrics.
+  void EmitIndexBackfillRetentionMetrics();
+
   // Background task that Retires old metrics.
   void CleanupOldMetrics();
 
@@ -899,6 +903,12 @@ class TSTabletManager : public tserver::TabletPeerLookupIf, public tablet::Table
 
   // Gauge tracking number of peers on this tserver actively undergoing RBS.
   scoped_refptr<yb::AtomicGauge<uint64_t>> num_tablet_peers_undergoing_rbs_;
+
+  // Gauges for tablets held by an active index-backfill ordering generation's retention
+  // barrier (deferred unique-index verification): held-peer count and the oldest barrier's
+  // age.
+  scoped_refptr<yb::AtomicGauge<uint32_t>> index_backfill_retention_barrier_tablets_metric_;
+  scoped_refptr<yb::AtomicGauge<uint64_t>> index_backfill_oldest_barrier_age_ms_metric_;
 
   struct SnapshotScheduleInfo {
     HybridTime last_snapshot_ht;

--- a/src/yb/tserver/tserver-path-handlers.cc
+++ b/src/yb/tserver/tserver-path-handlers.cc
@@ -244,6 +244,29 @@ void HandleTabletPage(
   const SchemaPtr schema = peer->tablet_metadata()->schema();
   server::HtmlOutputSchemaTable(*schema, output);
 
+  const auto generation = peer->tablet_metadata()->index_backfill_ordering_generation();
+  if (generation.active) {
+    // A held generation pins history GC on this tablet (deferred unique-index verification);
+    // surfacing it here pairs with the ts_index_backfill_* gauges for stuck-barrier triage.
+    *output << "<h2>Index-Backfill Ordering Generation</h2>\n";
+    *output << "<table class='table table-striped'>\n";
+    *output << Format("<tr><th>Index table</th><td>$0</td></tr>\n",
+                      EscapeForHtmlToString(generation.table_id));
+    *output << Format("<tr><th>Base op index</th><td>$0</td></tr>\n", generation.base_op_index);
+    *output << Format("<tr><th>Write-ID floor version</th><td>$0</td></tr>\n",
+                      generation.write_id_floor_version);
+    if (generation.retention_barrier_ht) {
+      *output << Format(
+          "<tr><th>Retention barrier</th><td>$0 (age: $1 ms)</td></tr>\n",
+          EscapeForHtmlToString(generation.retention_barrier_ht.ToString()),
+          generation.RetentionBarrierAgeMs(peer->clock_ptr()->Now()));
+    } else {
+      *output << "<tr><th>Retention barrier</th>"
+                 "<td>missing (blocks all history GC on this tablet)</td></tr>\n";
+    }
+    *output << "</table>\n";
+  }
+
   *output << "<h2>Other Tablet Info Pages</h2>" << endl;
 
   // List of links to various tablet-specific info pages

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -1703,6 +1703,64 @@ TEST_P(PgIndexBackfillVerifierReleased, VerifyAfterReleaseFailsCleanly) {
   ASSERT_STR_CONTAINS(result.status().ToString(), "ordering generation");
 }
 
+// Retention-barrier gauges under the production lifecycle: held while the generation is
+// active.
+// Precise age semantics are pinned by the fixed-hybrid-time itest; this checks the
+// end-to-end wiring from the real activation path.
+TEST_P(PgIndexBackfillVerifier, RetentionBarrierMetricsReflectHeldGeneration) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (1, 1)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+
+  // Release is blocked, so every replica of the index tablet keeps its generation: each
+  // tserver must report the held tablet, with a positive barrier age (the barrier derives
+  // from the backfill read time, which is necessarily in the past by build completion).
+  for (size_t i = 0; i != cluster_->num_tablet_servers(); ++i) {
+    auto* ts = cluster_->tablet_server(i);
+    ASSERT_OK(WaitFor(
+        [ts]() -> Result<bool> {
+          return VERIFY_RESULT(ts->GetMetric<int64>(
+              "server", "yb.tabletserver", "ts_index_backfill_retention_barrier_tablets",
+              "value")) >= 1;
+        },
+        MonoDelta::FromSeconds(15) * kTimeMultiplier,
+        Format("tserver $0 to report a barrier-held tablet", i)));
+    ASSERT_GT(
+        ASSERT_RESULT(ts->GetMetric<int64>(
+            "server", "yb.tabletserver", "ts_index_backfill_oldest_retention_barrier_age_ms",
+            "value")),
+        0);
+  }
+}
+
+TEST_P(PgIndexBackfillVerifierReleased, RetentionBarrierMetricsClearOnRelease) {
+  std::vector<ExternalDaemon*> tserver_daemons;
+  for (auto* tserver : cluster_->tserver_daemons()) {
+    tserver_daemons.push_back(tserver);
+  }
+  LogWaiter release_waiter(
+      tserver_daemons, "Releasing index-backfill ordering generation");
+
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (1, 1)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+  ASSERT_OK(release_waiter.WaitFor(MonoDelta::FromSeconds(30) * kTimeMultiplier));
+
+  for (size_t i = 0; i != cluster_->num_tablet_servers(); ++i) {
+    auto* ts = cluster_->tablet_server(i);
+    ASSERT_OK(WaitFor(
+        [ts]() -> Result<bool> {
+          return VERIFY_RESULT(ts->GetMetric<int64>(
+              "server", "yb.tabletserver", "ts_index_backfill_retention_barrier_tablets",
+              "value")) == 0;
+        },
+        MonoDelta::FromSeconds(15) * kTimeMultiplier,
+        Format("tserver $0 barrier-tablet gauge to clear", i)));
+  }
+}
+
 // Generation-reference mismatches fail cleanly without scanning.
 TEST_P(PgIndexBackfillVerifier, GenerationMismatchFailsCleanly) {
   ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));


### PR DESCRIPTION
## Summary

Retention-barrier observability for deferred unique-index verification (#33444). With #33655
enforcing the retention barrier as a history read fence, an orphaned active ordering
generation pins ALL history GC on its tablet -- previously findable only by reading tablet
superblocks. This was called out as a measurement-gate requirement in the read-fence review:
the rollout's retained-history measurements need these signals. ("Barrier" wording
throughout, not "pin": upstream #32314 owns retention-pin terminology,
`enable_db_history_retention_pins`, and its per-database pins are a different mechanism
that composes with this barrier via MIN in `AllowedHistoryCutoff`.) Two server-level tserver
gauges, updated by the existing 1s `EmitMetrics` poller:

- `ts_index_backfill_retention_barrier_tablets` -- tablet peers whose history GC is pinned by an active
  index-backfill ordering generation. Counts peers in any state: the pin is on-disk
  metadata, not runtime state.
- `ts_index_backfill_oldest_retention_barrier_age_ms` -- age of the oldest active barrier,
  clamped at zero (the barrier derives from a master-chosen read time, which clock skew can
  put slightly ahead of this server's clock right after activation). 0 when no generation is
  active or no active generation carries a barrier hybrid time -- that missing-barrier state
  blocks all history GC on its tablet and already logs a warning every 30s.

**Alerting guidance:** key alerts on `ts_index_backfill_retention_barrier_tablets > 0` persisting
longer than the expected build+verify duration -- never on age alone. The worst state (an
active generation with a missing barrier) blocks all history GC yet reports age 0; the
pinned count plus the tserver's periodic missing-barrier warning are the signals that cover
it.

The tserver `/tablet` detail page additionally shows a held generation's fields (index
table, base op index, write-ID floor version, retention barrier + age) for per-tablet
triage.

Stacked on #33403, #33404, #33484, #33544, #33553, #33580, #33584, #33601, #33602, #33654,
#33655, and #33656, based on `feature-stack/Shopify/uniq-idx-7-fail-closed-gate` per the
feature-stack workflow, so the diff is exactly this PR's own commit. A failing pr-title
check on stacked PRs is a known gap in that check; the stack merges bottom-up and retargets
as parents merge.

## Upgrade/Rollback safety

A non-event: no wire, persisted-format, RPC, or flag changes -- two new server-level gauges
and a web-UI section, all reading existing tablet metadata. Old and new tservers coexist
freely; rollback simply stops exporting the metrics.

## Test plan

macOS arm64, release -- all green:

- [x] New: `FixedHybridTimeWriteIdITest.RetentionBarrierMetricsTrackActiveGenerations` --
      deterministic gauge semantics via directly-set generations, on every replica: baseline
      zero, pinned count with a barrier placed 5s in the past (age floor asserted with
      slack), the missing-barrier edge (pinned = 1 with age = 0), and release clearing both.
- [x] New: `PgIndexBackfillVerifier.RetentionBarrierMetricsReflectHeldGeneration/0` -- end-to-end
      wiring under the real activation path: with the funnel's release blocked, all three
      tservers report the pin and a positive age.
- [x] New: `PgIndexBackfillVerifierReleased.RetentionBarrierMetricsClearOnRelease/0` -- gauges
      return to zero after the production release path runs.
- [x] Regressions: `FixedHybridTimeWriteIdITest.MissingBarrierBlocksAllHistoryGC`,
      `FixedHybridTimeWriteIdITest.RetentionBarrierPreservesSupersededWindowVersions`. All
      three new tests re-run after the review round (HTML escaping + shared age helper).

AlmaLinux (x86_64, clang21), rebased onto master `c7253d204d`:

At this PR's own commit (`52818e84cd`), ASAN -- all green:

- [x] `fixed_hybrid_time_write_id-itest` (carries
      `RetentionBarrierMetricsTrackActiveGenerations`).
- [x] `RetentionBarrierMetricsReflectHeldGeneration` and
      `RetentionBarrierMetricsClearOnRelease`, both params (4 runs).

The rename from "retention pin" to "retention barrier" (metric
`ts_index_backfill_retention_barrier_tablets`, plus all three test names) avoids colliding
with upstream #32314, which now owns "retention pin" for its per-database session pins. The
two mechanisms compose correctly: both feed `AllowedHistoryCutoff` through `MakeAtMost`, so
the upstream cap cannot override this barrier.

Integrated at the stack tip (`334a1deb3d`), all green. Exact suites per build type:

- [x] TSAN (6): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `non_transactional_batch_writer-test`,
      `keyed_fingerprint-test`, `raft_consensus-itest`.
- [x] ASAN (15): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `keyed_fingerprint-test`,
      `non_transactional_batch_writer-test`, `clone-tablet-itest`,
      `remote_bootstrap-itest`, `tablet_bootstrap-test`, `auto_flags-itest`,
      `docdb-test`, `compaction_file_filter-test`,
      `xcluster_external_apply_bootstrap-test`, `pg_txn-test`, `pg_ash-test`,
      full `pg_index_backfill-test`.
- [x] Debug (19): the ASAN list minus `compaction_file_filter-test`, plus
      `master_failover-itest`, `snapshot-test`, `tablet_snapshots-test`,
      `compaction-test`, `tablet-split-itest`.
- [x] Release (5): `keyed_fingerprint-test`, `auto_flags-itest`, full
      `pg_index_backfill-test`, java `TestIndexBackfill`, java
      `TestPgRegressBackfillIndex`.
- [x] All three full `pg_index_backfill-test` runs (ASAN, debug, release) pass with no
      test failures.

Two known-upstream issues surfaced by the tip matrix, both shown not attributable to this
stack:

- TSAN `tablet-split-itest` reports 3 data races in `yb::client::YBTable::~YBTable()`
  (table.cc:81) racing its partition-refresh callback, inside the upstream test
  `AutomaticTabletSplitITest.SizeRatio` (93 cases ran, 0 gtest failures). This stack has zero
  diff under `src/yb/client/`, and that test passes 3/3 isolated at the new master base.
- `wait_states-itest` hangs 9 cases at the 601s timeout (`AshCql`, the `kYCQL_*` group,
  `kBackfillIndex_*`, `kConsensusMeta_Flush`, `kCreatingNewTablet`,
  `kSaveRaftGroupMetadataToDisk`). Reproduced identically on plain master `c7253d204d`
  carrying none of this stack's code: 53 ran, the same 9 failed, same ~600.5s expiries.

Disposition change since the previous revision: the
`PgIndexBackfillBackendsManager.NoAbortTxn/1` flake cited earlier was fixed upstream. It
passes 3/3 at the new base and in all three full `pg_index_backfill-test` runs here, so it is
no longer carried as a known flake.

