### PR TITLE
[BACKPORT 2026.1][#33201] DocDB: Drop pending status moves for participants with no completed batches (#33202)

### DIFF
--- a/src/yb/client/transaction.cc
+++ b/src/yb/client/transaction.cc
@@ -677,6 +677,7 @@ class YBTransaction::Impl final : public internal::TxnBatcherIf {
         RequestStatusTablet(deadline);
         return;
       }
+      DropPendingStatusMovesWithoutMetadata();
       if (!transaction_status_move_handles_.empty()) {
         DCHECK(!commit_waiter_);
         VLOG_WITH_PREFIX(1) << "Waiting for transaction move RPCs to finish";
@@ -2327,6 +2328,30 @@ class YBTransaction::Impl final : public internal::TxnBatcherIf {
           DoSendUpdateTransactionPromotingRpcs(std::move(transaction), id);
         },
         std::chrono::milliseconds(FLAGS_TEST_txn_status_moved_rpc_send_delay_ms));
+  }
+
+  // Stops waiting on the participants whose UpdateTransaction(PROMOTING) rpc is never going to be
+  // sent. DoSendUpdateTransactionPromotingRpcs() skips a participant until one of its batches
+  // completes, so a participant whose only batches failed keeps its entry in
+  // transaction_status_move_handles_ forever and the commit waits on an rpc that never goes out.
+  //
+  // Only safe at commit time: CheckCouldCommitUnlocked() rejects a commit with running requests, so
+  // no further batch can complete. Such a participant is not part of the commit either, since
+  // DoCommit() drops tablets without metadata.
+  void DropPendingStatusMovesWithoutMetadata() REQUIRES(mutex_) {
+    for (auto it = transaction_status_move_tablets_.begin();
+         it != transaction_status_move_tablets_.end();) {
+      const auto tablet_state = tablets_.find(*it);
+      CHECK(tablet_state != tablets_.end());
+      if (tablet_state->second.has_metadata) {
+        ++it;
+        continue;
+      }
+      VLOG_WITH_PREFIX(1) << "Tablet " << *it << " has no metadata, dropping its"
+                          << " UpdateTransaction(PROMOTING) rpc";
+      transaction_status_move_handles_.erase(*it);
+      it = transaction_status_move_tablets_.erase(it);
+    }
   }
 
   void DoSendUpdateTransactionPromotingRpcs(

--- a/src/yb/yql/pgwrapper/geo_transactions_promotion-test.cc
+++ b/src/yb/yql/pgwrapper/geo_transactions_promotion-test.cc
@@ -54,6 +54,7 @@ DECLARE_uint64(force_single_shard_waiter_retry_ms);
 DECLARE_uint64(refresh_waiter_timeout_ms);
 DECLARE_uint64(transaction_heartbeat_usec);
 DECLARE_uint64(transactions_status_poll_interval_ms);
+DECLARE_int32(ysql_client_read_write_timeout_ms);
 DECLARE_int32(ysql_yb_ash_sampling_interval_ms);
 DECLARE_bool(ysql_yb_ddl_transaction_block_enabled);
 DECLARE_bool(enable_object_locking_for_table_locks);
@@ -448,6 +449,20 @@ class GeoTransactionsFailOnConflictTest : public GeoTransactionsPromotionTest {
     // This test depends on fail-on-conflict concurrency control to perform its validation.
     // TODO(wait-queues): https://github.com/yugabyte/yugabyte-db/issues/17871
     EnableFailOnConflict();
+    GeoTransactionsPromotionTest::SetUp();
+  }
+};
+
+class GeoTransactionsPromotionShortRpcTimeoutTest : public GeoTransactionsPromotionTest {
+ public:
+  static constexpr auto kClientTimeoutMs = 30000;
+
+  void SetUp() override {
+    // Bounds the FinishTransaction rpc, which is otherwise sent without a deadline: postgres
+    // disables the statement timeout before running CommitTransactionCommand, so pggate falls back
+    // to this flag. Forwarded to the postgres process by PgWrapper as a non-default gflag.
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_client_read_write_timeout_ms) =
+        kClientTimeoutMs * kTimeMultiplier;
     GeoTransactionsPromotionTest::SetUp();
   }
 };
