### PR TITLE
[doc][yba] Add clock source configuration guidance for on-prem deployments

### DIFF
--- a/docs/content/stable/deploy/manual-deployment/system-config.md
+++ b/docs/content/stable/deploy/manual-deployment/system-config.md
@@ -62,7 +62,7 @@ rtcsync
 # sourcedir /run/chrony-dhcp
 ```
 
-- `minpoll 4 maxpoll 4` fixes the polling interval at 16 seconds. This is required if you use ClockBound, and is recommended even otherwise.
+- `minpoll 4 maxpoll 4` fixes the polling interval at 16 seconds. This is required if you use [ClockBound](#configure-clockbound), and is recommended regardless.
 - `minsources` defaults to 1, letting one source steer the clock while every other source disagrees. Use at least 2, and more if you have more sources.
 - `maxdistance` defaults to 3 seconds, six times the default skew threshold, so it never rejects a source. Keep it well below `--max_clock_skew_usec`.
 - Use time servers that smear leap seconds.

--- a/docs/content/stable/deploy/manual-deployment/system-config.md
+++ b/docs/content/stable/deploy/manual-deployment/system-config.md
@@ -34,6 +34,84 @@ To install chrony, run:
 $ sudo yum install -y chrony
 ```
 
+### Configure chrony
+
+YugabyteDB shuts down a YB-TServer or YB-Master when it detects clock skew larger than `--max_clock_skew_usec` (500 ms by default). Configure chrony so that synchronization stays accurate, and so that it draws on time sources that are themselves highly available and accurate.
+
+On cloud service providers, use the provider's link-local time service. On-premises you can place a time service behind a virtual IP or router as those services do, or configure several independent sources in chrony. If you configure multiple sources, spread them across availability zones or regions.
+
+An example `chrony.conf` for an on-premises deployment with several time sources:
+
+```
+server ntp1.example.internal prefer iburst minpoll 4 maxpoll 4
+server ntp2.example.internal prefer iburst minpoll 4 maxpoll 4
+server ntp3.example.internal prefer iburst minpoll 4 maxpoll 4
+server ntp4.example.internal prefer iburst minpoll 4 maxpoll 4
+
+minsources 2
+maxdistance 0.1
+maxclockerror 50
+
+logchange 0.1
+logdir /var/log/chrony
+log measurements statistics tracking
+
+rtcsync
+
+# Sources from DHCP arrive without the minpoll and maxpoll options above.
+# sourcedir /run/chrony-dhcp
+```
+
+- `minpoll 4 maxpoll 4` fixes the polling interval at 16 seconds. This is required if you use ClockBound, and is recommended even otherwise.
+- `minsources` defaults to 1, letting one source steer the clock while every other source disagrees. Use at least 2, and more if you have more sources.
+- `maxdistance` defaults to 3 seconds, six times the default skew threshold, so it never rejects a source. Keep it well below `--max_clock_skew_usec`.
+- Use time servers that smear leap seconds.
+
+### Verify clock synchronization
+
+Use `chronyc tracking` to check how closely the node follows its source:
+
+```output
+Reference ID    : C0A80A0B (ntp1.example.internal)
+Stratum         : 3
+System time     : 0.000000241 seconds fast of NTP time
+Last offset     : -0.000001108 seconds
+Residual freq   : +0.000 ppm
+Root delay      : 0.000198441 seconds
+Root dispersion : 0.000387219 seconds
+Update interval : 16.0 seconds
+Leap status     : Normal
+```
+
+`Leap status` is `Normal`, the offsets are well under a millisecond, and `Update interval` matches the configured 16 seconds. The clock error - `Root dispersion`, plus half of `Root delay`, plus `System time` - is 0.49 ms. With ClockBound, clock error must also stay below `clockbound_clock_error_estimate_usec`.
+
+The same fields on a node that is not synchronized closely enough:
+
+```output
+System time     : 0.087412663 seconds slow of NTP time
+Residual freq   : -58.229 ppm
+Root delay      : 0.000241883 seconds
+Root dispersion : 0.104778310 seconds
+Update interval : 1024.0 seconds
+```
+
+Clock error is now 192 ms, over a third of the default 500 ms skew threshold, and the residual frequency is implausible for a stable clock. The 1024-second update interval also shows that `maxpoll` is not taking effect, usually because sources are being loaded from `sourcedir`, `confdir`, or `include`.
+
+Use `chronyc sources` to check the individual sources:
+
+```output
+MS Name/IP address         Stratum Poll Reach LastRx Last sample
+===============================================================================
+^* ntp1.example.internal         2   4   377     9   -142ns[ -160ns] +/-  412us
+^+ ntp2.example.internal         2   4   377    12  +2891ns[+2874ns] +/-  438us
+^x ntp3.example.internal         2   4   377     5   +487ms[ +487ms] +/- 6021us
+^+ ntp4.example.internal         2   4   377     7  -1067ns[-1049ns] +/-  447us
+```
+
+`ntp1` is selected (`*`), and `ntp2` and `ntp4` are combined with it (`+`); all three are reachable (`Reach 377`, meaning the last eight polls succeeded) and agree to within microseconds.
+
+`ntp3` is marked `x`: chrony has classified it a falseticker because it disagrees with the other sources by 487 ms. Correct or replace it.
+
 ### Configure Precision Time Protocol
 
 {{<tags/feature/tp>}} Precision Time Protocol (PTP) is a network protocol designed for highly accurate time synchronization across devices in a network. PTP provides microsecond-level accuracy. PTP relies on a PTP Hardware Clock (PHC), a dedicated physical clock device that enhances time synchronization accuracy.

--- a/docs/content/stable/deploy/manual-deployment/system-config.md
+++ b/docs/content/stable/deploy/manual-deployment/system-config.md
@@ -43,10 +43,10 @@ On cloud service providers, use the provider's link-local time service. On-premi
 An example `chrony.conf` for an on-premises deployment with several time sources:
 
 ```
-server ntp1.example.internal prefer iburst minpoll 4 maxpoll 4
-server ntp2.example.internal prefer iburst minpoll 4 maxpoll 4
-server ntp3.example.internal prefer iburst minpoll 4 maxpoll 4
-server ntp4.example.internal prefer iburst minpoll 4 maxpoll 4
+server ntp1.example.internal prefer iburst minpoll 4 maxpoll 4 maxdelay 0.1
+server ntp2.example.internal prefer iburst minpoll 4 maxpoll 4 maxdelay 0.1
+server ntp3.example.internal prefer iburst minpoll 4 maxpoll 4 maxdelay 0.1
+server ntp4.example.internal prefer iburst minpoll 4 maxpoll 4 maxdelay 0.1
 
 minsources 2
 maxdistance 0.1

--- a/docs/content/stable/deploy/manual-deployment/system-config.md
+++ b/docs/content/stable/deploy/manual-deployment/system-config.md
@@ -110,7 +110,7 @@ MS Name/IP address         Stratum Poll Reach LastRx Last sample
 
 `ntp1` is selected (`*`), and `ntp2` and `ntp4` are combined with it (`+`); all three are reachable (`Reach 377`, meaning the last eight polls succeeded) and agree to within microseconds.
 
-`ntp3` is marked `x`: chrony has classified it a falseticker because it disagrees with the other sources by 487 ms. Correct or replace it.
+`ntp3` is marked `x`: chrony has classified it as a falseticker because it disagrees with the other sources by 487 ms. Correct or replace it.
 
 ### Configure Precision Time Protocol
 

--- a/docs/content/stable/deploy/manual-deployment/system-config.md
+++ b/docs/content/stable/deploy/manual-deployment/system-config.md
@@ -83,7 +83,7 @@ Update interval : 16.0 seconds
 Leap status     : Normal
 ```
 
-`Leap status` is `Normal`, the offsets are well under a millisecond, and `Update interval` matches the configured 16 seconds. The clock error - `Root dispersion`, plus half of `Root delay`, plus `System time` - is 0.49 ms. With ClockBound, clock error must also stay below `clockbound_clock_error_estimate_usec`.
+In this example, Leap status is "Normal", the offsets are well under a millisecond, and Update interval matches the configured 16 seconds. The clock error , calculated as Root dispersion plus half of Root delay plus System time, is 0.49 ms. With ClockBound, clock error must also stay below `clockbound_clock_error_estimate_usec`.
 
 The same fields on a node that is not synchronized closely enough:
 

--- a/docs/content/stable/deploy/manual-deployment/system-config.md
+++ b/docs/content/stable/deploy/manual-deployment/system-config.md
@@ -38,7 +38,7 @@ $ sudo yum install -y chrony
 
 YugabyteDB shuts down a YB-TServer or YB-Master when it detects clock skew larger than `--max_clock_skew_usec` (500 ms by default). Configure chrony so that synchronization stays accurate, and so that it draws on time sources that are themselves highly available and accurate.
 
-On cloud service providers, use the provider's link-local time service. On-premises you can place a time service behind a virtual IP or router as those services do, or configure several independent sources in chrony. If you configure multiple sources, spread them across availability zones or regions.
+On cloud service providers, use the provider's link-local time service. On-premises, configure several independent sources in chrony, and spread them across availability zones or regions.
 
 An example `chrony.conf` for an on-premises deployment with several time sources:
 