@@ -885,6 +900,51 @@ TEST_F(GeoTransactionsPromotionTest, YB_DISABLE_TEST_IN_TSAN(TestParticipantLead
   int64_t count = ASSERT_RESULT(conn.FetchRow<int64_t>(Format(
         "SELECT COUNT(*) FROM $0", kLocalTable)));
   ASSERT_EQ(1, count);
+}
+
+TEST_F_EX(GeoTransactionsPromotionTest,
+          YB_DISABLE_TEST_IN_TSAN(TestCommitWithZeroBatchParticipant),
+          GeoTransactionsPromotionShortRpcTimeoutTest) {
+  constexpr auto kLocalPkTable = "local_pk_table";
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_force_global_transactions) = true;
+  {
+    auto setup_conn = ASSERT_RESULT(Connect());
+    ASSERT_OK(setup_conn.ExecuteFormat(
+        "CREATE TABLE $0(k int PRIMARY KEY, v int) TABLESPACE tablespace$1",
+        kLocalPkTable, kLocalRegion));
+    ASSERT_OK(setup_conn.ExecuteFormat("INSERT INTO $0 VALUES (1, 1)", kLocalPkTable));
+  }
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_force_global_transactions) = false;
+
+  auto conn = ASSERT_RESULT(Connect());
+  ASSERT_OK(conn.Execute("SET force_global_transaction = false"));
+  ASSERT_OK(WarmupTablespaceCache(conn, kLocalPkTable));
+  ASSERT_OK(WarmupTablespaceCache(conn, Format("$0$1_1", kTablePrefix, kOtherRegion)));
+
+  ASSERT_OK(conn.StartTransaction(IsolationLevel::SERIALIZABLE_ISOLATION));
+
+  // Register a local participant tablet whose batch never completes: the duplicate key fails the
+  // write, so num_completed_batches stays at zero, and failing inside a savepoint leaves the
+  // transaction running.
+  ASSERT_OK(conn.Execute("SAVEPOINT sp"));
+  ASSERT_NOK(conn.ExecuteFormat("INSERT INTO $0 VALUES (1, 2)", kLocalPkTable));
+  ASSERT_OK(conn.Execute("ROLLBACK TO SAVEPOINT sp"));
+
+  // Write outside the local region to promote the transaction to global.
+  ASSERT_OK(conn.ExecuteFormat(
+      "INSERT INTO $0$1_1(value) VALUES (1)", kTablePrefix, kOtherRegion));
+
+  // The zero-batch participant is skipped when the PROMOTING rpcs go out, so the commit must drop
+  // it rather than wait on an rpc that is never sent.
+  ASSERT_OK(conn.CommitTransaction());
+
+  auto count = ASSERT_RESULT(conn.FetchRow<int64_t>(
+      Format("SELECT COUNT(*) FROM $0$1_1", kTablePrefix, kOtherRegion)));
+  ASSERT_EQ(1, count);
+  auto value = ASSERT_RESULT(conn.FetchRow<int32_t>(
+      Format("SELECT v FROM $0 WHERE k = 1", kLocalPkTable)));
+  ASSERT_EQ(1, value);
 }
 
 TEST_F_EX(GeoTransactionsPromotionTest,


### PR DESCRIPTION
## Summary

`StartPromotionToGlobal` registers every tablet in `tablets_` for a
status-location move.
`DoSendUpdateTransactionPromotingRpcs` then skips any tablet with no
completed batches, but leaves
its entry in `transaction_status_move_handles_`. That entry is only ever
erased by
`UpdateTransactionPromotingDone`, which runs when the rpc completes — so
for a tablet whose rpc is
never sent, it stays forever, and `Commit()` parks on `commit_waiter_`
until the pggate rpc deadline
expires (600 s by default).

A write that fails inside a savepoint reaches commit in exactly this
state: the tablet is registered
in `tablets_` with `num_completed_batches == 0`, and
`CanAbortTransaction` leaves the transaction
running because the failure carries a non-minimum `subtransaction_id`.

`Commit()` now prunes those tablets from
`transaction_status_move_tablets_` and
`transaction_status_move_handles_` before deciding whether to wait.

Pruning rather than sending the rpc anyway:
`ApplyUpdateTransactionPromoting` returns an expired
status for a transaction the participant has not registered, which would
surface as a spurious
abort. The participant is not part of the commit either — `DoCommit()`
drops tablets without
metadata, which is recorded in the same branch that increments
`num_completed_batches`. This is safe
at commit time only, since `CheckCouldCommitUnlocked` rejects a commit
with running requests, so no
further batch can complete.

The new test uses a fixture that lowers
`ysql_client_read_write_timeout_ms`, so that on a regression
the commit fails with an rpc timeout inside the test rather than being
killed by the harness timeout
with no assertion output.

Original commit: 3a325999599f56d78c09117ac08471822aa4d247 / #33202

## Test plan

- [x] New test
`GeoTransactionsPromotionTest.TestCommitWithZeroBatchParticipant` in
`src/yb/yql/pgwrapper/geo_transactions_promotion-test.cc` — verified it
hangs on the unmodified
  tree and passes with the fix:
  ```
  ybd --cxx-test pgwrapper_geo_transactions_promotion-test \
--gtest_filter
GeoTransactionsPromotionTest.TestCommitWithZeroBatchParticipant
  ```
- [ ] Full `pgwrapper_geo_transactions_promotion-test` binary (CI)

Assisted-By: devx/86cd09ab-76cd-4714-97ce-fb4896a579e7

## Merge conflicts

- `src/yb/client/transaction.cc:2333` — the cherry-pick chained from the 2025.2 task branch, whose comment/VLOG wording had been adapted to that branch's pre-rename `DoSendUpdateTransactionStatusLocationRpcs` naming; 2026.1 already has master's renamed `DoSendUpdateTransactionPromotingRpcs`, so the original master hunk was restored verbatim. The resulting diff is byte-identical to the original commit.