--- a/docs/content/stable/yugabyte-platform/prepare/server-nodes-software/software-on-prem-manual.md
+++ b/docs/content/stable/yugabyte-platform/prepare/server-nodes-software/software-on-prem-manual.md
@@ -103,6 +103,8 @@ A local Network Time Protocol (NTP) server or equivalent must be available.
 
 Ensure an NTP-compatible time service client is installed in the node OS (chrony is installed by default in the standard AlmaLinux 8 instance used in this example). Then, configure the time service client to use the available time server. The procedure includes this step and assumes chrony is the installed client.
 
+For the settings that matter for clock skew, and how to verify synchronization, refer to [Set up time synchronization](../../../../deploy/manual-deployment/system-config/#set-up-time-synchronization).
+
 ## Open incoming TCP/IP ports
 
 Database servers need incoming TCP/IP access enabled for communications between themselves and YugabyteDB Anywhere.
@@ -120,7 +122,7 @@ Physical nodes (or cloud instances) are installed with a standard AlmaLinux 8 se
 1. Add the following line to the `/etc/chrony.conf` file:
 
     ```text
-    server <your-time-server-IP-address> prefer iburst
+    server <your-time-server-IP-address> prefer iburst minpoll 4 maxpoll 4
     ```
 
     Then run the following command:

--- a/docs/content/v2025.2/deploy/manual-deployment/system-config.md
+++ b/docs/content/v2025.2/deploy/manual-deployment/system-config.md
@@ -37,7 +37,7 @@ $ sudo yum install -y chrony
 
 YugabyteDB shuts down a YB-TServer or YB-Master when it detects clock skew larger than `--max_clock_skew_usec` (500 ms by default). Configure chrony so that synchronization stays accurate, and so that it draws on time sources that are themselves highly available and accurate.
 
-On cloud service providers, use the provider's link-local time service. On-premises you can place a time service behind a virtual IP or router as those services do, or configure several independent sources in chrony. If you configure multiple sources, spread them across availability zones or regions.
+On cloud service providers, use the provider's link-local time service. On-premises, configure several independent sources in chrony, and spread them across availability zones or regions.
 
 An example `chrony.conf` for an on-premises deployment with several time sources:
 

--- a/docs/content/v2025.2/deploy/manual-deployment/system-config.md
+++ b/docs/content/v2025.2/deploy/manual-deployment/system-config.md
@@ -42,10 +42,10 @@ On cloud service providers, use the provider's link-local time service. On-premi
 An example `chrony.conf` for an on-premises deployment with several time sources:
 
 ```
-server ntp1.example.internal prefer iburst minpoll 4 maxpoll 4
-server ntp2.example.internal prefer iburst minpoll 4 maxpoll 4
-server ntp3.example.internal prefer iburst minpoll 4 maxpoll 4
-server ntp4.example.internal prefer iburst minpoll 4 maxpoll 4
+server ntp1.example.internal prefer iburst minpoll 4 maxpoll 4 maxdelay 0.1
+server ntp2.example.internal prefer iburst minpoll 4 maxpoll 4 maxdelay 0.1
+server ntp3.example.internal prefer iburst minpoll 4 maxpoll 4 maxdelay 0.1
+server ntp4.example.internal prefer iburst minpoll 4 maxpoll 4 maxdelay 0.1
 
 minsources 2
 maxdistance 0.1

--- a/docs/content/v2025.2/deploy/manual-deployment/system-config.md
+++ b/docs/content/v2025.2/deploy/manual-deployment/system-config.md
@@ -33,6 +33,84 @@ To install chrony, run:
 $ sudo yum install -y chrony
 ```
 
+### Configure chrony
+
+YugabyteDB shuts down a YB-TServer or YB-Master when it detects clock skew larger than `--max_clock_skew_usec` (500 ms by default). Configure chrony so that synchronization stays accurate, and so that it draws on time sources that are themselves highly available and accurate.
+
+On cloud service providers, use the provider's link-local time service. On-premises you can place a time service behind a virtual IP or router as those services do, or configure several independent sources in chrony. If you configure multiple sources, spread them across availability zones or regions.
+
+An example `chrony.conf` for an on-premises deployment with several time sources:
+
+```
+server ntp1.example.internal prefer iburst minpoll 4 maxpoll 4
+server ntp2.example.internal prefer iburst minpoll 4 maxpoll 4
+server ntp3.example.internal prefer iburst minpoll 4 maxpoll 4
+server ntp4.example.internal prefer iburst minpoll 4 maxpoll 4
+
+minsources 2
+maxdistance 0.1
+maxclockerror 50
+
+logchange 0.1
+logdir /var/log/chrony
+log measurements statistics tracking
+
+rtcsync
+
+# Sources from DHCP arrive without the minpoll and maxpoll options above.
+# sourcedir /run/chrony-dhcp
+```
+
+- `minpoll 4 maxpoll 4` fixes the polling interval at 16 seconds. This is required if you use ClockBound, and is recommended even otherwise.
+- `minsources` defaults to 1, letting one source steer the clock while every other source disagrees. Use at least 2, and more if you have more sources.
+- `maxdistance` defaults to 3 seconds, six times the default skew threshold, so it never rejects a source. Keep it well below `--max_clock_skew_usec`.
+- Use time servers that smear leap seconds.
+
+### Verify clock synchronization
+
+Use `chronyc tracking` to check how closely the node follows its source:
+
+```output
+Reference ID    : C0A80A0B (ntp1.example.internal)
+Stratum         : 3
+System time     : 0.000000241 seconds fast of NTP time
+Last offset     : -0.000001108 seconds
+Residual freq   : +0.000 ppm
+Root delay      : 0.000198441 seconds
+Root dispersion : 0.000387219 seconds
+Update interval : 16.0 seconds
+Leap status     : Normal
+```
+
+`Leap status` is `Normal`, the offsets are well under a millisecond, and `Update interval` matches the configured 16 seconds. The clock error - `Root dispersion`, plus half of `Root delay`, plus `System time` - is 0.49 ms. With ClockBound, clock error must also stay below `clockbound_clock_error_estimate_usec`.
+
+The same fields on a node that is not synchronized closely enough:
+
+```output
+System time     : 0.087412663 seconds slow of NTP time
+Residual freq   : -58.229 ppm
+Root delay      : 0.000241883 seconds
+Root dispersion : 0.104778310 seconds
+Update interval : 1024.0 seconds
+```
+
+Clock error is now 192 ms, over a third of the default 500 ms skew threshold, and the residual frequency is implausible for a stable clock. The 1024-second update interval also shows that `maxpoll` is not taking effect, usually because sources are being loaded from `sourcedir`, `confdir`, or `include`.
+
+Use `chronyc sources` to check the individual sources:
+
+```output
+MS Name/IP address         Stratum Poll Reach LastRx Last sample
+===============================================================================
+^* ntp1.example.internal         2   4   377     9   -142ns[ -160ns] +/-  412us
+^+ ntp2.example.internal         2   4   377    12  +2891ns[+2874ns] +/-  438us
+^x ntp3.example.internal         2   4   377     5   +487ms[ +487ms] +/- 6021us
+^+ ntp4.example.internal         2   4   377     7  -1067ns[-1049ns] +/-  447us
+```
+
+`ntp1` is selected (`*`), and `ntp2` and `ntp4` are combined with it (`+`); all three are reachable (`Reach 377`, meaning the last eight polls succeeded) and agree to within microseconds.
+
+`ntp3` is marked `x`: chrony has classified it a falseticker because it disagrees with the other sources by 487 ms. Correct or replace it.
+
 ### Configure Precision Time Protocol
 
 {{<tags/feature/tp>}} Precision Time Protocol (PTP) is a network protocol designed for highly accurate time synchronization across devices in a network. PTP provides microsecond-level accuracy. PTP relies on a PTP Hardware Clock (PHC), a dedicated physical clock device that enhances time synchronization accuracy.

--- a/docs/content/v2025.2/yugabyte-platform/prepare/server-nodes-software/software-on-prem-manual.md
+++ b/docs/content/v2025.2/yugabyte-platform/prepare/server-nodes-software/software-on-prem-manual.md
@@ -101,6 +101,8 @@ A local Network Time Protocol (NTP) server or equivalent must be available.
 
 Ensure an NTP-compatible time service client is installed in the node OS (chrony is installed by default in the standard AlmaLinux 8 instance used in this example). Then, configure the time service client to use the available time server. The procedure includes this step and assumes chrony is the installed client.
 
+For the settings that matter for clock skew, and how to verify synchronization, refer to [Set up time synchronization](../../../../deploy/manual-deployment/system-config/#set-up-time-synchronization).
+
 ## Open incoming TCP/IP ports
 
 Database servers need incoming TCP/IP access enabled for communications between themselves and YugabyteDB Anywhere.
@@ -118,7 +120,7 @@ Physical nodes (or cloud instances) are installed with a standard AlmaLinux 8 se
 1. Add the following line to the `/etc/chrony.conf` file:
 
     ```text
-    server <your-time-server-IP-address> prefer iburst
+    server <your-time-server-IP-address> prefer iburst minpoll 4 maxpoll 4
     ```
 
     Then run the following command:


### PR DESCRIPTION
## Summary

The clock synchronization docs do not cover which settings matter for YugabyteDB, how chrony decides which time source to trust, or how to verify the result.

## What this adds

Two sections under **Set up time synchronization**:

- **Configure chrony** — where an available and accurate time source comes from, an example `chrony.conf`, and one line per setting on why it matters for YugabyteDB.
- **Verify clock synchronization** — `chronyc tracking` and `chronyc sources`, each with healthy output and output from a node that is not synchronized closely enough, and what to look at in both.
