### PR TITLE
[DocDB][Vector Index] Quantization with float16 and int8+rerank.

### DIFF
--- a/architecture/design/docdb-vector-index-quantization.md
+++ b/architecture/design/docdb-vector-index-quantization.md
@@ -1,0 +1,204 @@
+# Vector index coordinate quantization
+
+DocDB vector indexes (`ybhnsw`) can store the coordinates of a served chunk in a narrower encoding
+than `float32`: either `float16`, or `int8` paired with a `float16` rerank tier. The HNSW graph is
+always built at full `float32` precision — only the copies written into the immutable chunk file
+are narrowed.
+
+`float32` is the default. A `float32` index writes version 1 of the chunk format and dispatches
+the same distance kernels it always has, so an index that does not opt in is unaffected.
+
+## What to expect
+
+VectorDBBench `Performance768D1M` (Cohere, 768 dimensions, 1M vectors, cosine), `k=100`,
+`ef_search=200`, single-node `m8i.2xlarge`, RF1:
+
+| encoding | QPS (30 clients) | vs `float32` | recall@100 | serial latency | p99 | load time | index size |
+|---|---|---|---|---|---|---|---|
+| `float32` (default) | 1337.3 | — | 0.9471 | 3.58 ms | 37.98 ms | 327 s | 3.19 GB |
+| `float16` | 1352.2 | +1.1% | 0.9471 | 4.60 ms | 41.45 ms | 331 s | 1.65 GB |
+| `int8` + `float16` rerank | 1669.7 | **+24.9%** | 0.9464 | 3.21 ms | 32.46 ms | 327 s | 2.42 GB |
+
+The two encodings solve different problems:
+
+- **`int8`** is the throughput option: **+24.9% QPS for 0.07 recall points**, and the only encoding
+  that also improves tail latency. Its record is *larger* than `float16`'s — the rerank copy costs
+  more than the narrowed traversal copy saves — so it is not the way to shrink an index.
+- **`float16`** halves the index (3.19 → 1.65 GB) at identical recall, but is worth about 1% of
+  throughput and *raises* serial latency and p99. Choose it for capacity, not for speed.
+
+Load time is the same for all three: the 4-second spread is inside the run-to-run noise on this
+benchmark, where two runs of one configuration differ by more than that.
+
+## Record layout
+
+`VectorStorageKind` names the traversal encoding and `RerankStorageKind` the optional second copy.
+Per vector at 768 dimensions:
+
+| encoding | traversal | rerank | record | vs `float32` | bytes per distance |
+|---|---|---|---|---|---|
+| `float32` | 3072 | — | 3092 | 1.00× | 3072 |
+| `float16` | 1536 | — | 1556 | 0.50× | 1536 |
+| `int8` | 768 | 1536 | 2324 | 0.75× | **768** |
+
+The 20-byte overhead is the per-vector `YbHnswVectorData` header. The traversal touches thousands
+of records per query while the rerank tier reads only the retained candidates, so `int8` spends
+0.75× the disk to make the hot path read a quarter of the bytes.
+
+`coordinate_codec.{h,cc}` owns both directions of the conversion, and nothing else narrows
+coordinates: the writer and the query path must round identically, or a vector stops being at
+distance zero from itself and the graph's neighbour choices stop agreeing with the distances used
+to search it.
+
+## The rerank tier, and why `ef` is not the knob
+
+`int8` quantizes each coordinate to a per-chunk step, which costs several points of recall@k.
+**Raising `ef` does not recover it** — a search retains `max_num_results` entries ranked by that
+same quantized distance, so widening the candidate set does not improve the final selection. For
+scalar quantization `ef` is not a recall knob.
+
+What recovers it is retaining more candidates than requested and rescoring them at `float16`
+before they leave the chunk. `MakeResult` is the only point at which distances cross the chunk
+boundary, so it is also the only point at which they must be in the metric's own units for
+VectorLSM to merge them against other chunks.
+
+The over-fetch is free while `factor × k <= ef`, since the search already maintains `max(ef, k)`
+candidates. Above that the candidate budget rises to `factor × k` and the traversal does
+proportionally more work — the case to watch when querying with a large `LIMIT`.
+
+## Per-chunk quantization scale
+
+`int8` uses a symmetric scale, `max|coordinate| / 127`, derived from the chunk's own coordinates
+and recorded in its footer. Scoping it to the chunk keeps it a pure function of data already in
+hand — no sampling, no configuration, nothing to recalibrate as an index grows — at the cost that
+two chunks of one index hold different scales. A query must therefore be quantized against the
+scale of the chunk it is compared against, never a freshly computed one.
+
+This is also why compaction reads the **rerank** copy rather than decoding the traversal
+coordinates. A merged chunk derives a new scale, so decoding `int8` would feed already-quantized
+values into a fresh quantization and lose a little more on every merge. The `float16` rerank copy
+round-trips exactly, making a vector a fixed point across arbitrarily many compactions.
+
+## Chunk format
+
+Each chunk records its own encoding in its footer, under a serialization version:
+
+| version | contents |
+|---|---|
+| 1 | base layout; always `float32` |
+| 2 | adds `Header::storage_kind` |
+| 3 | adds `Header::rerank_kind` and `Header::quantization_scale` |
+
+The writer emits the lowest version that can represent the header, which is what keeps a `float32`
+index at version 1. `Load` rejects a version it does not recognise rather than reading the fields
+it knows and treating the remainder as block offsets, and `ValidateHeader` then checks the parsed
+header against itself before any record is read through it — a `vector_data_size` disagreeing with
+the encodings would otherwise read past every record into the next, and an unusable quantization
+scale would decode coordinates to zero or infinity.
+
+## SIMD kernels
+
+x86-64 builds at `-march=ivybridge`, so no AVX-512 family enables itself from its `-march` macro
+and `usearch_include_wrapper_internal.h` forces the three SimSIMD targets the encodings need:
+`HASWELL`, `SKYLAKE` and `ICE`. Forcing a target is safe — each kernel carries its own target
+attribute so it compiles under the Ivy Bridge baseline, and `simsimd_capabilities()` dispatches on
+CPUID, so a kernel the host cannot run is never called.
+
+`ICE` is the target the narrowed encodings depend on. SimSIMD has no `*_i8_skylake`, so without
+it the `int8` ladder drops from AVX-512 straight to the 256-bit Haswell kernels while `float32`
+keeps a 512-bit one. `cos/l2sq/dot_i8_ice` accumulate into `int32` exactly as the Haswell kernels
+do, so they are bit-identical and cost no accuracy: the measured 0.9464 recall for `int8` is the
+quantization's cost alone.
+
+`float16` distances use the 256-bit `*_f16_haswell` kernels, which widen each coordinate to fp32
+and accumulate there. That is the reason `float16` storage buys capacity rather than throughput —
+halving the bytes does not halve the work when the kernel is narrower than `float32`'s.
+
+## Enabling an encoding
+
+A **master** flag chooses the encoding, which is stamped into the index's catalog entry at
+`CREATE INDEX`. It is therefore fixed for the life of that index and identical on every replica,
+rather than following each tserver's local flags.
+
+```bash
+# On every yb-master. Runtime-settable; no restart needed.
+--vector_index_storage_coordinate_type=int8      # or float16, or float32 (default)
+```
+
+```bash
+# On every yb-tserver. 1 disables the over-fetch, making reranking a no-op. Valid range 1-64.
+--vector_index_rerank_overfetch_factor=2         # default
+```
+
+An index keeps the encoding it was created with, so the flag's value at query time says nothing
+about an index created earlier. To see what an index actually got, read the footer from the index
+flush log lines:
+
+```
+YbHnsw ... header: { dimensions: 768 vector_data_size: 2324 ... storage_kind: kInt8
+                     rerank_kind: kFloat16 quantization_scale: 0.00418465 }
+```
+
+`vector_data_size` is the giveaway: `20 + 4·d` for `float32`, `20 + 2·d` for `float16`, and
+`20 + 3·d` for `int8`.
+
+### Downgrade
+
+Selecting a narrow encoding is a one-way step for the chunks written while it is selected. A
+version-2 or version-3 chunk is unreadable by a binary that only understands version 1. Clearing
+the flag stops new chunks from using the encoding but does not rewrite existing ones, and an index
+created while the flag was set keeps its encoding in the catalog. Moving such a cluster to a
+binary without these encodings requires those indexes be dropped and rebuilt.
+
+## Scope
+
+The SimSIMD `#define`s take effect only in translation units that include
+`usearch_include_wrapper_internal.h`, directly or through `hnsw.h`. That is 9 files: 5 production
+(`hnsw.cc`, `yb_hnsw_wrapper.cc`, `hnswlib_wrapper.cc`, `usearch_wrapper.cc`, `hnsw_options.cc`)
+and 4 tests. Every production one is vector-index code, and `hnsw.h` is included by no other
+header, so there is no further fan-out and nothing in `tserver`, `master`, `rocksdb` or `postgres`
+is reached. hnswlib's own SIMD is independent: it gates on `__AVX512F__`, which `-march=ivybridge`
+does not define.
+
+Disassembly confirms every AVX-512 instruction sits in a symbol suffixed `_ice` or `_skylake`. The
+`ICE` kernels add about 5 KB of text, of which 3 of 7 are reachable from any YB code path. With
+the default `float32` encoding the target is a runtime no-op, because the `float32` ladder has no
+`ICE` rung.
+
+Vector indexes are **YSQL-only**. YCQL cannot create one — `add_vector_options` has no callers and
+a CQL `DataType::VECTOR` hits `FATAL_INVALID_ENUM_VALUE` — so neither the encodings nor the SIMD
+targets can reach a YCQL workload.
+
+`int32` accumulator headroom for `int8` inputs is 8.3×: saturation needs `d > 133,144` against a
+`VECTOR_MAX_DIM` of 16,000.
+
+## Tests
+
+- `coordinate_codec-test.cc` — round-trip error bounds for both encodings, clamping of
+  unrepresentable values and NaN, and that one input always narrows to the same bytes.
+- `hnsw-test.cc` — that reranking recovers what `int8` costs *and* that the un-reranked
+  configuration is measurably worse, without which the test would pass just as happily when the
+  rerank tier does nothing; that over-fetch works when `ef <= max_num_results`, the regime a naive
+  candidate budget silently breaks; that an infinite coordinate cannot set the quantization scale.
+- `yb_hnsw_storage-test.cc` — iteration and `Distance` through the `VectorIndexIf` stack, and that
+  compaction reads the rerank copy rather than decoding `int8`.
+- `pg_vector_index-test.cc` — the same suite against each encoding end-to-end through flush,
+  restart, compaction and the query path; that the distance the user sees is unaffected by the
+  storage encoding; and that the tserver over-fetch flag is wired through.
+
+## Caveats
+
+- **The SIMD kernels have no sanitizer coverage.** SimSIMD is disabled under ASAN and TSAN, whose
+  builds therefore exercise usearch's scalar metric. The wide intrinsic loads in the AVX-512
+  kernels largely evade instrumentation, so a bad read inside one faults or is missed rather than
+  being reported.
+- **One CPU, one workload.** Every number above is `m8i.2xlarge` on Cohere 768d/1M at RF1. The
+  Skylake/ICE dispatch split and the balance between bytes moved and kernel cost will differ on
+  another host, at another dimension count, or under a mixed read/write load.
+- **The `int32` overflow bound is implicit.** The 8.3× headroom follows from `VECTOR_MAX_DIM`; no
+  assertion ties the two together, so raising that limit past ~133,000 would need it rechecked.
+- **`float16` costs latency.** It is the only encoding that makes serial latency and p99 worse.
+  Treat it as a capacity option, not a performance one.
+- **Include order in `hnsw.cc`.** It includes `usearch/index.hpp` directly after `hnsw.h`, which
+  already pulls in the wrapper. The wrapper's `#define`s land first, but reordering those includes
+  would silently change which kernels compile in.

--- a/src/yb/ann_methods/CMakeLists.txt
+++ b/src/yb/ann_methods/CMakeLists.txt
@@ -42,4 +42,5 @@ set(YB_TEST_LINK_LIBS ann_methods ann_methods_test_proto yrpc hnsw_test_util ${Y
 
 ADD_YB_TEST(index_merge-test)
 ADD_YB_TEST(vector_index_perf-test)
+ADD_YB_TEST(yb_hnsw_storage-test)
 ADD_YB_TEST(vector_lsm-test)

--- a/src/yb/ann_methods/usearch_wrapper.cc
+++ b/src/yb/ann_methods/usearch_wrapper.cc
@@ -124,7 +124,7 @@ class UsearchIndex :
       : block_cache_(block_cache),
         dimensions_(options.dimensions),
         distance_kind_(options.distance_kind),
-        metric_(options.CreateMetric<Vector>()),
+        metric_(options.CreateBuildMetric<Vector>()),
         backend_(backend),
         index_(IndexImpl::make(metric_, CreateIndexDenseConfig(options))) {
     CHECK_GT(dimensions_, 0);
@@ -350,7 +350,7 @@ class UsearchIndexTraits :
       const MemTrackerPtr& mem_tracker)
       : block_cache_(block_cache), options_(options), backend_(backend),
         mem_tracker_(mem_tracker),
-        metric_(options.CreateMetric<Vector>()) {
+        metric_(options.CreateBuildMetric<Vector>()) {
     LOG_IF(DFATAL, backend != HnswBackend::USEARCH && backend != HnswBackend::YB_HNSW_USEARCH) <<
         "Invalid backend for usearch index: " << HnswBackend_Name(backend);
   }

--- a/src/yb/ann_methods/vector_index_perf-test.cc
+++ b/src/yb/ann_methods/vector_index_perf-test.cc
@@ -17,6 +17,7 @@
 #include "yb/ann_methods/hnswlib_wrapper.h"
 #include "yb/ann_methods/usearch_wrapper.h"
 
+#include "yb/util/env.h"
 #include "yb/util/size_literals.h"
 
 namespace yb::ann_methods {
@@ -44,6 +45,14 @@ class VectorIndexPerfTest : public hnsw::VectorIndexTestBase {
     vector_index::HNSWOptions options = {
       .dimensions = dimensions_,
     };
+    // Same options apart from the on-disk encoding, so the graph built in RAM is identical and
+    // the set isolates what narrowing the served records costs.
+    auto float16_options = options;
+    float16_options.storage_kind = vector_index::VectorStorageKind::kFloat16;
+    auto int8_options = options;
+    int8_options.storage_kind = vector_index::VectorStorageKind::kInt8;
+    int8_options.rerank_kind = vector_index::RerankStorageKind::kFloat16;
+
     indexes_.emplace_back(
         "usearch",
         ASSERT_RESULT((CreateUsearchIndexTraits<Vector, DistanceResult>(
@@ -53,6 +62,16 @@ class VectorIndexPerfTest : public hnsw::VectorIndexTestBase {
         "hnswlib",
         ASSERT_RESULT((CreateHnswlibIndexTraits<Vector, DistanceResult>(
             block_cache_, options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)))
+            ->Create(vector_index::FactoryMode::kCreate));
+    indexes_.emplace_back(
+        "hnswlib_f16_source",
+        ASSERT_RESULT((CreateHnswlibIndexTraits<Vector, DistanceResult>(
+            block_cache_, float16_options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)))
+            ->Create(vector_index::FactoryMode::kCreate));
+    indexes_.emplace_back(
+        "hnswlib_i8_source",
+        ASSERT_RESULT((CreateHnswlibIndexTraits<Vector, DistanceResult>(
+            block_cache_, int8_options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)))
             ->Create(vector_index::FactoryMode::kCreate));
     for (const auto& [_, index] : indexes_) {
       ASSERT_OK(index->Reserve(
@@ -66,11 +85,24 @@ class VectorIndexPerfTest : public hnsw::VectorIndexTestBase {
 
     indexes_.emplace_back(
         "yb_hnsw",
-        ASSERT_RESULT(indexes_.front().second->SaveToFile(GetTestPath("0.yb_hnsw"))));
+        ASSERT_RESULT(indexes_[0].second->SaveToFile(GetTestPath("0.yb_hnsw"))));
 
     indexes_.emplace_back(
         "yb_hnsw_hnswlib",
         ASSERT_RESULT(indexes_[1].second->SaveToFile(GetTestPath("1.yb_hnsw"))));
+
+    indexes_.emplace_back(
+        "yb_hnsw_hnswlib_f16",
+        ASSERT_RESULT(indexes_[2].second->SaveToFile(GetTestPath("2.yb_hnsw"))));
+
+    indexes_.emplace_back(
+        "yb_hnsw_hnswlib_i8",
+        ASSERT_RESULT(indexes_[3].second->SaveToFile(GetTestPath("3.yb_hnsw"))));
+
+    for (const auto& name : {"1.yb_hnsw", "2.yb_hnsw", "3.yb_hnsw"}) {
+      LOG(INFO) << name << " size: "
+                << ASSERT_RESULT(Env::Default()->GetFileSize(GetTestPath(name)));
+    }
   }
 
   void InsertRandomVector(Vector& holder) {

--- a/src/yb/ann_methods/yb_hnsw_storage-test.cc
+++ b/src/yb/ann_methods/yb_hnsw_storage-test.cc
@@ -1,0 +1,477 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+// Narrowed coordinate storage through the VectorIndexIf wrapper stack -- the path a VectorLSM
+// chunk takes: build in RAM, SaveToFile, then Create(kLoad) + LoadFromFile. The parts that matter
+// are the ones reading stored records back out: iteration, which is how compaction consumes
+// source chunks, and Distance, which callers reach with full-precision vectors.
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <set>
+
+#include "yb/ann_methods/hnswlib_wrapper.h"
+
+#include "yb/hnsw/hnsw_block_cache.h"
+#include "yb/hnsw/vector_index_test_base.h"
+
+#include "yb/util/size_literals.h"
+#include "yb/util/status_log.h"
+#include "yb/util/test_util.h"
+
+#include "yb/vector_index/coordinate_codec.h"
+#include "yb/vector_index/vector_index_if.h"
+
+namespace yb::ann_methods {
+
+using vector_index::FactoryMode;
+using vector_index::HNSWOptions;
+using vector_index::RerankStorageKind;
+using vector_index::VectorId;
+using vector_index::VectorIndexIfPtr;
+using vector_index::VectorStorageKind;
+
+using DistanceResult = float;
+using IndexPtr = VectorIndexIfPtr<FloatVector, DistanceResult>;
+
+class YbHnswStorageWrapperTest : public hnsw::VectorIndexTestBase {
+ protected:
+  size_t BlockCacheCapacity() override {
+    return 256_MB;
+  }
+
+  HNSWOptions Options(
+      VectorStorageKind storage_kind,
+      RerankStorageKind rerank_kind = RerankStorageKind::kNone) const {
+    HNSWOptions options;
+    options.dimensions = dimensions_;
+    options.num_neighbors_per_vertex = 16;
+    options.num_neighbors_per_vertex_base = 32;
+    options.ef_construction = 100;
+    options.storage_kind = storage_kind;
+    options.rerank_kind = rerank_kind;
+    return options;
+  }
+
+  // Builds an in-RAM hnswlib chunk, flushes it, then reopens it the way a restart would: a fresh
+  // instance from the traits factory that has only ever seen the file.
+  IndexPtr BuildAndReload(
+      VectorStorageKind storage_kind, const std::string& name,
+      RerankStorageKind rerank_kind = RerankStorageKind::kNone) {
+    auto options = Options(storage_kind, rerank_kind);
+    auto traits = CHECK_RESULT((CreateHnswlibIndexTraits<FloatVector, DistanceResult>(
+        block_cache_, options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)));
+
+    auto mutable_index = traits->Create(FactoryMode::kCreate);
+    CHECK_OK(mutable_index->Reserve(
+        vectors_.size(), 1, 1, rocksdb::Cache::ReservationMode::kAlways));
+    for (size_t i = 0; i != vectors_.size(); ++i) {
+      CHECK_OK(mutable_index->Insert(ids_[i], vectors_[i]));
+    }
+
+    const auto path = GetTestPath(name);
+    // SaveToFile returns the file-backed index directly; drop it and go through the load
+    // factory instead, so this covers the restart path rather than the flush path.
+    CHECK_RESULT(mutable_index->SaveToFile(path));
+
+    auto loaded = traits->Create(FactoryMode::kLoad);
+    CHECK_OK(loaded->LoadFromFile(path, 1));
+    return loaded;
+  }
+
+  void GenerateVectors(size_t count) {
+    vectors_ = RandomVectors(count);
+    ids_.clear();
+    ids_.reserve(count);
+    for (size_t i = 0; i != count; ++i) {
+      ids_.push_back(VectorId::GenerateRandom());
+    }
+  }
+
+  // The shipping int8 configuration.
+  IndexPtr BuildAndReloadInt8(const std::string& name) {
+    return BuildAndReload(VectorStorageKind::kInt8, name, RerankStorageKind::kFloat16);
+  }
+
+  vector_index::SearchOptions MakeSearchOptions(size_t max_results, size_t ef = 64) const {
+    return vector_index::SearchOptions {
+      .max_num_results = max_results,
+      .ef = ef,
+    };
+  }
+
+  std::vector<hnsw::Vector> vectors_;
+  std::vector<VectorId> ids_;
+  MemTrackerPtr mem_tracker_ =
+      MemTracker::GetRootTracker()->FindOrCreateTracker(1_GB, "yb_hnsw_storage_test");
+};
+
+// VectorLSM's MergingIterator reads every source chunk through this iterator on every compaction,
+// and reading float32-wide from a float16 record would run off the end of each one -- so this
+// checks both that iteration terminates correctly and that its values round-trip.
+TEST_F(YbHnswStorageWrapperTest, IterationDecodesNarrowedRecords) {
+  constexpr size_t kNumVectors = 500;
+  dimensions_ = 24;
+  GenerateVectors(kNumVectors);
+
+  for (auto storage_kind : {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16}) {
+    auto index = BuildAndReload(storage_kind, Format("iter_$0.yb_hnsw", storage_kind));
+    ASSERT_EQ(index->Size(), kNumVectors) << storage_kind;
+
+    std::map<VectorId, hnsw::Vector> seen;
+    for (const auto& [vector_id, vector] : *index) {
+      ASSERT_EQ(vector.size(), dimensions_) << storage_kind;
+      ASSERT_TRUE(seen.emplace(vector_id, vector).second)
+          << "duplicate id from iteration: " << vector_id << ", " << storage_kind;
+    }
+    ASSERT_EQ(seen.size(), kNumVectors) << storage_kind;
+
+    // Every yielded vector must equal the original narrowed through the same encoding, which is
+    // exactly the invariant that keeps compaction from degrading an index over time.
+    for (size_t i = 0; i != kNumVectors; ++i) {
+      auto it = seen.find(ids_[i]);
+      ASSERT_NE(it, seen.end()) << "missing id " << ids_[i] << ", " << storage_kind;
+
+      std::vector<std::byte> narrowed(
+          vector_index::CoordinateBytes(storage_kind, dimensions_));
+      vector_index::NarrowCoordinates(
+          storage_kind, vectors_[i].data(), dimensions_, narrowed.data());
+      hnsw::Vector expected(dimensions_);
+      vector_index::WidenCoordinates(
+          storage_kind, narrowed.data(), dimensions_, expected.data());
+
+      ASSERT_EQ(expected, it->second) << "vector " << i << ", " << storage_kind;
+    }
+  }
+}
+
+// Re-narrowing what iteration produced has to reproduce the same bytes, or precision would drift
+// on every compaction.
+TEST_F(YbHnswStorageWrapperTest, CompactionRoundTripIsStable) {
+  dimensions_ = 32;
+  GenerateVectors(400);
+
+  auto index = BuildAndReload(VectorStorageKind::kFloat16, "roundtrip.yb_hnsw");
+
+  auto narrow = [this](const hnsw::Vector& vector) {
+    std::vector<std::byte> out(
+        vector_index::CoordinateBytes(VectorStorageKind::kFloat16, dimensions_));
+    vector_index::NarrowCoordinates(
+        VectorStorageKind::kFloat16, vector.data(), dimensions_, out.data());
+    return out;
+  };
+
+  for (const auto& [vector_id, vector] : *index) {
+    // vector came out of a float16 record, so narrowing it again must be a no-op.
+    std::vector<std::byte> widened_then_narrowed = narrow(vector);
+    hnsw::Vector again(dimensions_);
+    vector_index::WidenCoordinates(
+        VectorStorageKind::kFloat16, widened_then_narrowed.data(), dimensions_, again.data());
+    ASSERT_EQ(vector, again) << vector_id;
+  }
+}
+
+// Distance() takes full-precision vectors but the metric decodes stored records, so it has to
+// narrow its arguments. Without that it compares float32 bytes with a float16 metric and returns
+// nonsense.
+TEST_F(YbHnswStorageWrapperTest, DistanceNarrowsFullPrecisionArguments) {
+  dimensions_ = 16;
+  GenerateVectors(200);
+
+  auto f32 = BuildAndReload(VectorStorageKind::kFloat32, "dist_f32.yb_hnsw");
+  auto f16 = BuildAndReload(VectorStorageKind::kFloat16, "dist_f16.yb_hnsw");
+
+  for (size_t i = 0; i != 50; ++i) {
+    const auto& lhs = vectors_[i];
+    const auto& rhs = vectors_[(i + 37) % vectors_.size()];
+
+    const auto exact = f32->Distance(lhs, rhs);
+    const auto narrowed = f16->Distance(lhs, rhs);
+
+    ASSERT_TRUE(std::isfinite(narrowed)) << "pair " << i;
+    ASSERT_GT(exact, 0.0f) << "pair " << i;
+    ASSERT_LE(std::fabs(narrowed - exact) / exact, 0.01) << "pair " << i;
+
+    // A vector against itself is exactly zero under either encoding.
+    ASSERT_EQ(f16->Distance(lhs, lhs), 0.0f) << "pair " << i;
+  }
+}
+
+// End to end through the wrapper: the loaded index answers searches, and narrowing costs little
+// enough accuracy that the top results still largely agree with full precision.
+TEST_F(YbHnswStorageWrapperTest, SearchAgreesWithFullPrecision) {
+  constexpr size_t kNumVectors = 4000;
+  constexpr size_t kNumQueries = 200;
+  constexpr size_t kMaxResults = 10;
+
+  dimensions_ = 64;
+  GenerateVectors(kNumVectors);
+
+  auto f32 = BuildAndReload(VectorStorageKind::kFloat32, "search_f32.yb_hnsw");
+  auto f16 = BuildAndReload(VectorStorageKind::kFloat16, "search_f16.yb_hnsw");
+
+  size_t common = 0;
+  for (size_t i = 0; i != kNumQueries; ++i) {
+    auto query = RandomVector();
+    auto from_f32 = ASSERT_RESULT(f32->Search(query, MakeSearchOptions(kMaxResults)));
+    auto from_f16 = ASSERT_RESULT(f16->Search(query, MakeSearchOptions(kMaxResults)));
+    ASSERT_EQ(from_f32.size(), kMaxResults);
+    ASSERT_EQ(from_f16.size(), kMaxResults);
+
+    std::set<VectorId> f32_ids;
+    for (const auto& entry : from_f32) {
+      f32_ids.insert(entry.vector_id);
+    }
+    for (const auto& entry : from_f16) {
+      common += f32_ids.contains(entry.vector_id);
+      ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+    }
+  }
+
+  const double overlap = static_cast<double>(common) / (kNumQueries * kMaxResults);
+  LOG(INFO) << "float16 top-" << kMaxResults << " overlap with float32: " << overlap;
+  ASSERT_GE(overlap, 0.9);
+}
+
+
+// The compaction hazard the two-tier record exists to avoid. Compaction re-inserts what this
+// iterator yields into a new chunk, which derives its own quantization scale, so decoding the int8
+// coordinates would feed already-quantized values into a fresh quantization and lose a little more
+// on every merge. The rerank copy round-trips exactly, making a vector a fixed point across
+// arbitrarily many compactions.
+TEST_F(YbHnswStorageWrapperTest, IterationReadsTheRerankCopy) {
+  constexpr size_t kNumVectors = 500;
+  dimensions_ = 24;
+  GenerateVectors(kNumVectors);
+
+  auto index = BuildAndReloadInt8("iter_i8.yb_hnsw");
+  ASSERT_EQ(index->Size(), kNumVectors);
+
+  size_t count = 0;
+  double worst_error = 0;
+  for (const auto& [vector_id, vector] : *index) {
+    ASSERT_EQ(vector.size(), dimensions_);
+    auto it = std::find(ids_.begin(), ids_.end(), vector_id);
+    ASSERT_NE(it, ids_.end()) << "unknown id from iteration: " << vector_id;
+    const auto& original = vectors_[it - ids_.begin()];
+
+    // Must be the float16 round trip of the original, not the int8 one. Exact equality against
+    // float16 rather than a tolerance is what distinguishes them: an int8 decode would be off by up
+    // to half a quantization step, orders of magnitude more.
+    std::vector<std::byte> narrowed(
+        vector_index::CoordinateBytes(VectorStorageKind::kFloat16, dimensions_));
+    vector_index::NarrowCoordinates(
+        VectorStorageKind::kFloat16, original.data(), dimensions_, narrowed.data());
+    hnsw::Vector expected(dimensions_);
+    vector_index::WidenCoordinates(
+        VectorStorageKind::kFloat16, narrowed.data(), dimensions_, expected.data());
+    ASSERT_EQ(expected, vector) << "id " << vector_id;
+
+    for (size_t i = 0; i != dimensions_; ++i) {
+      worst_error = std::max<double>(worst_error, std::fabs(vector[i] - original[i]));
+    }
+    ++count;
+  }
+  ASSERT_EQ(count, kNumVectors);
+  LOG(INFO) << "worst absolute coordinate error from iteration: " << worst_error;
+}
+
+// Repeated compaction must not degrade a vector. Feeding what iteration yields back through a
+// fresh chunk models one merge; doing it several times is what would expose compounding error.
+TEST_F(YbHnswStorageWrapperTest, Int8SurvivesRepeatedCompaction) {
+  constexpr size_t kNumVectors = 300;
+  constexpr size_t kGenerations = 4;
+  dimensions_ = 32;
+  GenerateVectors(kNumVectors);
+
+  std::map<VectorId, hnsw::Vector> previous;
+  for (size_t generation = 0; generation != kGenerations; ++generation) {
+    auto index = BuildAndReloadInt8(Format("gen_$0.yb_hnsw", generation));
+
+    std::map<VectorId, hnsw::Vector> current;
+    for (const auto& [vector_id, vector] : *index) {
+      ASSERT_TRUE(current.emplace(vector_id, vector).second) << vector_id;
+    }
+    ASSERT_EQ(current.size(), kNumVectors);
+
+    if (generation != 0) {
+      // Bit-identical to the previous generation, which is the fixed point that makes compaction
+      // safe to run any number of times. Compared per id rather than whole-map, so a failure
+      // names the vector that drifted instead of dumping every coordinate in the chunk.
+      for (const auto& [vector_id, vector] : current) {
+        auto it = previous.find(vector_id);
+        ASSERT_NE(it, previous.end()) << "generation " << generation << " lost " << vector_id;
+        ASSERT_EQ(vector, it->second)
+            << "generation " << generation << " drifted for " << vector_id;
+      }
+    }
+    previous = std::move(current);
+
+    // The next generation is built from what this one yielded, i.e. from stored records rather
+    // than from the originals -- which is what a real compaction does.
+    for (size_t i = 0; i != kNumVectors; ++i) {
+      vectors_[i] = previous[ids_[i]];
+    }
+  }
+}
+
+// Distance() feeds VectorLSM's comparison of in-flight vectors against chunk results, so it has
+// to be in the metric's own units. Computing it with the int8 metric would return a value in
+// quantized units -- comparable within one chunk and meaningless anywhere else.
+TEST_F(YbHnswStorageWrapperTest, Int8DistanceUsesTheRerankMetric) {
+  dimensions_ = 16;
+  GenerateVectors(200);
+
+  auto f32 = BuildAndReload(VectorStorageKind::kFloat32, "dist_f32.yb_hnsw");
+  auto f16 = BuildAndReload(VectorStorageKind::kFloat16, "dist_f16.yb_hnsw");
+  auto i8 = BuildAndReloadInt8("dist_i8.yb_hnsw");
+
+  for (size_t i = 0; i != 50; ++i) {
+    const auto& lhs = vectors_[i];
+    const auto& rhs = vectors_[(i + 37) % vectors_.size()];
+
+    const auto exact = f32->Distance(lhs, rhs);
+    ASSERT_GT(exact, 0.0f) << "pair " << i;
+
+    // Agrees with float16 to the bit, because that is the metric it uses.
+    ASSERT_EQ(i8->Distance(lhs, rhs), f16->Distance(lhs, rhs)) << "pair " << i;
+    // And therefore lands within float16's error of full precision, not int8's.
+    ASSERT_LE(std::fabs(i8->Distance(lhs, rhs) - exact) / exact, 0.01) << "pair " << i;
+    ASSERT_EQ(i8->Distance(lhs, lhs), 0.0f) << "pair " << i;
+  }
+}
+
+// The scale is derived per chunk, so two chunks of the same index hold different ones. A search
+// that quantized its query with a cached or shared scale would decode one of them wrong.
+TEST_F(YbHnswStorageWrapperTest, ScalesDifferAcrossChunks) {
+  constexpr size_t kNumVectors = 300;
+  dimensions_ = 16;
+
+  // Two chunks whose coordinate ranges differ by two orders of magnitude.
+  GenerateVectors(kNumVectors);
+  auto narrow_range = vectors_;
+  auto wide_range = vectors_;
+  for (auto& vector : wide_range) {
+    for (auto& coordinate : vector) {
+      coordinate *= 100.0f;
+    }
+  }
+
+  vectors_ = narrow_range;
+  auto small = BuildAndReloadInt8("scale_small.yb_hnsw");
+  vectors_ = wide_range;
+  auto large = BuildAndReloadInt8("scale_large.yb_hnsw");
+
+  // Each chunk must be searchable on its own terms: a query drawn from its own range finds its
+  // exact match at distance zero, which only holds if the query was quantized with that chunk's
+  // scale.
+  for (size_t i = 0; i != 20; ++i) {
+    auto from_small = ASSERT_RESULT(small->Search(narrow_range[i], MakeSearchOptions(1, 200)));
+    ASSERT_EQ(from_small.size(), 1);
+    ASSERT_EQ(from_small.front().distance, 0.0f) << "narrow-range vector " << i;
+
+    auto from_large = ASSERT_RESULT(large->Search(wide_range[i], MakeSearchOptions(1, 200)));
+    ASSERT_EQ(from_large.size(), 1);
+    ASSERT_EQ(from_large.front().distance, 0.0f) << "wide-range vector " << i;
+  }
+
+  // Distances the two chunks report are directly comparable, which is what lets VectorLSM merge
+  // them: reranking puts both into the metric's units regardless of their scales.
+  const auto small_self = small->Distance(narrow_range[0], narrow_range[1]);
+  const auto large_self = large->Distance(wide_range[0], wide_range[1]);
+  // wide_range is narrow_range scaled by 100, so L2 squared is 10000x.
+  ASSERT_LE(std::fabs(large_self / small_self - 10000.0) / 10000.0, 0.01)
+      << "small: " << small_self << ", large: " << large_self;
+}
+
+// End to end through the wrapper, and the reason the encoding is shippable: int8 traversal alone
+// loses recall, and reranking recovers it to float16's level.
+TEST_F(YbHnswStorageWrapperTest, Int8SearchAgreesWithFullPrecision) {
+  constexpr size_t kNumVectors = 4000;
+  constexpr size_t kNumQueries = 200;
+  constexpr size_t kMaxResults = 10;
+
+  dimensions_ = 64;
+  GenerateVectors(kNumVectors);
+
+  auto f32 = BuildAndReload(VectorStorageKind::kFloat32, "search_f32.yb_hnsw");
+  auto f16 = BuildAndReload(VectorStorageKind::kFloat16, "search_f16.yb_hnsw");
+  auto i8 = BuildAndReloadInt8("search_i8.yb_hnsw");
+  auto i8_bare = BuildAndReload(VectorStorageKind::kInt8, "search_i8_bare.yb_hnsw");
+
+  size_t common_f16 = 0, common_i8 = 0, common_bare = 0;
+  for (size_t i = 0; i != kNumQueries; ++i) {
+    auto query = RandomVector();
+    auto options = MakeSearchOptions(kMaxResults);
+    auto from_f32 = ASSERT_RESULT(f32->Search(query, options));
+    ASSERT_EQ(from_f32.size(), kMaxResults);
+
+    std::set<VectorId> f32_ids;
+    for (const auto& entry : from_f32) {
+      f32_ids.insert(entry.vector_id);
+    }
+
+    for (auto [index, common] : std::initializer_list<std::pair<IndexPtr*, size_t*>>{
+             {&f16, &common_f16}, {&i8, &common_i8}, {&i8_bare, &common_bare}}) {
+      auto results = ASSERT_RESULT((*index)->Search(query, options));
+      ASSERT_EQ(results.size(), kMaxResults);
+      for (const auto& entry : results) {
+        *common += f32_ids.contains(entry.vector_id);
+        ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+      }
+    }
+  }
+
+  const double denominator = kNumQueries * kMaxResults;
+  const double f16_overlap = common_f16 / denominator;
+  const double i8_overlap = common_i8 / denominator;
+  const double bare_overlap = common_bare / denominator;
+  LOG(INFO) << "top-" << kMaxResults << " overlap with float32: float16 " << f16_overlap
+            << ", int8 + float16 rerank " << i8_overlap << ", int8 alone " << bare_overlap;
+
+  ASSERT_GE(f16_overlap, 0.9);
+  // Reranking cannot beat the encoding it reranks with, so float16 is the ceiling. That the
+  // rerank ran at all is asserted below by the units of the distance rather than by comparing
+  // recall against `bare`, whose gap depends on the data.
+  ASSERT_GE(i8_overlap, f16_overlap - 0.02);
+
+  // What proves the rerank ran, deterministically: each reported distance must be exactly what
+  // the float16 index gives for the same pair, because that is the computation MakeResult
+  // performs. Without a rerank tier the traversal's quantized distance is reported instead.
+  std::map<VectorId, size_t> index_by_id;
+  for (size_t i = 0; i != ids_.size(); ++i) {
+    index_by_id.emplace(ids_[i], i);
+  }
+  for (size_t i = 0; i != 20; ++i) {
+    auto query = RandomVector();
+    auto options = MakeSearchOptions(kMaxResults);
+    auto reranked = ASSERT_RESULT(i8->Search(query, options));
+    auto quantized = ASSERT_RESULT(i8_bare->Search(query, options));
+    ASSERT_EQ(reranked.size(), kMaxResults);
+    ASSERT_EQ(quantized.size(), kMaxResults);
+
+    for (const auto& entry : reranked) {
+      auto it = index_by_id.find(entry.vector_id);
+      ASSERT_NE(it, index_by_id.end()) << entry;
+      ASSERT_EQ(entry.distance, f16->Distance(query, vectors_[it->second]))
+          << "reported distance is not the float16 metric's: " << entry;
+    }
+    const auto& nearest = quantized.front();
+    auto it = index_by_id.find(nearest.vector_id);
+    ASSERT_NE(it, index_by_id.end()) << nearest;
+    ASSERT_NE(nearest.distance, f16->Distance(query, vectors_[it->second]))
+        << "un-reranked search reported a float16 distance: " << nearest;
+  }
+}
+
+}  // namespace yb::ann_methods

--- a/src/yb/ann_methods/yb_hnsw_wrapper.cc
+++ b/src/yb/ann_methods/yb_hnsw_wrapper.cc
@@ -19,6 +19,7 @@
 #include "yb/util/scope_exit.h"
 #include "yb/util/status_format.h"
 
+#include "yb/vector_index/coordinate_codec.h"
 #include "yb/vector_index/index_wrapper_base.h"
 
 namespace yb::ann_methods {
@@ -28,6 +29,7 @@ namespace {
 using vector_index::IndexableVectorType;
 using vector_index::VectorId;
 using vector_index::ValidDistanceResultType;
+using vector_index::VectorStorageKind;
 
 template<IndexableVectorType Vector>
 class YbHnswIterator : public AbstractIterator<std::pair<VectorId, Vector>> {
@@ -36,7 +38,7 @@ class YbHnswIterator : public AbstractIterator<std::pair<VectorId, Vector>> {
   using Base = AbstractIterator<ValueType>;
 
   YbHnswIterator(const hnsw::YbHnsw& hnsw, size_t index)
-      : cache_scope_(cache_, hnsw), dimensions_(hnsw.header().dimensions), index_(index) {
+      : cache_scope_(cache_, hnsw), header_(hnsw.header()), index_(index) {
   }
 
   void Next() override {
@@ -44,11 +46,25 @@ class YbHnswIterator : public AbstractIterator<std::pair<VectorId, Vector>> {
   }
 
   ValueType Dereference() const override {
-    const auto* coordinates = cache_.CoordinatesPtr(index_);
     ValueType result;
     result.first = cache_.GetVectorData(index_);
-    result.second.resize(dimensions_);
-    memcpy(result.second.data(), coordinates, dimensions_ * sizeof(typename Vector::value_type));
+    result.second.resize(header_.dimensions);
+    // Records may be narrower than Vector::value_type, so this decodes rather than copies; a
+    // memcpy would walk past the end of each record.
+    //
+    // Where a rerank copy exists it is the one compaction must read. The traversal encoding may be
+    // quantized against a scale the merged chunk will not reuse, so decoding it would feed
+    // already-quantized values into a fresh quantization and compound the error once per
+    // compaction. The rerank encodings round trip exactly.
+    if (header_.rerank_kind != vector_index::RerankStorageKind::kNone) {
+      vector_index::WidenCoordinates(
+          vector_index::StorageKindForRerank(header_.rerank_kind),
+          cache_.RerankCoordinatesPtr(index_), header_.dimensions, result.second.data());
+    } else {
+      vector_index::WidenCoordinates(
+          header_.storage_kind, header_.quantization_scale, cache_.CoordinatesPtr(index_),
+          header_.dimensions, result.second.data());
+    }
     return result;
   }
 
@@ -60,7 +76,7 @@ class YbHnswIterator : public AbstractIterator<std::pair<VectorId, Vector>> {
  private:
   mutable hnsw::SearchCache cache_;
   hnsw::SearchCacheScope cache_scope_;
-  const size_t dimensions_;
+  const hnsw::Header& header_;
   size_t index_;
 };
 
@@ -88,9 +104,12 @@ class YbHnswIndex :
   }
 
   Status Import(
-      const hnsw::HnswlibIndex<DistanceResult>& index, const std::string& path) {
-    VLOG_WITH_FUNC(3) << "index: " << index.cur_element_count << ", path: " << path;
-    return index_.Import(index, path);
+      const hnsw::HnswlibIndex<DistanceResult>& index, const std::string& path,
+      VectorStorageKind storage_kind, vector_index::RerankStorageKind rerank_kind) {
+    VLOG_WITH_FUNC(3)
+        << "index: " << index.cur_element_count << ", path: " << path
+        << ", storage_kind: " << storage_kind << ", rerank_kind: " << rerank_kind;
+    return index_.Import(index, path, storage_kind, rerank_kind);
   }
 
   std::unique_ptr<AbstractIterator<std::pair<VectorId, Vector>>> BeginImpl() const override {
@@ -127,8 +146,44 @@ class YbHnswIndex :
   }
 
   DistanceResult Distance(const Vector& lhs, const Vector& rhs) const override {
-    return index_.Distance(
-        pointer_cast<const std::byte*>(lhs.data()), pointer_cast<const std::byte*>(rhs.data()));
+    const auto& header = index_.header();
+    // Compared against distances from other chunks -- VectorLSM scores the mutable chunk's
+    // in-flight vectors through it -- so it must be in the metric's own units. That means the
+    // rerank encoding and metric where a tier exists: a quantized traversal distance is only
+    // comparable within its own chunk.
+    //
+    // Cold path (SearchExact and tests), so a scratch allocation per call is fine.
+    if (header.rerank_kind != vector_index::RerankStorageKind::kNone) {
+      const auto kind = vector_index::StorageKindForRerank(header.rerank_kind);
+      if (kind == VectorStorageKind::kFloat32) {
+        return index_.RerankDistance(
+            pointer_cast<const std::byte*>(lhs.data()),
+            pointer_cast<const std::byte*>(rhs.data()));
+      }
+      // No rerank encoding quantizes, so none of them needs the scale.
+      const auto bytes = vector_index::CoordinateBytes(kind, header.dimensions);
+      std::vector<std::byte> buffer(bytes * 2);
+      vector_index::NarrowCoordinates(kind, lhs.data(), header.dimensions, buffer.data());
+      vector_index::NarrowCoordinates(
+          kind, rhs.data(), header.dimensions, buffer.data() + bytes);
+      return index_.RerankDistance(buffer.data(), buffer.data() + bytes);
+    }
+
+    if (header.storage_kind == VectorStorageKind::kFloat32) {
+      return index_.Distance(
+          pointer_cast<const std::byte*>(lhs.data()), pointer_cast<const std::byte*>(rhs.data()));
+    }
+    // The metric decodes this file's encoding, so full-precision arguments must go through the
+    // same narrowing the stored records did.
+    const auto bytes = vector_index::CoordinateBytes(header.storage_kind, header.dimensions);
+    std::vector<std::byte> buffer(bytes * 2);
+    vector_index::NarrowCoordinates(
+        header.storage_kind, header.quantization_scale, lhs.data(), header.dimensions,
+        buffer.data());
+    vector_index::NarrowCoordinates(
+        header.storage_kind, header.quantization_scale, rhs.data(), header.dimensions,
+        buffer.data() + bytes);
+    return index_.Distance(buffer.data(), buffer.data() + bytes);
   }
 
   Result<Vector> GetVector(VectorId vector_id) const override {
@@ -176,14 +231,25 @@ class YbHnswIndex :
   mutable LockFreeStack<SearchContextHolder> search_contexts_;
 };
 
+// Builds metrics from `options` for whichever encoding YbHnsw asks about: what Import is about
+// to write, or what Init read from a file's footer.
+hnsw::YbHnsw::MetricFactory MakeMetricFactory(const vector_index::HNSWOptions& options) {
+  return [options](size_t dimensions, VectorStorageKind storage_kind) {
+    return std::make_unique<hnsw::UsearchMetric>(
+        options.CreateStoredMetric(dimensions, storage_kind));
+  };
+}
+
 } // namespace
 
 template <class Vector, class DistanceResult>
 Result<vector_index::VectorIndexIfPtr<Vector, DistanceResult>> ImportYbHnsw(
     const unum::usearch::index_dense_gt<vector_index::VectorId>& index, const std::string& path,
     const hnsw::BlockCachePtr& block_cache) {
+  // The usearch index owns its own float32 metric; narrowed storage is not wired through this
+  // backend, so the chunk is written and served at full precision.
   auto result = std::make_shared<YbHnswIndex<Vector, DistanceResult>>(
-      std::make_unique<hnsw::UsearchMetric>(index.metric()), block_cache);
+      index.metric(), block_cache);
   RETURN_NOT_OK(result->Import(index, path));
   return result;
 }
@@ -193,8 +259,8 @@ Result<vector_index::VectorIndexIfPtr<Vector, DistanceResult>> ImportYbHnsw(
     const hnsw::HnswlibIndex<DistanceResult>& index, const std::string& path,
     const hnsw::BlockCachePtr& block_cache, const vector_index::HNSWOptions& options) {
   auto result = std::make_shared<YbHnswIndex<Vector, DistanceResult>>(
-      std::make_unique<hnsw::UsearchMetric>(options.CreateMetric<Vector>()), block_cache);
-  RETURN_NOT_OK(result->Import(index, path));
+      MakeMetricFactory(options), block_cache);
+  RETURN_NOT_OK(result->Import(index, path, options.storage_kind, options.rerank_kind));
   return result;
 }
 
@@ -212,7 +278,7 @@ template <class Vector, class DistanceResult>
 vector_index::VectorIndexIfPtr<Vector, DistanceResult> CreateYbHnsw(
     const hnsw::BlockCachePtr& block_cache, const vector_index::HNSWOptions& options) {
   return std::make_shared<YbHnswIndex<Vector, DistanceResult>>(
-      std::make_unique<hnsw::UsearchMetric>(options.CreateMetric<Vector>()), block_cache);
+      MakeMetricFactory(options), block_cache);
 }
 
 template

--- a/src/yb/common/common.proto
+++ b/src/yb/common/common.proto
@@ -141,11 +141,26 @@ enum HnswBackend {
   YB_HNSW_HNSWLIB = 3;
 };
 
+// Encoding of the coordinates a served vector index chunk stores on disk. Graph construction
+// always runs at full precision regardless.
+enum VectorStorageType {
+  STORAGE_FLOAT32 = 0;
+  STORAGE_FLOAT16 = 1;
+  // int8 traversal coordinates plus a float16 rerank copy. Selects the pair, not just the
+  // traversal encoding: int8 alone loses recall no amount of ef recovers.
+  STORAGE_INT8 = 2;
+}
+
 message HnswIndexOptionsPB {
   optional uint32 m = 1;
   optional uint32 m0 = 2;
   optional uint32 ef_construction = 3;
   optional HnswBackend backend = 4;
+
+  // Fixed at CREATE INDEX. Chunks record their own encoding, so this only governs chunks
+  // written from now on; keeping it in the catalog is what makes every replica of an index
+  // agree instead of following each tserver's local flags.
+  optional VectorStorageType storage_type = 5 [ default = STORAGE_FLOAT32 ];
 }
 
 message PgVectorIdxOptionsPB {

--- a/src/yb/docdb/doc_vector_index.cc
+++ b/src/yb/docdb/doc_vector_index.cc
@@ -100,6 +100,31 @@ vector_index::DistanceKind ConvertDistanceKind(PgVectorDistanceType dist_type) {
   FATAL_INVALID_ENUM_VALUE(PgVectorDistanceType, dist_type);
 }
 
+vector_index::VectorStorageKind ConvertStorageKind(VectorStorageType storage_type) {
+  switch (storage_type) {
+    case VectorStorageType::STORAGE_FLOAT32:
+      return vector_index::VectorStorageKind::kFloat32;
+    case VectorStorageType::STORAGE_FLOAT16:
+      return vector_index::VectorStorageKind::kFloat16;
+    case VectorStorageType::STORAGE_INT8:
+      return vector_index::VectorStorageKind::kInt8;
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageType, storage_type);
+}
+
+// The rerank tier is implied by the storage type rather than separately configurable: a quantizing
+// traversal encoding is not usable without one.
+vector_index::RerankStorageKind ConvertRerankKind(VectorStorageType storage_type) {
+  switch (storage_type) {
+    case VectorStorageType::STORAGE_FLOAT32: [[fallthrough]];
+    case VectorStorageType::STORAGE_FLOAT16:
+      return vector_index::RerankStorageKind::kNone;
+    case VectorStorageType::STORAGE_INT8:
+      return vector_index::RerankStorageKind::kFloat16;
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageType, storage_type);
+}
+
 vector_index::HNSWOptions ConvertToHnswOptions(const PgVectorIdxOptionsPB& options) {
   return {
     .dimensions = options.dimensions(),
@@ -107,6 +132,8 @@ vector_index::HNSWOptions ConvertToHnswOptions(const PgVectorIdxOptionsPB& optio
     .num_neighbors_per_vertex_base = options.hnsw().m0(),
     .ef_construction = options.hnsw().ef_construction(),
     .distance_kind = ConvertDistanceKind(options.dist_type()),
+    .storage_kind = ConvertStorageKind(options.hnsw().storage_type()),
+    .rerank_kind = ConvertRerankKind(options.hnsw().storage_type()),
   };
 }
 

--- a/src/yb/hnsw/hnsw-test.cc
+++ b/src/yb/hnsw/hnsw-test.cc
@@ -11,12 +11,20 @@
 // under the License.
 //
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <set>
+
 #include "yb/hnsw/hnsw.h"
 #include "yb/hnsw/hnsw_block_cache.h"
 #include "yb/hnsw/vector_index_test_base.h"
 
 #include "yb/rocksdb/cache.h"
 
+#include "yb/util/env.h"
+#include "yb/util/flags.h"
 #include "yb/util/metrics.h"
 #include "yb/util/random_util.h"
 #include "yb/util/size_literals.h"
@@ -25,12 +33,16 @@
 #include "yb/util/tsan_util.h"
 
 #include "yb/vector_index/vector_index_fwd.h"
+#include "yb/vector_index/coordinate_codec.h"
 #include "yb/vector_index/distance.h"
+#include "yb/vector_index/hnsw_options.h"
 #include "yb/vector_index/usearch_include_wrapper_internal.h"
 #include "yb/vector_index/vector_index_if.h"
 
 using namespace std::chrono_literals;
 using namespace yb::size_literals;
+
+DECLARE_uint32(vector_index_rerank_overfetch_factor);
 
 METRIC_DEFINE_entity(table);
 
@@ -199,6 +211,620 @@ TEST_F(YbHnswTest, Cache) {
 
 TEST_F(YbHnswTest, ConcurrentCache) {
   TestRandom(true, 4);
+}
+
+// ------------------------------------------------------------------------------------------------
+// Narrowed coordinate storage
+// ------------------------------------------------------------------------------------------------
+
+using vector_index::RerankStorageKind;
+using vector_index::VectorStorageKind;
+
+namespace {
+
+// Offset of a footer's version byte: MakeFooter writes it first, and the footer's own length is
+// the last 8 bytes of the file.
+Result<uint8_t> ReadFooterVersion(Env& env, const std::string& path) {
+  std::unique_ptr<RandomAccessFile> file;
+  RETURN_NOT_OK(env.NewRandomAccessFile(path, &file));
+  auto file_size = VERIFY_RESULT(file->Size());
+
+  std::array<uint8_t, sizeof(uint64_t)> size_buffer;
+  Slice size_slice;
+  RETURN_NOT_OK(file->Read(
+      file_size - size_buffer.size(), size_buffer.size(), &size_slice, size_buffer.data()));
+  auto footer_size = LittleEndian::Load64(size_slice.data());
+
+  uint8_t version = 0;
+  Slice version_slice;
+  RETURN_NOT_OK(file->Read(file_size - footer_size, 1, &version_slice, &version));
+  return version;
+}
+
+size_t CountCommon(const YbHnsw::SearchResult& lhs, const YbHnsw::SearchResult& rhs) {
+  std::set<vector_index::VectorId> ids;
+  for (const auto& entry : lhs) {
+    ids.insert(entry.vector_id);
+  }
+  size_t result = 0;
+  for (const auto& entry : rhs) {
+    result += ids.contains(entry.vector_id);
+  }
+  return result;
+}
+
+}  // namespace
+
+// Exercises the hnswlib -> YbHnsw import path, which is the one narrowed storage is wired
+// through, at both encodings.
+class YbHnswStorageTest : public VectorIndexTestBase {
+ protected:
+  using HnswlibImpl = HnswlibIndex<YbHnsw::DistanceType>;
+
+  void BuildHnswlibIndex(size_t num_vectors) {
+    space_ = std::make_unique<hnswlib::L2Space>(dimensions_);
+    hnswlib_index_ = std::make_unique<HnswlibImpl>(
+        space_.get(), num_vectors, /* M= */ 16, /* ef_construction= */ 100);
+    vectors_.reserve(num_vectors);
+    ids_.reserve(num_vectors);
+    for (size_t i = 0; i != num_vectors; ++i) {
+      vectors_.push_back(RandomVector());
+      ids_.push_back(vector_index::VectorId::GenerateRandom());
+      hnswlib_index_->addPoint(vectors_.back().data(), ids_.back());
+    }
+  }
+
+  const Vector& VectorForId(const vector_index::VectorId& id) const {
+    auto it = std::find(ids_.begin(), ids_.end(), id);
+    CHECK(it != ids_.end()) << "unknown vector id: " << id;
+    return vectors_[it - ids_.begin()];
+  }
+
+  // Distance the rerank tier is expected to report: the float16 metric over float16 copies of
+  // both sides, which is exactly what MakeResult computes.
+  YbHnsw::DistanceType Float16Distance(const Vector& lhs, const Vector& rhs) const {
+    vector_index::HNSWOptions options;
+    options.dimensions = dimensions_;
+    options.distance_kind = vector_index::DistanceKind::kL2Squared;
+    UsearchMetric metric(
+        options.CreateStoredMetric(dimensions_, VectorStorageKind::kFloat16));
+    const auto bytes = vector_index::CoordinateBytes(VectorStorageKind::kFloat16, dimensions_);
+    std::vector<std::byte> buffer(bytes * 2);
+    vector_index::NarrowCoordinates(
+        VectorStorageKind::kFloat16, lhs.data(), dimensions_, buffer.data());
+    vector_index::NarrowCoordinates(
+        VectorStorageKind::kFloat16, rhs.data(), dimensions_, buffer.data() + bytes);
+    return metric.Distance(buffer.data(), buffer.data() + bytes);
+  }
+
+  // Uses the production metric factory path, so a wrong storage-kind-to-scalar-kind mapping shows
+  // up here rather than only in a full cluster test.
+  YbHnsw::MetricFactory MakeMetricFactory() const {
+    vector_index::HNSWOptions options;
+    options.dimensions = dimensions_;
+    options.distance_kind = vector_index::DistanceKind::kL2Squared;
+    return [options](size_t dimensions, VectorStorageKind storage_kind) {
+      return std::make_unique<UsearchMetric>(
+          options.CreateStoredMetric(dimensions, storage_kind));
+    };
+  }
+
+  // Imports the built graph at `storage_kind`. When `reload` is set the returned instance is a
+  // fresh YbHnsw that only ever saw the file, which is what a tserver restart looks like.
+  Result<std::unique_ptr<YbHnsw>> Import(
+      VectorStorageKind storage_kind, const std::string& name, bool reload = false,
+      RerankStorageKind rerank_kind = RerankStorageKind::kNone) {
+    auto path = GetTestPath(name);
+    auto result = std::make_unique<YbHnsw>(MakeMetricFactory(), block_cache_);
+    RETURN_NOT_OK(result->Import(*hnswlib_index_, path, storage_kind, rerank_kind));
+    if (reload) {
+      result = std::make_unique<YbHnsw>(MakeMetricFactory(), block_cache_);
+      RETURN_NOT_OK(result->Init(path));
+    }
+    return result;
+  }
+
+  // The shipping int8 configuration: quantized traversal coordinates with an fp16 rerank copy.
+  Result<std::unique_ptr<YbHnsw>> ImportInt8(const std::string& name, bool reload = false) {
+    return Import(VectorStorageKind::kInt8, name, reload, RerankStorageKind::kFloat16);
+  }
+
+  vector_index::SearchOptions MakeSearchOptions(size_t max_results, size_t ef = 64) const {
+    return vector_index::SearchOptions {
+      .max_num_results = max_results,
+      .ef = ef,
+      .filter = AcceptAllVectors(),
+    };
+  }
+
+  std::unique_ptr<hnswlib::SpaceInterface<YbHnsw::DistanceType>> space_;
+  std::unique_ptr<HnswlibImpl> hnswlib_index_;
+  std::vector<Vector> vectors_;
+  std::vector<vector_index::VectorId> ids_;
+  YbHnswSearchContext context_;
+};
+
+// A float32 index must keep producing version-1 footers, byte for byte, or every existing
+// deployment's files stop being readable by the release before this one.
+TEST_F(YbHnswStorageTest, Float32KeepsFooterVersionOne) {
+  BuildHnswlibIndex(200);
+
+  ASSERT_OK(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  ASSERT_EQ(ASSERT_RESULT(ReadFooterVersion(*Env::Default(), GetTestPath("f32.yb_hnsw"))), 1);
+
+  ASSERT_OK(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+  ASSERT_EQ(ASSERT_RESULT(ReadFooterVersion(*Env::Default(), GetTestPath("f16.yb_hnsw"))), 2);
+
+  // The rerank tier and the quantization scale are version 3, so adding them must not have
+  // pushed float16 files past what a build with only float16 support can read.
+  ASSERT_OK(ImportInt8("i8.yb_hnsw"));
+  ASSERT_EQ(ASSERT_RESULT(ReadFooterVersion(*Env::Default(), GetTestPath("i8.yb_hnsw"))), 3);
+}
+
+TEST_F(YbHnswStorageTest, HeaderReflectsStorageKind) {
+  BuildHnswlibIndex(200);
+
+  auto f32 = ASSERT_RESULT(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  auto f16 = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+
+  ASSERT_EQ(f32->header().storage_kind, VectorStorageKind::kFloat32);
+  ASSERT_EQ(f16->header().storage_kind, VectorStorageKind::kFloat16);
+  ASSERT_EQ(f32->header().dimensions, dimensions_);
+  ASSERT_EQ(f16->header().dimensions, dimensions_);
+
+  // Only the coordinates shrink; the record header does not.
+  const auto record_overhead = f32->header().vector_data_size - dimensions_ * sizeof(float);
+  ASSERT_EQ(f16->header().vector_data_size, record_overhead + dimensions_ * sizeof(uint16_t));
+
+  // Half-size records mean roughly twice as many fit in a block of the same size.
+  ASSERT_GT(f16->header().vector_data_amount_per_block,
+            f32->header().vector_data_amount_per_block);
+}
+
+// The encoding has to come from the file, not from whatever the caller currently thinks. A stale
+// setting here used to be undetectable: the metric would decode records at the wrong width and
+// return plausible-looking garbage.
+TEST_F(YbHnswStorageTest, InitTakesStorageKindFromTheFile) {
+  BuildHnswlibIndex(200);
+  ASSERT_OK(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+
+  YbHnsw reopened(MakeMetricFactory(), block_cache_);
+  ASSERT_OK(reopened.Init(GetTestPath("f16.yb_hnsw")));
+  ASSERT_EQ(reopened.header().storage_kind, VectorStorageKind::kFloat16);
+
+  // And it still answers correctly, i.e. the metric it built matches the records.
+  auto results = reopened.Search(
+      vectors_.front().data(), MakeSearchOptions(1, /* ef= */ 200), context_);
+  ASSERT_EQ(results.size(), 1);
+  ASSERT_EQ(results.front().distance, 0.0f);
+}
+
+// Writer and query path share one conversion, so an indexed vector used as its own query must
+// come back at distance zero. If they ever diverge, this is the first thing that breaks.
+TEST_F(YbHnswStorageTest, SelfDistanceIsZero) {
+  BuildHnswlibIndex(500);
+
+  for (auto storage_kind :
+       {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16, VectorStorageKind::kInt8}) {
+    // int8 only ever runs with a rerank tier, and the returned distance comes from that tier, so
+    // this covers both conversions agreeing with themselves.
+    auto rerank_kind = storage_kind == VectorStorageKind::kInt8
+        ? RerankStorageKind::kFloat16 : RerankStorageKind::kNone;
+    auto index = ASSERT_RESULT(Import(
+        storage_kind, Format("$0.yb_hnsw", storage_kind), /* reload= */ false, rerank_kind));
+    for (size_t i = 0; i != 20; ++i) {
+      const auto& query = vectors_[i * (vectors_.size() / 20)];
+      // An exact match is the global minimum by a wide margin; a generous ef makes finding it
+      // a certainty, so a failure here means the codec, not the graph walk.
+      auto results = index->Search(query.data(), MakeSearchOptions(1, /* ef= */ 200), context_);
+      ASSERT_EQ(results.size(), 1) << storage_kind;
+      ASSERT_EQ(results.front().distance, 0.0f)
+          << "storage_kind: " << storage_kind << ", vector: " << i;
+    }
+  }
+}
+
+// Narrowing costs some accuracy, and this pins how much. The threshold is deliberately loose:
+// uniform random vectors in low dimensions are a harder case than real embeddings, because
+// neighbours sit at nearly identical distances and reorder easily.
+TEST_F(YbHnswStorageTest, Float16KeepsRecall) {
+  constexpr size_t kNumVectors = 4000;
+  constexpr size_t kNumQueries = 200;
+  constexpr size_t kMaxResults = 10;
+  constexpr double kMinOverlap = 0.9;
+
+  dimensions_ = 64;
+  BuildHnswlibIndex(kNumVectors);
+
+  auto f32 = ASSERT_RESULT(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  auto f16 = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+
+  size_t common = 0;
+  double worst_distance_error = 0;
+  for (size_t i = 0; i != kNumQueries; ++i) {
+    auto query = RandomVector();
+    auto f32_results = f32->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    auto f16_results = f16->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    ASSERT_EQ(f32_results.size(), f16_results.size());
+    common += CountCommon(f32_results, f16_results);
+
+    // Top-1 distances should agree closely even when the identities differ.
+    worst_distance_error = std::max<double>(
+        worst_distance_error,
+        std::fabs(f32_results.front().distance - f16_results.front().distance) /
+            std::max(f32_results.front().distance, 1e-6f));
+  }
+
+  const double overlap = static_cast<double>(common) / (kNumQueries * kMaxResults);
+  LOG(INFO) << "float16 top-" << kMaxResults << " overlap with float32: " << overlap
+            << ", worst relative top-1 distance error: " << worst_distance_error;
+  ASSERT_GE(overlap, kMinOverlap);
+  ASSERT_LE(worst_distance_error, 0.05);
+}
+
+// Compaction reads source chunks back out of the served file, so a reopened index has to survive
+// the same searches. Covers Init() plus the block cache path.
+TEST_F(YbHnswStorageTest, Float16SurvivesReload) {
+  constexpr size_t kMaxResults = 10;
+  dimensions_ = 32;
+  BuildHnswlibIndex(2000);
+
+  auto fresh = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "a.yb_hnsw"));
+  auto reloaded = ASSERT_RESULT(
+      Import(VectorStorageKind::kFloat16, "b.yb_hnsw", /* reload= */ true));
+
+  for (size_t i = 0; i != 100; ++i) {
+    auto query = RandomVector();
+    auto from_fresh = fresh->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    auto from_reloaded = reloaded->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    ASSERT_EQ(from_fresh.size(), from_reloaded.size());
+    for (size_t j = 0; j != from_fresh.size(); ++j) {
+      ASSERT_EQ(AsString(from_fresh[j]), AsString(from_reloaded[j]));
+    }
+  }
+}
+
+// Out-of-range coordinates must not turn into infinities: a single inf coordinate makes every
+// distance to that vector NaN, and NaN comparisons quietly corrupt the search heaps.
+TEST_F(YbHnswStorageTest, OutOfRangeCoordinatesStayFinite) {
+  dimensions_ = 8;
+  space_ = std::make_unique<hnswlib::L2Space>(dimensions_);
+  hnswlib_index_ = std::make_unique<HnswlibImpl>(
+      space_.get(), 64, /* M= */ 16, /* ef_construction= */ 100);
+
+  for (size_t i = 0; i != 32; ++i) {
+    auto vector = RandomVector();
+    if (i % 8 == 0) {
+      // Outside fp16's range but comfortably inside float32's, so the graph is still built from
+      // finite distances and this isolates the clamp rather than testing hnswlib with infinities.
+      vector[i % dimensions_] = 1e6f;
+      vector[(i + 1) % dimensions_] = -1e6f;
+    }
+    vectors_.push_back(vector);
+    hnswlib_index_->addPoint(vector.data(), vector_index::VectorId::GenerateRandom());
+  }
+
+  auto index = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "clamped.yb_hnsw"));
+  for (size_t i = 0; i != 16; ++i) {
+    auto results = index->Search(RandomVector().data(), MakeSearchOptions(10), context_);
+    ASSERT_FALSE(results.empty());
+    for (const auto& entry : results) {
+      ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+    }
+  }
+}
+
+
+// The scale is chunk-local and unrecoverable from anything else in the file, so it has to survive
+// the footer round trip bit for bit -- it is serialized as a bit pattern precisely because a
+// nearly-right scale would decode every record slightly wrong and look like a recall bug.
+TEST_F(YbHnswStorageTest, HeaderRoundTripsScaleAndRerankKind) {
+  BuildHnswlibIndex(200);
+
+  auto fresh = ASSERT_RESULT(ImportInt8("a.yb_hnsw"));
+  auto reloaded = ASSERT_RESULT(ImportInt8("b.yb_hnsw", /* reload= */ true));
+
+  ASSERT_EQ(fresh->header().storage_kind, VectorStorageKind::kInt8);
+  ASSERT_EQ(fresh->header().rerank_kind, RerankStorageKind::kFloat16);
+  ASSERT_GT(fresh->header().quantization_scale, 0.0f);
+
+  ASSERT_EQ(reloaded->header().storage_kind, VectorStorageKind::kInt8);
+  ASSERT_EQ(reloaded->header().rerank_kind, RerankStorageKind::kFloat16);
+  // Exact equality, not a tolerance: the field is serialized as a bit pattern, and a scale that
+  // decodes almost right would make every record slightly wrong and read as a recall bug.
+  ASSERT_EQ(reloaded->header().quantization_scale, fresh->header().quantization_scale);
+
+  // Encodings that do not quantize must not carry a scale, so a stray non-zero value here would
+  // mean the field is being set from something other than the data.
+  auto f16 = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+  ASSERT_EQ(f16->header().rerank_kind, RerankStorageKind::kNone);
+  ASSERT_EQ(f16->header().quantization_scale, 0.0f);
+}
+
+// Both copies live in one record, so vector_data_size is the only stride and the rerank copy is
+// found at a fixed offset inside it. Getting this arithmetic wrong reads the wrong bytes without
+// ever going out of bounds, which is why it is asserted rather than left to the search tests.
+TEST_F(YbHnswStorageTest, RecordLayoutIsInterleaved) {
+  BuildHnswlibIndex(200);
+
+  auto f32 = ASSERT_RESULT(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  auto i8 = ASSERT_RESULT(ImportInt8("i8.yb_hnsw"));
+
+  const auto record_overhead = f32->header().vector_data_size - dimensions_ * sizeof(float);
+  ASSERT_EQ(
+      i8->header().vector_data_size,
+      record_overhead + dimensions_ * sizeof(int8_t) + dimensions_ * sizeof(uint16_t));
+  ASSERT_EQ(i8->header().coordinates_size(), dimensions_ * sizeof(int8_t));
+
+  // 3 bytes per coordinate against float32's 4, so the whole file is smaller even though each
+  // vector is stored twice.
+  ASSERT_LT(i8->header().vector_data_size, f32->header().vector_data_size);
+  ASSERT_LT(
+      ASSERT_RESULT(Env::Default()->GetFileSize(GetTestPath("i8.yb_hnsw"))),
+      ASSERT_RESULT(Env::Default()->GetFileSize(GetTestPath("f32.yb_hnsw"))));
+}
+
+// The point of the design: int8 traversal costs recall, and reranking a modest over-fetch at
+// float16 gets it back. Asserting the un-reranked configuration is measurably worse is not
+// redundant -- without it the test passes just as happily when the rerank tier does nothing,
+// which is what a capped candidate budget produces.
+TEST_F(YbHnswStorageTest, Int8WithRerankMatchesFloat16Recall) {
+  constexpr size_t kNumVectors = 4000;
+  constexpr size_t kNumQueries = 200;
+  constexpr size_t kMaxResults = 10;
+
+  dimensions_ = 64;
+  BuildHnswlibIndex(kNumVectors);
+
+  auto f32 = ASSERT_RESULT(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  auto f16 = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+  auto i8 = ASSERT_RESULT(ImportInt8("i8.yb_hnsw"));
+  auto i8_bare = ASSERT_RESULT(Import(VectorStorageKind::kInt8, "i8_bare.yb_hnsw"));
+
+  std::vector<Vector> queries;
+  for (size_t i = 0; i != kNumQueries; ++i) {
+    queries.push_back(RandomVector());
+  }
+
+  auto measure_overlap = [this, &queries, &f32](YbHnsw& index) {
+    size_t common = 0;
+    for (const auto& query : queries) {
+      auto expected = f32->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+      auto actual = index.Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+      common += CountCommon(expected, actual);
+    }
+    return static_cast<double>(common) / (queries.size() * kMaxResults);
+  };
+
+  const auto f16_overlap = measure_overlap(*f16);
+  const auto i8_overlap = measure_overlap(*i8);
+  const auto bare_overlap = measure_overlap(*i8_bare);
+
+  LOG(INFO) << "top-" << kMaxResults << " overlap with float32: float16 " << f16_overlap
+            << ", int8 + float16 rerank " << i8_overlap << ", int8 alone " << bare_overlap;
+
+  // Reranking cannot beat the encoding it reranks with, so float16's overlap is the ceiling; the
+  // margin absorbs graph non-determinism between the two files. That reranking ran at all is
+  // asserted deterministically below, not by comparing recall.
+  ASSERT_GE(i8_overlap, f16_overlap - 0.02);
+
+  // Deterministic proof the rerank ran: each reported distance must be exactly what the float16
+  // metric gives for that row, since that is what MakeResult computes. The un-reranked index
+  // reports the traversal's quantized distance, larger by 1/scale squared.
+  for (size_t i = 0; i != 20; ++i) {
+    auto query = RandomVector();
+    auto reranked = i8->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    auto quantized = i8_bare->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    ASSERT_EQ(reranked.size(), kMaxResults);
+    ASSERT_EQ(quantized.size(), kMaxResults);
+
+    for (const auto& entry : reranked) {
+      ASSERT_EQ(entry.distance, Float16Distance(query, VectorForId(entry.vector_id)))
+          << "reported distance is not the float16 metric's: " << entry;
+    }
+    // And without a rerank tier it is not, which is what makes the assertion above meaningful.
+    const auto& nearest = quantized.front();
+    ASSERT_NE(nearest.distance, Float16Distance(query, VectorForId(nearest.vector_id)))
+        << "un-reranked search reported a float16 distance: " << nearest;
+  }
+}
+
+// Over-fetching must work when ef <= max_num_results, the case a naive
+// min(max(ef, k), overfetch * k) budget silently breaks: it retains exactly k candidates, so
+// reranking reorders rather than corrects. Size assertions all still pass in that state, so this
+// compares behaviour across over-fetch factors instead.
+TEST_F(YbHnswStorageTest, OverFetchActuallyOverFetches) {
+  constexpr size_t kNumVectors = 4000;
+  constexpr size_t kNumQueries = 100;
+
+  dimensions_ = 64;
+  BuildHnswlibIndex(kNumVectors);
+
+  auto i8 = ASSERT_RESULT(ImportInt8("i8.yb_hnsw"));
+
+  std::vector<Vector> queries;
+  for (size_t i = 0; i != kNumQueries; ++i) {
+    queries.push_back(RandomVector());
+  }
+
+  // ef below, equal to, and above max_num_results, plus the k=1 boundary.
+  for (auto [max_results, ef] : std::initializer_list<std::pair<size_t, size_t>>{
+           {50, 10}, {50, 50}, {10, 64}, {1, 1}, {1, 64}}) {
+    std::vector<std::vector<std::string>> rendered_by_factor;
+    std::vector<double> total_distance_by_factor;
+    for (uint32_t factor : {1, 3}) {
+      google::FlagSaver flag_saver;
+      ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_rerank_overfetch_factor) = factor;
+      std::vector<std::string> rendered;
+      double total_distance = 0;
+      for (const auto& query : queries) {
+        auto actual = i8->Search(query.data(), MakeSearchOptions(max_results, ef), context_);
+        // Over-fetching is internal: the caller still gets exactly what it asked for.
+        ASSERT_EQ(actual.size(), std::min(max_results, kNumVectors))
+            << "max_results: " << max_results << ", ef: " << ef << ", factor: " << factor;
+        for (const auto& entry : actual) {
+          ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+          total_distance += entry.distance;
+        }
+        rendered.push_back(AsString(actual));
+      }
+      rendered_by_factor.push_back(std::move(rendered));
+      total_distance_by_factor.push_back(total_distance);
+    }
+
+    LOG(INFO) << "max_results: " << max_results << ", ef: " << ef
+              << " -- summed distance at factor 1: " << total_distance_by_factor[0]
+              << ", at factor 3: " << total_distance_by_factor[1];
+
+    // Reranking a superset cannot select a worse result, so summed over all queries a larger
+    // retained set must not be farther. Recall is not the assertion: it is not monotone in the
+    // budget, which also moves the traversal's termination bound.
+    ASSERT_LE(total_distance_by_factor[1], total_distance_by_factor[0] * 1.0001)
+        << "retaining more candidates produced farther results: max_results " << max_results
+        << ", ef " << ef;
+
+    // Where the over-fetch pushes the budget past max(ef, k) the search demonstrably does more
+    // work, so the answer has to change somewhere across these queries. Under the capped formula
+    // it would be identical for every one of them, which is the bug.
+    if (3 * max_results > std::max(ef, max_results)) {
+      ASSERT_NE(rendered_by_factor[0], rendered_by_factor[1])
+          << "factor 3 returned exactly what factor 1 did for all " << kNumQueries
+          << " queries, so the candidate budget is not growing: max_results " << max_results
+          << ", ef " << ef;
+    }
+  }
+}
+
+TEST_F(YbHnswStorageTest, Int8SurvivesReload) {
+  constexpr size_t kMaxResults = 10;
+  dimensions_ = 32;
+  BuildHnswlibIndex(2000);
+
+  auto fresh = ASSERT_RESULT(ImportInt8("a.yb_hnsw"));
+  auto reloaded = ASSERT_RESULT(ImportInt8("b.yb_hnsw", /* reload= */ true));
+
+  for (size_t i = 0; i != 100; ++i) {
+    auto query = RandomVector();
+    auto from_fresh = fresh->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    auto from_reloaded = reloaded->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    ASSERT_EQ(from_fresh.size(), from_reloaded.size());
+    for (size_t j = 0; j != from_fresh.size(); ++j) {
+      ASSERT_EQ(AsString(from_fresh[j]), AsString(from_reloaded[j]));
+    }
+  }
+}
+
+// A chunk whose coordinates are all zero would otherwise derive a zero scale, and dividing by it
+// turns every coordinate into an infinity -- which makes every distance NaN rather than failing.
+TEST_F(YbHnswStorageTest, Int8HandlesAnAllZeroChunk) {
+  dimensions_ = 8;
+  space_ = std::make_unique<hnswlib::L2Space>(dimensions_);
+  hnswlib_index_ = std::make_unique<HnswlibImpl>(
+      space_.get(), 64, /* M= */ 16, /* ef_construction= */ 100);
+  for (size_t i = 0; i != 32; ++i) {
+    vectors_.push_back(Vector(dimensions_, 0.0f));
+    hnswlib_index_->addPoint(vectors_.back().data(), vector_index::VectorId::GenerateRandom());
+  }
+
+  auto index = ASSERT_RESULT(ImportInt8("zeros.yb_hnsw"));
+  ASSERT_GT(index->header().quantization_scale, 0.0f);
+
+  auto results = index->Search(vectors_.front().data(), MakeSearchOptions(10), context_);
+  ASSERT_FALSE(results.empty());
+  for (const auto& entry : results) {
+    ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+    ASSERT_EQ(entry.distance, 0.0f) << entry;
+  }
+}
+
+// An infinite coordinate must not set the quantization scale: its reciprocal is zero, which would
+// quantize the whole chunk, well-behaved coordinates included, to zero -- silently destroying the
+// traversal while the reranked distances still look plausible.
+TEST_F(YbHnswStorageTest, Int8ScaleIgnoresNonFiniteCoordinates) {
+  dimensions_ = 8;
+  space_ = std::make_unique<hnswlib::L2Space>(dimensions_);
+  hnswlib_index_ = std::make_unique<HnswlibImpl>(
+      space_.get(), 64, /* M= */ 16, /* ef_construction= */ 100);
+
+  // Every coordinate is well below 4, so the expected scale comes from this and nothing else.
+  float max_finite = 0;
+  for (size_t i = 0; i != 32; ++i) {
+    auto vector = RandomVector();
+    for (auto coordinate : vector) {
+      max_finite = std::max(max_finite, std::fabs(coordinate));
+    }
+    vectors_.push_back(vector);
+    ids_.push_back(vector_index::VectorId::GenerateRandom());
+    hnswlib_index_->addPoint(vectors_.back().data(), ids_.back());
+  }
+
+  // One vector carrying an infinity and a NaN. hnswlib will compute non-finite distances to it
+  // while building, which is fine here: what is under test is the scale the writer derives.
+  auto poisoned = RandomVector();
+  poisoned[0] = std::numeric_limits<float>::infinity();
+  poisoned[1] = -std::numeric_limits<float>::infinity();
+  poisoned[2] = std::numeric_limits<float>::quiet_NaN();
+  vectors_.push_back(poisoned);
+  ids_.push_back(vector_index::VectorId::GenerateRandom());
+  hnswlib_index_->addPoint(vectors_.back().data(), ids_.back());
+
+  auto index = ASSERT_RESULT(ImportInt8("poisoned.yb_hnsw"));
+  const auto scale = index->header().quantization_scale;
+  ASSERT_TRUE(std::isfinite(scale)) << "an infinite coordinate set the scale";
+  ASSERT_GT(scale, 0.0f);
+  // Derived from the finite data alone. Compared against the largest finite magnitude among the
+  // healthy vectors, whose own coordinates are the only ones that should count.
+  ASSERT_LE(std::fabs(scale - max_finite / vector_index::kMaxInt8), 1e-9f)
+      << "scale " << scale << " does not match max finite magnitude " << max_finite;
+
+  // And the healthy vectors still quantize to distinguishable records: each is found at distance
+  // zero from itself, which cannot hold if every coordinate collapsed to the same byte.
+  for (size_t i = 0; i != 10; ++i) {
+    auto results = index->Search(
+        vectors_[i].data(), MakeSearchOptions(1, /* ef= */ 200), context_);
+    ASSERT_EQ(results.size(), 1);
+    ASSERT_EQ(results.front().distance, 0.0f) << "vector " << i;
+  }
+}
+
+// Same clamp hazard as float16, but a different failure: an out-of-range float -> int8_t
+// conversion is undefined behaviour rather than a saturation, so without the clamp the stored
+// byte is whatever the hardware happens to produce.
+TEST_F(YbHnswStorageTest, Int8ClampsOutOfRangeCoordinates) {
+  dimensions_ = 8;
+  space_ = std::make_unique<hnswlib::L2Space>(dimensions_);
+  hnswlib_index_ = std::make_unique<HnswlibImpl>(
+      space_.get(), 64, /* M= */ 16, /* ef_construction= */ 100);
+
+  for (size_t i = 0; i != 32; ++i) {
+    auto vector = RandomVector();
+    // One vector far outside the rest, so the scale it sets leaves every other coordinate in the
+    // bottom few steps of the range -- the outlier case the scale is most sensitive to.
+    if (i == 0) {
+      vector[0] = 1e4f;
+    }
+    vectors_.push_back(vector);
+    hnswlib_index_->addPoint(vector.data(), vector_index::VectorId::GenerateRandom());
+  }
+
+  auto index = ASSERT_RESULT(ImportInt8("outlier.yb_hnsw"));
+  for (size_t i = 0; i != 16; ++i) {
+    auto results = index->Search(RandomVector().data(), MakeSearchOptions(10), context_);
+    ASSERT_FALSE(results.empty());
+    for (const auto& entry : results) {
+      ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+      ASSERT_GE(entry.distance, 0.0f) << entry;
+    }
+  }
+
+  // A query well outside the chunk's range clamps rather than wrapping, and still returns
+  // finite, ordered results.
+  auto far_query = Vector(dimensions_, 1e9f);
+  auto results = index->Search(far_query.data(), MakeSearchOptions(5), context_);
+  ASSERT_FALSE(results.empty());
+  for (const auto& entry : results) {
+    ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+  }
 }
 
 }  // namespace yb::hnsw

--- a/src/yb/hnsw/hnsw.cc
+++ b/src/yb/hnsw/hnsw.cc
@@ -13,6 +13,10 @@
 
 #include "yb/hnsw/hnsw.h"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 #include "usearch/index.hpp"
 
 #include "yb/hnsw/block_writer.h"
@@ -20,11 +24,14 @@
 
 #include "yb/util/cast.h"
 #include "yb/util/env.h"
+#include "yb/util/flag_validators.h"
 #include "yb/util/flags.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/size_literals.h"
+#include "yb/util/status_format.h"
 #include "yb/util/status_log.h"
 
+#include "yb/vector_index/coordinate_codec.h"
 #include "yb/vector_index/vector_index_if.h"
 
 using namespace yb::size_literals;
@@ -34,6 +41,18 @@ DEFINE_RUNTIME_uint64(yb_hnsw_max_block_size, 64_KB,
 
 DEFINE_RUNTIME_bool(yb_hnsw_keep_new_blocks_in_cache, false,
     "Whether to keep new generated blocks in cache after YbHnsw index is built.");
+
+DEFINE_RUNTIME_uint32(vector_index_rerank_overfetch_factor, 2,
+    "Multiplier applied to the requested result count to size the candidate set a vector index "
+    "chunk with a rerank tier rescores at full precision before returning. 1 retains exactly the "
+    "requested count, which makes reranking a no-op. Only affects chunks whose coordinates are "
+    "stored in a lossy encoding.");
+
+// Bounded because the value multiplies the candidates a search explores once it exceeds ef, so a
+// mistyped large value turns every query into a scan. 2 is sufficient in measurement; 3 adds
+// nothing.
+DEFINE_validator(vector_index_rerank_overfetch_factor,
+    FLAG_COND_VALIDATOR(_value >= 1 && _value <= 64, "Must be between 1 and 64"));
 
 #define YB_MISALIGNED_STORE(ptr, type, field, value) \
   MisalignedAssign<decltype(type::field)>(ptr, offsetof(type, field), value)
@@ -64,14 +83,46 @@ class YbHnswIndexAdapter {
 
   virtual int16_t NodeLevel(size_t index) = 0;
   virtual vector_index::VectorId NodeKey(size_t index) = 0;
+  // Writes this node's coordinates into `out` in the encodings MakeHeader() declared -- traversal
+  // first, then the rerank copy if any. Must fill exactly
+  // vector_data_size - sizeof(VectorData) bytes.
   virtual void NodeCoordinates(size_t index, void* out) = 0;
   virtual NeighborsType Neighbors(size_t index, size_t level) = 0;
   virtual NeighborsType NeighborsBase(size_t index) = 0;
+
+  // Coordinates NodeCoordinates() had to clamp. Zero for adapters that do not narrow.
+  virtual size_t NumClampedCoordinates() const { return 0; }
 
   virtual ~YbHnswIndexAdapter() = default;
 };
 
 namespace {
+
+// Coordinate bytes a record holds, across both tiers.
+size_t RecordCoordinateBytes(const Header& header) {
+  return vector_index::CoordinateBytes(header.storage_kind, header.dimensions) +
+         (header.rerank_kind == vector_index::RerankStorageKind::kNone
+              ? 0
+              : vector_index::CoordinateBytes(
+                    vector_index::StorageKindForRerank(header.rerank_kind), header.dimensions));
+}
+
+// Checks a header parsed from a file against itself, before anything reads a record through it.
+// Both failures are otherwise silent: a vector_data_size disagreeing with the encodings reads
+// past every record into the next, and an unusable scale decodes coordinates to zero or infinity
+// -- and an infinite coordinate makes every distance NaN, corrupting the heaps' ordering.
+Status ValidateHeader(const Header& header) {
+  SCHECK_EQ(
+      header.vector_data_size, sizeof(YbHnswVectorData) + RecordCoordinateBytes(header),
+      Corruption, Format("YbHnsw record size disagrees with its encodings: $0", header));
+
+  if (header.storage_kind == vector_index::VectorStorageKind::kInt8) {
+    SCHECK(
+        header.quantization_scale > 0 && std::isfinite(header.quantization_scale), Corruption,
+        Format("YbHnsw int8 chunk has an unusable quantization scale: $0", header));
+  }
+  return Status::OK();
+}
 
 using VectorData = YbHnswVectorData;
 
@@ -117,6 +168,9 @@ class YbHnswBuilder {
 
   Result<std::pair<FileBlockCachePtr, Header>> Build() {
     header_ = inspector_.MakeHeader();
+    // ValidateHeader()'s invariant, on write: a mismatch means the adapter's MakeHeader and
+    // NodeCoordinates disagree about the record layout, producing an unreadable file.
+    DCHECK_EQ(header_.vector_data_size, sizeof(VectorData) + RecordCoordinateBytes(header_));
     PrepareVectors();
     VLOG_WITH_FUNC(4) << "Size: " << inspector_.Size() << ", header: " << header_.ToString();
 
@@ -131,6 +185,11 @@ class YbHnswBuilder {
     RETURN_NOT_OK(out_->Close());
     out_.reset();
     RETURN_NOT_OK(block_cache_.env().RenameFile(tmp_path, path_));
+    LOG_IF(WARNING, inspector_.NumClampedCoordinates() != 0)
+        << "YbHnsw " << path_ << ": clamped " << inspector_.NumClampedCoordinates()
+        << " coordinate(s) that this chunk's encoding cannot represent (storage_kind: "
+        << header_.storage_kind << ", rerank_kind: " << header_.rerank_kind
+        << "); searches involving those vectors will be less accurate";
     std::unique_ptr<RandomAccessFile> file;
     RETURN_NOT_OK(block_cache_.env().NewRandomAccessFile(path_, &file));
     auto file_block_cache = std::make_unique<FileBlockCache>(
@@ -449,25 +508,61 @@ SearchCacheScope::SearchCacheScope(SearchCache& cache, const YbHnsw& hnsw) : cac
   cache.Bind(hnsw.header_, *hnsw.file_block_cache_);
 }
 
-YbHnsw::YbHnsw(MetricPtr&& metric, BlockCachePtr block_cache)
-    : metric_(std::move(metric)), block_cache_(std::move(block_cache)) {
+YbHnsw::YbHnsw(const UsearchMetric::Impl& metric, BlockCachePtr block_cache)
+    : YbHnsw(
+          [metric](size_t, vector_index::VectorStorageKind storage_kind) -> MetricPtr {
+            LOG_IF(DFATAL, storage_kind != vector_index::VectorStorageKind::kFloat32)
+                << "Fixed float32 metric cannot decode " << storage_kind << " records";
+            return std::make_unique<UsearchMetric>(metric);
+          },
+          std::move(block_cache)) {
+}
+
+YbHnsw::YbHnsw(MetricFactory metric_factory, BlockCachePtr block_cache)
+    : metric_factory_(std::move(metric_factory)), block_cache_(std::move(block_cache)) {
 }
 
 YbHnsw::~YbHnsw() = default;
+
+void YbHnsw::InitMetrics() {
+  metric_ = metric_factory_(header_.dimensions, header_.storage_kind);
+  rerank_metric_ = header_.rerank_kind == vector_index::RerankStorageKind::kNone
+      ? nullptr
+      : metric_factory_(
+            header_.dimensions, vector_index::StorageKindForRerank(header_.rerank_kind));
+}
+
+size_t YbHnsw::RerankCandidateCount(size_t max_num_results) const {
+  if (!rerank_metric_) {
+    return max_num_results;
+  }
+  const size_t factor = FLAGS_vector_index_rerank_overfetch_factor;
+  // Saturate rather than wrap: a wrap would silently return the wrong rows, where giving up the
+  // over-fetch only gives up the recall reranking would have recovered.
+  if (max_num_results > std::numeric_limits<size_t>::max() / factor) {
+    return max_num_results;
+  }
+  return max_num_results * factor;
+}
 
 Status YbHnsw::Import(
     const unum::usearch::index_dense_gt<vector_index::VectorId>& index, const std::string& path) {
   YbHnswUsearchIndexAdapter inspector(index);
   YbHnswBuilder builder(inspector, *block_cache_, path);
   std::tie(file_block_cache_, header_) = VERIFY_RESULT(builder.Build());
+  InitMetrics();
   return Status::OK();
 }
 
 class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
  public:
-  explicit YbHnswHnswlibIndexAdapter(
-      std::reference_wrapper<const HnswlibIndex<YbHnsw::DistanceType>> index)
-      : index_(index) {}
+  YbHnswHnswlibIndexAdapter(
+      std::reference_wrapper<const HnswlibIndex<YbHnsw::DistanceType>> index,
+      vector_index::VectorStorageKind storage_kind,
+      vector_index::RerankStorageKind rerank_kind)
+      : index_(index), storage_kind_(storage_kind), rerank_kind_(rerank_kind),
+        dimensions_(index.get().data_size_ / sizeof(YbHnswBuilder::CoordinateType)),
+        quantization_scale_(CalcQuantizationScale()) {}
 
   size_t Size() override {
     return index_.getCurrentElementCount();
@@ -480,8 +575,13 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
   Header MakeHeader() override {
     Header result;
     result.max_block_size = FLAGS_yb_hnsw_max_block_size;
-    result.dimensions = index_.data_size_ / sizeof(YbHnswBuilder::CoordinateType);
-    result.vector_data_size = index_.data_size_ + sizeof(VectorData);
+    result.dimensions = dimensions_;
+    result.storage_kind = storage_kind_;
+    result.rerank_kind = rerank_kind_;
+    result.quantization_scale = quantization_scale_;
+    result.vector_data_size =
+        vector_index::CoordinateBytes(storage_kind_, dimensions_) + RerankBytes() +
+        sizeof(VectorData);
     InitVectorDataAmountPerBlock(result, index_.getCurrentElementCount());
     result.max_level = index_.getMaxLevel();
     result.config.connectivity_base = index_.maxM_;
@@ -502,7 +602,28 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
   }
 
   void NodeCoordinates(size_t index, void* out) override {
-    memcpy(out, index_.getDataByInternalId(CastIndex(index)), index_.data_size_);
+    const auto* coordinates =
+        pointer_cast<const YbHnswBuilder::CoordinateType*>(
+            index_.getDataByInternalId(CastIndex(index)));
+    if (storage_kind_ == vector_index::VectorStorageKind::kFloat32) {
+      memcpy(out, coordinates, index_.data_size_);
+    } else {
+      vector_index::NarrowCoordinates(
+          storage_kind_, quantization_scale_, coordinates, dimensions_, out, &num_clamped_);
+    }
+    if (rerank_kind_ == vector_index::RerankStorageKind::kNone) {
+      return;
+    }
+    // Both copies narrow the same full-precision source, so the rerank copy does not inherit the
+    // traversal copy's error.
+    vector_index::NarrowCoordinates(
+        vector_index::StorageKindForRerank(rerank_kind_), coordinates, dimensions_,
+        static_cast<std::byte*>(out) + vector_index::CoordinateBytes(storage_kind_, dimensions_),
+        &num_clamped_);
+  }
+
+  size_t NumClampedCoordinates() const override {
+    return num_clamped_;
   }
 
   NeighborsType Neighbors(size_t index, size_t level) override {
@@ -525,15 +646,58 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
     return NeighborsType(VectorNoPtr(start), VectorNoPtr(start + size * sizeof(VectorNo)));
   }
 
+  size_t RerankBytes() const {
+    return rerank_kind_ == vector_index::RerankStorageKind::kNone
+        ? 0
+        : vector_index::CoordinateBytes(
+              vector_index::StorageKindForRerank(rerank_kind_), dimensions_);
+  }
+
+  // Symmetric quantization step for the whole chunk, from the largest magnitude it contains.
+  // Scoped to the chunk so it stays a pure function of data already in hand -- no sampling, no
+  // configuration, nothing to recalibrate as the index grows. The extra linear pass is affordable
+  // against a graph build that is not linear.
+  float CalcQuantizationScale() const {
+    if (storage_kind_ != vector_index::VectorStorageKind::kInt8) {
+      return 0;
+    }
+    float max_abs = 0;
+    const auto size = index_.getCurrentElementCount();
+    for (size_t index = 0; index != size; ++index) {
+      const auto* coordinates = pointer_cast<const YbHnswBuilder::CoordinateType*>(
+          index_.getDataByInternalId(CastIndex(index)));
+      for (size_t i = 0; i != dimensions_; ++i) {
+        // Only finite coordinates set the scale: one infinity would make the scale infinite and
+        // quantize the whole chunk, well-behaved coordinates included, to zero. NarrowCoordinates
+        // clamps infinities and maps NaN to zero anyway. NaN fails the comparison for free.
+        const auto magnitude = std::fabs(coordinates[i]);
+        if (std::isfinite(magnitude) && magnitude > max_abs) {
+          max_abs = magnitude;
+        }
+      }
+    }
+    // A zero scale would make every coordinate infinite; any positive scale encodes zeros
+    // exactly, so the fallback value is arbitrary.
+    return max_abs == 0 ? 1.0f : max_abs / vector_index::kMaxInt8;
+  }
+
   const HnswlibIndex<YbHnsw::DistanceType>& index_;
+  const vector_index::VectorStorageKind storage_kind_;
+  const vector_index::RerankStorageKind rerank_kind_;
+  const size_t dimensions_;
+  const float quantization_scale_;
+  size_t num_clamped_ = 0;
 };
 
 Status YbHnsw::Import(
     const HnswlibIndex<DistanceType>& index,
-    const std::string& path) {
-  YbHnswHnswlibIndexAdapter inspector(index);
+    const std::string& path,
+    vector_index::VectorStorageKind storage_kind,
+    vector_index::RerankStorageKind rerank_kind) {
+  YbHnswHnswlibIndexAdapter inspector(index, storage_kind, rerank_kind);
   YbHnswBuilder builder(inspector, *block_cache_, path);
   std::tie(file_block_cache_, header_) = VERIFY_RESULT(builder.Build());
+  InitMetrics();
   return Status::OK();
 }
 
@@ -542,6 +706,8 @@ Status YbHnsw::Init(const std::string& path) {
   RETURN_NOT_OK(block_cache_->env().NewRandomAccessFile(path, &file));
   file_block_cache_ = std::make_unique<FileBlockCache>(*block_cache_, std::move(file));
   header_ = VERIFY_RESULT(file_block_cache_->Load());
+  RETURN_NOT_OK(ValidateHeader(header_));
+  InitMetrics();
   return Status::OK();
 }
 
@@ -557,7 +723,48 @@ YbHnsw::SearchResult YbHnsw::Search(
   return MakeResult(options.max_num_results, context);
 }
 
+YbHnsw::SearchResult YbHnsw::Search(
+    const CoordinateType* query_vector, const vector_index::SearchOptions& options,
+    YbHnswSearchContext& context) const {
+  if (header_.rerank_kind != vector_index::RerankStorageKind::kNone) {
+    auto rerank_kind = vector_index::StorageKindForRerank(header_.rerank_kind);
+    auto& buffer = context.rerank_query;
+    buffer.resize(vector_index::CoordinateBytes(rerank_kind, header_.dimensions));
+    vector_index::NarrowCoordinates(
+        rerank_kind, query_vector, header_.dimensions, buffer.data());
+  }
+  if (header_.storage_kind == vector_index::VectorStorageKind::kFloat32) {
+    return Search(pointer_cast<const std::byte*>(query_vector), options, context);
+  }
+  auto& buffer = context.narrowed_query;
+  buffer.resize(vector_index::CoordinateBytes(header_.storage_kind, header_.dimensions));
+  // Clamped against this chunk's own scale, so a query coordinate outside the range the chunk
+  // contains is clipped. Not counted: that is a property of the query, not of the stored data.
+  vector_index::NarrowCoordinates(
+      header_.storage_kind, header_.quantization_scale, query_vector, header_.dimensions,
+      buffer.data());
+  return Search(buffer.data(), options, context);
+}
+
 YbHnsw::SearchResult YbHnsw::MakeResult(size_t max_results, YbHnswSearchContext& context) const {
+  if (rerank_metric_) {
+    // Distances leave the chunk here, so this is where they must start meaning something outside
+    // it: the traversal ranked in its encoding's units, and rescoring puts them into the metric's
+    // own so VectorLSM can merge across chunks. This breaks context.top's heap invariant, which
+    // is safe only because MakeResult is its last use and SearchInBaseLayer clears it on entry.
+    //
+    // A wrong rerank_query size means the byte-pointer Search overload was called directly on a
+    // file with a rerank tier, which would read past the buffer.
+    DCHECK_EQ(
+        context.rerank_query.size(),
+        vector_index::CoordinateBytes(
+            vector_index::StorageKindForRerank(header_.rerank_kind), header_.dimensions));
+    const auto* query = context.rerank_query.data();
+    for (auto& entry : context.top.data()) {
+      entry.first = rerank_metric_->Distance(
+          query, context.search_cache.RerankCoordinatesPtr(entry.second));
+    }
+  }
   return vector_index::MakeResult<DistanceType>(
       max_results, context.top.data(),
       [&](const auto& entry) {
@@ -611,9 +818,16 @@ void YbHnsw::SearchInBaseLayer(
   // So could use the following as initial capacity for visited.
   visited.reserve(header_.config.connectivity_base + 1u);
 
-  auto top_limit = options.max_num_results;
-  auto extra_top_limit = std::max<size_t>(
-      options.ef, options.max_num_results) - options.max_num_results;
+  // With a rerank tier the search must retain more than the caller asked for, or MakeResult
+  // reranks exactly the entries it would have returned anyway.
+  //
+  // budget takes the max so it never caps top_limit. Capping at max(ef, max_num_results) instead
+  // looks harmless but silently defeats reranking whenever ef <= max_num_results: top_limit
+  // collapses to max_num_results with no extra candidates. Without a rerank tier top_limit is
+  // max_num_results and these reduce to what they were before.
+  auto top_limit = RerankCandidateCount(options.max_num_results);
+  auto budget = std::max({options.ef, options.max_num_results, top_limit});
+  auto extra_top_limit = budget - top_limit;
   next.push({best_dist, best_vector});
   if (!options.filter || options.filter(cache.GetVectorData(best_vector))) {
     top.push({best_dist, best_vector});
@@ -663,23 +877,18 @@ void YbHnsw::SearchInBaseLayer(
 }
 
 YbHnsw::DistanceType YbHnsw::Distance(const std::byte* lhs, const std::byte* rhs) const {
+  DCHECK(metric_) << "Distance requested before Init/Import";
   return metric_->Distance(lhs, rhs);
+}
+
+YbHnsw::DistanceType YbHnsw::RerankDistance(const std::byte* lhs, const std::byte* rhs) const {
+  DCHECK(rerank_metric_) << "RerankDistance requested on a file without a rerank tier";
+  return rerank_metric_->Distance(lhs, rhs);
 }
 
 YbHnsw::DistanceType YbHnsw::Distance(
     const std::byte* lhs, size_t vector, SearchCache& cache) const {
   return Distance(lhs, cache.CoordinatesPtr(vector));
-}
-
-boost::iterator_range<MisalignedPtr<const YbHnsw::CoordinateType>> YbHnsw::MakeCoordinates(
-    const std::byte* ptr) const {
-  auto start = MisalignedPtr<const CoordinateType>(ptr);
-  return boost::make_iterator_range(start, start + header_.dimensions);
-}
-
-boost::iterator_range<MisalignedPtr<const YbHnsw::CoordinateType>> YbHnsw::Coordinates(
-    size_t vector, SearchCache& cache) const {
-  return MakeCoordinates(cache.CoordinatesPtr(vector));
 }
 
 const Header& YbHnsw::header() const {
@@ -775,6 +984,11 @@ vector_index::VectorId SearchCache::GetVectorData(size_t vector) {
 
 const std::byte* SearchCache::CoordinatesPtr(size_t vector) {
   return VectorHeader(vector).raw() + offsetof(VectorData, coordinates);
+}
+
+const std::byte* SearchCache::RerankCoordinatesPtr(size_t vector) {
+  DCHECK(header_->rerank_kind != vector_index::RerankStorageKind::kNone);
+  return CoordinatesPtr(vector) + header_->coordinates_size();
 }
 
 HnswDistanceType UsearchMetric::Distance(

--- a/src/yb/hnsw/hnsw.h
+++ b/src/yb/hnsw/hnsw.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <functional>
 #include <queue>
 
 #include <boost/range/iterator_range.hpp>
@@ -56,6 +57,10 @@ class SearchCache {
       size_t vector);
   vector_index::VectorId GetVectorData(size_t vector);
   const std::byte* CoordinatesPtr(size_t vector);
+
+  // Rerank copy, which follows the traversal coordinates in the same record. Only meaningful
+  // when the bound header has a rerank tier.
+  const std::byte* RerankCoordinatesPtr(size_t vector);
 
  private:
   Slice GetVectorDataSlice(size_t vector);
@@ -105,6 +110,12 @@ struct YbHnswSearchContext {
   ExtraTop extra_top;
   NextQueue next;
   SearchCache search_cache;
+
+  // Query narrowed to the file's storage encoding, then to its rerank encoding. Grown once per
+  // pooled context and reused. Both are live at once on a chunk with a rerank tier, so they
+  // cannot share storage; neither is used when the file stores float32.
+  std::vector<std::byte> narrowed_query;
+  std::vector<std::byte> rerank_query;
 };
 
 class YbHnswMetric {
@@ -133,34 +144,49 @@ class YbHnsw {
   using MetricPtr = std::unique_ptr<Metric>;
   using SearchResult = std::vector<vector_index::VectorWithDistance<DistanceType>>;
 
-  YbHnsw(const UsearchMetric::Impl& metric, BlockCachePtr block_cache)
-      : YbHnsw(std::make_unique<UsearchMetric>(metric), block_cache) {
-  }
+  // Builds the metric for a dimension count and coordinate encoding. The metric decodes stored
+  // records, so it must agree with how they were written: Init() passes the encoding from the
+  // file's own footer, never caller-supplied configuration, which can drift from what the chunk
+  // actually contains.
+  using MetricFactory =
+      std::function<MetricPtr(size_t dimensions, vector_index::VectorStorageKind storage_kind)>;
 
-  YbHnsw(MetricPtr&& metric, BlockCachePtr block_cache);
+  // Convenience constructor for a fixed float32 metric.
+  YbHnsw(const UsearchMetric::Impl& metric, BlockCachePtr block_cache);
+
+  YbHnsw(MetricFactory metric_factory, BlockCachePtr block_cache);
   ~YbHnsw();
 
   // Imports specified index to YbHnsw structure, also storing this structure to disk.
   Status Import(
     const unum::usearch::index_dense_gt<vector_index::VectorId>& index, const std::string& path);
   Status Import(
-    const HnswlibIndex<DistanceType>& index, const std::string& path);
+    const HnswlibIndex<DistanceType>& index, const std::string& path,
+    vector_index::VectorStorageKind storage_kind = vector_index::VectorStorageKind::kFloat32,
+    vector_index::RerankStorageKind rerank_kind = vector_index::RerankStorageKind::kNone);
 
   // Initialize YbHnsw from specified file, using block_cache to cache blocks.
   Status Init(const std::string& path);
 
+  // Searches with a query already in this file's storage encoding. Does not fill
+  // context.rerank_query, so on a file with a rerank tier the caller must have done so.
   SearchResult Search(
       const std::byte* query_vector, const vector_index::SearchOptions& options,
       YbHnswSearchContext& context) const;
 
+  // Narrows the query through the same conversion the stored records went through, then
+  // delegates to the overload above.
   SearchResult Search(
       const CoordinateType* query_vector, const vector_index::SearchOptions& options,
-      YbHnswSearchContext& context) const {
-    return Search(
-        pointer_cast<const std::byte*>(query_vector), options, context);
-  }
+      YbHnswSearchContext& context) const;
 
+  // Distance between two records in this file's storage encoding. Full-precision callers must
+  // narrow first -- see NarrowCoordinates.
   DistanceType Distance(const std::byte* lhs, const std::byte* rhs) const;
+
+  // Distance between two records in this file's rerank encoding, i.e. in true metric units.
+  // Only valid when this file has a rerank tier.
+  DistanceType RerankDistance(const std::byte* lhs, const std::byte* rhs) const;
 
   const Header& header() const;
 
@@ -175,13 +201,20 @@ class YbHnsw {
   SearchResult MakeResult(size_t max_results, YbHnswSearchContext& context) const;
 
   DistanceType Distance(const std::byte* lhs, size_t vector, SearchCache& cache) const;
-  boost::iterator_range<MisalignedPtr<const CoordinateType>> MakeCoordinates(
-      const std::byte* ptr) const;
-  boost::iterator_range<MisalignedPtr<const CoordinateType>> Coordinates(
-      size_t vector, SearchCache& cache) const;
 
-  MetricPtr metric_;
+  // Builds metric_ and rerank_metric_ from header_, which must already be populated.
+  void InitMetrics();
+
+  // Candidates a search must retain so reranking them yields the true top max_num_results.
+  // Equal to max_num_results without a rerank tier, leaving the heap limits unchanged.
+  size_t RerankCandidateCount(size_t max_num_results) const;
+
+  const MetricFactory metric_factory_;
   const BlockCachePtr block_cache_;
+  MetricPtr metric_;
+
+  // Metric over the rerank copy. Null when header_.rerank_kind is kNone.
+  MetricPtr rerank_metric_;
 
   Header header_;
   FileBlockCachePtr file_block_cache_;

--- a/src/yb/hnsw/hnsw_block_cache.cc
+++ b/src/yb/hnsw/hnsw_block_cache.cc
@@ -13,12 +13,16 @@
 
 #include "yb/hnsw/hnsw_block_cache.h"
 
+#include <cstring>
+#include <type_traits>
+
 #include <boost/intrusive/list.hpp>
 
 #include "yb/hnsw/block_writer.h"
 #include "yb/rocksdb/cache.h"
 
 #include "yb/util/crc.h"
+#include "yb/util/format.h"
 #include "yb/util/metrics.h"
 #include "yb/util/size_literals.h"
 #include "yb/util/unique_lock.h"
@@ -63,6 +67,28 @@ namespace yb::hnsw {
 
 namespace {
 
+// Version 1: original layout.
+// Version 2: appends Header::storage_kind.
+// Version 3: appends Header::rerank_kind and Header::quantization_scale.
+//
+// The writer picks the lowest version that can represent the header, so a float32 index still
+// produces a byte-identical version-1 file readable by binaries that predate narrowed storage.
+// Version-2 and -3 files are not, so enabling either is a one-way step for the chunks written
+// while it is on.
+constexpr uint8_t kSerializationVersionV1 = 1;
+constexpr uint8_t kSerializationVersionV2 = 2;
+constexpr uint8_t kSerializationVersionV3 = 3;
+constexpr uint8_t kMaxSupportedSerializationVersion = kSerializationVersionV3;
+
+uint8_t SerializationVersionFor(const Header& header) {
+  if (header.rerank_kind != vector_index::RerankStorageKind::kNone ||
+      header.storage_kind == vector_index::VectorStorageKind::kInt8) {
+    return kSerializationVersionV3;
+  }
+  return header.storage_kind == vector_index::VectorStorageKind::kFloat32
+      ? kSerializationVersionV1 : kSerializationVersionV2;
+}
+
 template <class Type, class Value, class Writer>
 concept HasAppend = requires(Writer& writer) {
   writer.template Append<Type>(std::declval<Value>());
@@ -74,9 +100,27 @@ concept HasRead = requires(Reader& reader) {
 };
 
 template <class Type, class Value, class Writer>
-requires(HasAppend<Type, Value, Writer>)
+requires(!std::is_enum_v<Value> && HasAppend<Type, Value, Writer>)
 void ConvertField(const Value& value, Writer& writer) {
   writer.template Append<Type>(value);
+}
+
+// Scoped enums do not convert implicitly, so they need their own overloads to serialize as
+// their underlying integer.
+template <class Type, class Value, class Writer>
+requires(std::is_enum_v<Value> && HasAppend<Type, Type, Writer>)
+void ConvertField(const Value& value, Writer& writer) {
+  writer.template Append<Type>(static_cast<Type>(value));
+}
+
+// Floats go out as their bit pattern, keeping the on-disk form fixed-width and BlockWriter/
+// BlockReader dealing only in integers.
+template <class Writer>
+requires(HasAppend<uint32_t, uint32_t, Writer>)
+void ConvertFloatField(const float& value, Writer& writer) {
+  uint32_t bits;
+  memcpy(&bits, &value, sizeof(bits));
+  writer.template Append<uint32_t>(bits);
 }
 
 template <class Converter, class Type>
@@ -100,9 +144,22 @@ void ConvertVector(size_t version, const Vector& vector, Writer& writer) {
 }
 
 template <class Type, class Value, class Reader>
-requires(HasRead<Type, Reader>)
+requires(!std::is_enum_v<Value> && HasRead<Type, Reader>)
 void ConvertField(Value& value, Reader& reader) {
   value = reader.template Read<Type>();
+}
+
+template <class Type, class Value, class Reader>
+requires(std::is_enum_v<Value> && HasRead<Type, Reader>)
+void ConvertField(Value& value, Reader& reader) {
+  value = static_cast<Value>(reader.template Read<Type>());
+}
+
+template <class Reader>
+requires(HasRead<uint32_t, Reader>)
+void ConvertFloatField(float& value, Reader& reader) {
+  auto bits = reader.template Read<uint32_t>();
+  memcpy(&value, &bits, sizeof(value));
 }
 
 template <class Vector, class Reader>
@@ -133,6 +190,15 @@ void Convert(size_t version, RefForConverter<Converter, Header> header, Converte
   ConvertField<uint64_t>(header.vector_data_block, serializer);
   ConvertField<uint64_t>(header.vector_data_amount_per_block, serializer);
   ConvertVector(version, header.layers, serializer);
+  if (version >= kSerializationVersionV2) {
+    ConvertField<uint8_t>(header.storage_kind, serializer);
+  }
+  if (version >= kSerializationVersionV3) {
+    ConvertField<uint8_t>(header.rerank_kind, serializer);
+    ConvertFloatField(header.quantization_scale, serializer);
+  }
+  // Anything appended here must be consumed by this function: FileBlockCache::Load derives the
+  // block count from the bytes the header converter leaves behind.
 }
 
 class WriteCounter {
@@ -150,16 +216,14 @@ class WriteCounter {
   size_t value_ = 0;
 };
 
-constexpr size_t kSerializationVersion = 1;
-
 template <class Out, class... Args>
-void Serialize(const Out& out, Args&&... args) {
-  Convert(kSerializationVersion, out, std::forward<Args&&>(args)...);
+void Serialize(uint8_t version, const Out& out, Args&&... args) {
+  Convert(version, out, std::forward<Args&&>(args)...);
 }
 
-size_t SerializedSize(const Header& header) {
+size_t SerializedSize(uint8_t version, const Header& header) {
   WriteCounter counter;
-  Convert(kSerializationVersion, header, counter);
+  Convert(version, header, counter);
   return counter.value();
 }
 
@@ -333,14 +397,15 @@ struct CachedBlock {
 };
 
 DataBlock FileBlockCacheBuilder::MakeFooter(const Header& header) const {
+  const auto version = SerializationVersionFor(header);
   DataBlock buffer(
     sizeof(uint8_t) +
-    SerializedSize(header) + sizeof(uint64_t) * blocks_.size() +
+    SerializedSize(version, header) + sizeof(uint64_t) * blocks_.size() +
     sizeof(uint32_t) + // CRC32
     sizeof(uint64_t)); // Size
   BlockWriter writer(buffer);
-  writer.Append<uint8_t>(kSerializationVersion);
-  Serialize(header, writer);
+  writer.Append<uint8_t>(version);
+  Serialize(version, header, writer);
   uint64_t sum = 0;
   for (const auto& block : blocks_) {
     sum += block.size;
@@ -409,7 +474,12 @@ Result<Header> FileBlockCache::Load() {
   RSTATUS_DCHECK_EQ(expected_crc, found_crc, Corruption, "Wrong footer CRC");
   Header header;
   SliceReader reader(footer_data);
-  size_t version = reader.Read<uint8_t>();
+  // Without this an unknown version is read and ignored, and the extra header fields it carries
+  // are consumed as block offsets.
+  auto version = reader.Read<uint8_t>();
+  SCHECK_LE(
+      version, kMaxSupportedSerializationVersion, Corruption,
+      Format("Unsupported YbHnsw serialization version: $0", version));
   Deserialize(version, header, reader);
   AllocateBlocks(reader.Left() / sizeof(uint64_t));
   size_t prev_end = 0;

--- a/src/yb/hnsw/types.h
+++ b/src/yb/hnsw/types.h
@@ -18,7 +18,9 @@
 #include "yb/util/logging.h"
 #include "yb/util/tostring.h"
 
+#include "yb/vector_index/coordinate_codec.h"
 #include "yb/vector_index/vector_index_fwd.h"
+#include "yb/vector_index/vector_storage_kind.h"
 
 namespace hnswlib {
 
@@ -80,10 +82,29 @@ struct Header {
   size_t vector_data_amount_per_block;
   std::vector<LayerInfo> layers;
 
+  // Coordinate encoding the graph traversal computes distances on, stored first in each vector
+  // data record. Absent from version-1 footers, which are always float32.
+  vector_index::VectorStorageKind storage_kind = vector_index::VectorStorageKind::kFloat32;
+
+  // Encoding of the rerank copy, stored right after the traversal coordinates in the same
+  // record. kNone means no second copy and traversal distances are returned as-is. Absent
+  // from footers before version 3.
+  vector_index::RerankStorageKind rerank_kind = vector_index::RerankStorageKind::kNone;
+
+  // Quantization step for kInt8 traversal coordinates: stored = round(coordinate / scale).
+  // Derived per chunk, so it must be read from the file and never recomputed. Zero otherwise.
+  float quantization_scale = 0;
+
+  // Bytes the traversal metric reads from a record, i.e. the offset of the rerank copy in it.
+  size_t coordinates_size() const {
+    return vector_index::CoordinateBytes(storage_kind, dimensions);
+  }
+
   std::string ToString() const {
     return YB_STRUCT_TO_STRING(
         dimensions, vector_data_size, entry, max_level, config, max_block_size,
-        max_vectors_per_non_base_block, vector_data_block, vector_data_amount_per_block, layers);
+        max_vectors_per_non_base_block, vector_data_block, vector_data_amount_per_block, layers,
+        storage_kind, rerank_kind, quantization_scale);
   }
 };
 

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -640,6 +640,27 @@ DEFINE_validator(vector_index_backend,
 TAG_FLAG(vector_index_backend, hidden);
 TAG_FLAG(vector_index_backend, advanced);
 
+static constexpr char kVectorStorageFloat32[] = "float32";
+static constexpr char kVectorStorageFloat16[] = "float16";
+static constexpr char kVectorStorageInt8[] = "int8";
+
+DEFINE_RUNTIME_string(vector_index_storage_coordinate_type, kVectorStorageFloat32,
+    "Coordinate encoding for the on-disk chunks of newly created vector indexes. \"float32\" "
+    "stores full precision. \"float16\" halves the coordinate bytes of every served chunk, so "
+    "roughly twice as much of the index fits in the block cache, at a small recall cost. "
+    "\"int8\" quarters the bytes a distance evaluation touches and stores a float16 rerank copy "
+    "alongside, which makes the whole record 0.75x float32 -- so it trades disk against search "
+    "cost in the other direction from \"float16\" and suits an index that already fits in the "
+    "block cache. The graph is built at full precision in every case. Recorded per index at "
+    "creation time, so it never changes for an existing index, and chunks written as anything "
+    "other than float32 cannot be read by releases that predate the encoding.");
+
+DEFINE_validator(vector_index_storage_coordinate_type,
+    FLAG_IN_SET_VALIDATOR(
+        kVectorStorageFloat32, kVectorStorageFloat16, kVectorStorageInt8));
+
+TAG_FLAG(vector_index_storage_coordinate_type, advanced);
+
 DEFINE_RUNTIME_AUTO_bool(enable_table_owned_vector_reverse_mapping, kExternal, false, true,
     "When true, newly created YSQL tables hold vector reverse mapping ownership. "
     "Such tables write vector reverse mappings on row insert/update regardless of "
@@ -4683,6 +4704,14 @@ Status CatalogManager::CreateTable(const CreateTableRequestPB* orig_req,
         vector_index_options.mutable_hnsw()->set_backend(HnswBackend::YB_HNSW_USEARCH);
       } else if (backend == kYbHnswHnswlib) {
         vector_index_options.mutable_hnsw()->set_backend(HnswBackend::YB_HNSW_HNSWLIB);
+      }
+      // Copied, not referenced: the flag is runtime-settable, so holding a reference to its
+      // std::string races with a concurrent set. The backend flag above is read the same way.
+      const auto storage_type = FLAGS_vector_index_storage_coordinate_type;
+      if (storage_type == kVectorStorageFloat16) {
+        vector_index_options.mutable_hnsw()->set_storage_type(VectorStorageType::STORAGE_FLOAT16);
+      } else if (storage_type == kVectorStorageInt8) {
+        vector_index_options.mutable_hnsw()->set_storage_type(VectorStorageType::STORAGE_INT8);
       }
     } else if (!is_pg_table) {
       DCHECK_EQ(index_info.columns().size(), schema.num_columns())
@@ -14246,12 +14275,6 @@ void CatalogManager::SchedulePostTabletCreationTasks(
 Status CatalogManager::PromoteTableToRunningState(
     TableInfoPtr table_info, const LeaderEpoch& epoch) {
   auto l = table_info->LockForWrite();
-  if (l->pb.state() == SysTablesEntryPB::RUNNING) {
-    // Another AddTableToTablet task generation already promoted the table: the catalog loader
-    // re-sends the RPCs on every sys catalog reload (master failover, PITR restore) while the
-    // table is PREPARING, so multiple generations can complete.
-    return Status::OK();
-  }
   SCHECK(
       l.mutable_data()->IsPreparing(), IllegalState,
       "Table $0 should be in PREPARING state. Current state: $1", table_info->ToString(),

--- a/src/yb/vector_index/CMakeLists.txt
+++ b/src/yb/vector_index/CMakeLists.txt
@@ -29,6 +29,7 @@ ADD_YB_LIBRARY(vector_index_proto
 set(VECTOR_INDEX_SRCS
   ann_validation.cc
   benchmark_data.cc
+  coordinate_codec.cc
   hnsw_options.cc
   hnsw_util.cc
   index_wrapper_base.cc
@@ -36,6 +37,7 @@ set(VECTOR_INDEX_SRCS
   vector_lsm.cc
   vector_lsm_metadata.cc
   vector_lsm_metrics.cc
+  vector_storage_kind.cc
   )
 
 set(VECTOR_INDEX_LIBS
@@ -57,4 +59,5 @@ add_dependencies(
 set(YB_TEST_LINK_LIBS
     vector_index yb_common_test_util ${YB_MIN_TEST_LIBS})
 
+ADD_YB_TEST(coordinate_codec-test)
 ADD_YB_TEST(hnsw_util-test)

--- a/src/yb/vector_index/coordinate_codec-test.cc
+++ b/src/yb/vector_index/coordinate_codec-test.cc
@@ -1,0 +1,356 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include <cmath>
+#include <limits>
+#include <random>
+#include <vector>
+
+#include "yb/vector_index/coordinate_codec.h"
+
+#include "yb/util/logging.h"
+#include "yb/util/test_util.h"
+
+namespace yb::vector_index {
+
+namespace {
+
+std::vector<std::byte> Narrow(
+    VectorStorageKind kind, const std::vector<float>& in, size_t* clamped = nullptr) {
+  std::vector<std::byte> out(CoordinateBytes(kind, in.size()));
+  NarrowCoordinates(kind, in.data(), in.size(), out.data(), clamped);
+  return out;
+}
+
+std::vector<float> Widen(VectorStorageKind kind, const std::vector<std::byte>& in, size_t dims) {
+  std::vector<float> out(dims);
+  WidenCoordinates(kind, in.data(), dims, out.data());
+  return out;
+}
+
+std::vector<std::byte> Narrow(
+    VectorStorageKind kind, float scale, const std::vector<float>& in,
+    size_t* clamped = nullptr) {
+  std::vector<std::byte> out(CoordinateBytes(kind, in.size()));
+  NarrowCoordinates(kind, scale, in.data(), in.size(), out.data(), clamped);
+  return out;
+}
+
+std::vector<float> Widen(
+    VectorStorageKind kind, float scale, const std::vector<std::byte>& in, size_t dims) {
+  std::vector<float> out(dims);
+  WidenCoordinates(kind, scale, in.data(), dims, out.data());
+  return out;
+}
+
+std::vector<float> RandomVector(size_t dimensions) {
+  std::mt19937_64 rng(42);
+  std::uniform_real_distribution<float> dis(-1.0f, 1.0f);
+  std::vector<float> result(dimensions);
+  for (auto& value : result) {
+    value = dis(rng);
+  }
+  return result;
+}
+
+}  // namespace
+
+class CoordinateCodecTest : public YBTest {
+};
+
+TEST_F(CoordinateCodecTest, SizesMatchScalarWidths) {
+  for (size_t dims : {1, 8, 128, 384, 768, 1536}) {
+    ASSERT_EQ(CoordinateBytes(VectorStorageKind::kFloat32, dims), dims * 4);
+    ASSERT_EQ(CoordinateBytes(VectorStorageKind::kFloat16, dims), dims * 2);
+  }
+}
+
+TEST_F(CoordinateCodecTest, Float32IsIdentity) {
+  std::vector<float> in{-1.5f, 0.0f, 3.25f, 1e20f, -1e-20f};
+  auto widened = Widen(VectorStorageKind::kFloat32, Narrow(VectorStorageKind::kFloat32, in),
+                       in.size());
+  ASSERT_EQ(in, widened);
+}
+
+// Repeated compaction reads chunks back through WidenCoordinates and writes them out through
+// NarrowCoordinates again. If that were not idempotent, precision would drift a little on every
+// compaction until the index no longer resembled the vectors it was built from.
+TEST_F(CoordinateCodecTest, NarrowingIsIdempotent) {
+  constexpr size_t kDims = 4096;
+  std::vector<float> in(kDims);
+  for (size_t i = 0; i != kDims; ++i) {
+    // Sweep sign and eleven orders of magnitude, including the subnormal range.
+    in[i] = static_cast<float>(
+        std::sin(static_cast<double>(i) * 0.37) * std::pow(10.0, (i % 11) - 6));
+  }
+
+  auto once = Narrow(VectorStorageKind::kFloat16, in);
+  auto twice = Narrow(
+      VectorStorageKind::kFloat16, Widen(VectorStorageKind::kFloat16, once, kDims));
+  ASSERT_EQ(once, twice);
+}
+
+// The writer and the query path share this function precisely so that a vector is still at
+// distance zero from itself after narrowing.
+TEST_F(CoordinateCodecTest, SameInputNarrowsToSameBytes) {
+  auto in = RandomVector(1536);
+  ASSERT_EQ(Narrow(VectorStorageKind::kFloat16, in), Narrow(VectorStorageKind::kFloat16, in));
+}
+
+// Two separate bounds, because only the first one is a relative bound. Coordinates below fp16's
+// smallest normal lose relative precision entirely, but their absolute error stays tiny, which
+// is all a squared distance is sensitive to.
+TEST_F(CoordinateCodecTest, Float16ErrorBounds) {
+  constexpr size_t kSamples = 20000;
+  constexpr float kRelativeBound = 4.883e-4f;  // 2^-11
+  constexpr float kAbsoluteBound = 3e-8f;
+  constexpr float kMinNormal = 6.103515625e-05f;  // fp16's smallest normal, the sweep boundary
+
+  double worst_relative = 0;
+  for (size_t i = 0; i <= kSamples; ++i) {
+    const float value = static_cast<float>(
+        kMinNormal * std::pow(6.5e4 / kMinNormal,
+                                     static_cast<double>(i) / kSamples));
+    const auto back = Widen(
+        VectorStorageKind::kFloat16, Narrow(VectorStorageKind::kFloat16, {value}), 1)[0];
+    worst_relative = std::max<double>(worst_relative, std::fabs((back - value) / value));
+  }
+  ASSERT_LE(worst_relative, kRelativeBound) << "relative error over fp16 normals";
+
+  double worst_absolute = 0;
+  for (size_t i = 0; i <= kSamples; ++i) {
+    const float value = static_cast<float>(
+        1e-10 * std::pow(kMinNormal / 1e-10, static_cast<double>(i) / kSamples));
+    const auto back = Widen(
+        VectorStorageKind::kFloat16, Narrow(VectorStorageKind::kFloat16, {value}), 1)[0];
+    worst_absolute = std::max<double>(worst_absolute, std::fabs(back - value));
+  }
+  ASSERT_LE(worst_absolute, kAbsoluteBound) << "absolute error below fp16's smallest normal";
+}
+
+// Without clamping, fp16_ieee_from_fp32_value saturates to infinity, and inf - inf makes every
+// distance to the vector NaN -- which corrupts the ordering of the search heaps silently rather
+// than failing. Same for a NaN coordinate arriving from the table.
+TEST_F(CoordinateCodecTest, ClampsValuesOutsideFloat16Range) {
+  const std::vector<float> in{1e30f, -1e30f, std::numeric_limits<float>::quiet_NaN(),
+                              kMaxFloat16, 65520.0f, 1.0f};
+  size_t clamped = 0;
+  auto back = Widen(
+      VectorStorageKind::kFloat16, Narrow(VectorStorageKind::kFloat16, in, &clamped), in.size());
+
+  for (size_t i = 0; i != back.size(); ++i) {
+    ASSERT_TRUE(std::isfinite(back[i])) << "coordinate " << i << " = " << back[i];
+  }
+  ASSERT_EQ(back[0], kMaxFloat16);
+  ASSERT_EQ(back[1], -kMaxFloat16);
+  ASSERT_EQ(back[2], 0.0f);
+  ASSERT_EQ(back[3], kMaxFloat16);
+  ASSERT_EQ(back[4], kMaxFloat16);
+  ASSERT_EQ(back[5], 1.0f);
+
+  // 1e30, -1e30, NaN and 65520 are all outside the representable range; 65504 and 1.0 are not.
+  ASSERT_EQ(clamped, size_t{4});
+
+  size_t none = 0;
+  Narrow(VectorStorageKind::kFloat16, {0.0f, 1.0f, -1.0f, kMaxFloat16}, &none);
+  ASSERT_EQ(none, size_t{0});
+}
+
+// The clamp counter accumulates so a caller can total it across a whole index build.
+TEST_F(CoordinateCodecTest, ClampCounterAccumulates) {
+  size_t clamped = 0;
+  Narrow(VectorStorageKind::kFloat16, {1e30f}, &clamped);
+  Narrow(VectorStorageKind::kFloat16, {1e30f, 1e30f}, &clamped);
+  ASSERT_EQ(clamped, size_t{3});
+}
+
+// Coordinates land at unaligned offsets inside a YbHnsw record (20 bytes in, with a stride that
+// is not a multiple of 4), so neither side of the codec may assume alignment.
+TEST_F(CoordinateCodecTest, HandlesUnalignedBuffers) {
+  constexpr size_t kDims = 37;
+  auto in = RandomVector(kDims);
+
+  constexpr float kScale = 0.01f;
+
+  for (size_t offset = 0; offset != 4; ++offset) {
+    for (auto kind : {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16,
+                      VectorStorageKind::kInt8}) {
+      std::vector<std::byte> buffer(CoordinateBytes(kind, kDims) + offset);
+      NarrowCoordinates(kind, kScale, in.data(), kDims, buffer.data() + offset);
+
+      std::vector<float> back(kDims);
+      WidenCoordinates(kind, kScale, buffer.data() + offset, kDims, back.data());
+
+      auto aligned = Widen(kind, kScale, Narrow(kind, kScale, in), kDims);
+      ASSERT_EQ(aligned, back) << "kind: " << kind << ", offset: " << offset;
+    }
+  }
+}
+
+
+TEST_F(CoordinateCodecTest, Int8SizeMatchesScalarWidth) {
+  ASSERT_EQ(CoordinateBytes(VectorStorageKind::kInt8, 768), size_t{768});
+  ASSERT_EQ(CoordinateBytes(VectorStorageKind::kInt8, 0), size_t{0});
+}
+
+// Everything else in the design rests on this: a value that has been through the codec once must
+// re-encode to the same bytes, or repeated compaction walks a vector away from where it started.
+TEST_F(CoordinateCodecTest, Int8NarrowingIsIdempotent) {
+  constexpr size_t kDims = 97;
+  constexpr float kScale = 0.003f;
+  auto in = RandomVector(kDims);
+
+  auto once = Narrow(VectorStorageKind::kInt8, kScale, in);
+  auto widened = Widen(VectorStorageKind::kInt8, kScale, once, kDims);
+  auto twice = Narrow(VectorStorageKind::kInt8, kScale, widened);
+  ASSERT_EQ(once, twice);
+
+  auto widened_again = Widen(VectorStorageKind::kInt8, kScale, twice, kDims);
+  ASSERT_EQ(widened, widened_again);
+}
+
+// The writer and the query path both come through here, so the same input has to produce the same
+// bytes -- otherwise an indexed vector stops being at distance zero from itself.
+TEST_F(CoordinateCodecTest, Int8SameInputNarrowsToSameBytes) {
+  constexpr size_t kDims = 64;
+  constexpr float kScale = 0.007f;
+  auto in = RandomVector(kDims);
+  ASSERT_EQ(
+      Narrow(VectorStorageKind::kInt8, kScale, in),
+      Narrow(VectorStorageKind::kInt8, kScale, in));
+}
+
+// int8's guarantee is absolute, not relative: within half a quantization step everywhere in
+// range. That is the opposite shape from float16, whose bound is relative and collapses for
+// subnormals, and it is why the two encodings suit different jobs.
+TEST_F(CoordinateCodecTest, Int8ErrorIsWithinHalfAStep) {
+  constexpr size_t kDims = 512;
+  constexpr float kScale = 0.002f;
+
+  auto in = RandomVector(kDims);
+  // Include the exact boundaries and a value far below the step size.
+  in[0] = 0.0f;
+  in[1] = kScale;
+  in[2] = -kScale;
+  in[3] = kScale / 2;
+  in[4] = kScale * 126.5f;
+  in[5] = 1e-30f;
+
+  auto back = Widen(
+      VectorStorageKind::kInt8, kScale, Narrow(VectorStorageKind::kInt8, kScale, in), kDims);
+
+  float worst = 0;
+  for (size_t i = 0; i != kDims; ++i) {
+    worst = std::max(worst, std::fabs(back[i] - in[i]));
+  }
+  LOG(INFO) << "worst absolute int8 error: " << worst << ", half a step: " << kScale / 2;
+  ASSERT_LE(worst, kScale / 2 * 1.0001f);
+
+  // Zero is exact at any scale, which is what makes an all-zero vector's self-distance zero.
+  ASSERT_EQ(back[0], 0.0f);
+  ASSERT_EQ(back[1], kScale);
+  ASSERT_EQ(back[2], -kScale);
+}
+
+// float16 saturates an out-of-range magnitude to infinity; an out-of-range float -> int8_t
+// conversion is undefined behaviour instead. So the clamp here is not just protecting accuracy,
+// it is the only thing keeping the stored byte meaningful at all.
+TEST_F(CoordinateCodecTest, Int8ClampsValuesOutsideRange) {
+  constexpr float kScale = 0.01f;
+  size_t clamped = 0;
+  std::vector<float> in = {
+      0.0f,                      // exact
+      kScale * 127,              // the largest in-range value
+      -kScale * 127,             // and its negation
+      kScale * 128,              // one step past
+      1e9f,                      // far past
+      -1e9f,
+      std::numeric_limits<float>::quiet_NaN(),
+  };
+  auto out = Narrow(VectorStorageKind::kInt8, kScale, in, &clamped);
+  const auto* bytes = reinterpret_cast<const int8_t*>(out.data());
+
+  ASSERT_EQ(bytes[0], 0);
+  ASSERT_EQ(bytes[1], 127);
+  ASSERT_EQ(bytes[2], -127);
+  ASSERT_EQ(bytes[3], 127);
+  ASSERT_EQ(bytes[4], 127);
+  ASSERT_EQ(bytes[5], -127);
+  // NaN becomes zero rather than an arbitrary byte.
+  ASSERT_EQ(bytes[6], 0);
+
+  // kScale * 128, +-1e9 and NaN are out of range; 0 and +-kScale * 127 are not.
+  ASSERT_EQ(clamped, size_t{4});
+
+  // Every byte is a valid int8, which is the undefined behaviour the clamp prevents.
+  for (size_t i = 0; i != in.size(); ++i) {
+    ASSERT_GE(bytes[i], -127) << "index " << i;
+    ASSERT_LE(bytes[i], 127) << "index " << i;
+  }
+}
+
+TEST_F(CoordinateCodecTest, Int8ClampCounterAccumulates) {
+  constexpr float kScale = 0.01f;
+  size_t clamped = 0;
+  Narrow(VectorStorageKind::kInt8, kScale, {1e9f}, &clamped);
+  Narrow(VectorStorageKind::kInt8, kScale, {1e9f, -1e9f}, &clamped);
+  ASSERT_EQ(clamped, size_t{3});
+}
+
+// The two encodings sit back to back in one record, so writing the second must not disturb the
+// first and reading either must not stray into the other.
+TEST_F(CoordinateCodecTest, InterleavedEncodingsDoNotOverlap) {
+  constexpr size_t kDims = 97;
+  constexpr float kScale = 0.003f;
+  constexpr size_t kRecordHeader = 20;   // sizeof(YbHnswVectorData)
+  auto in = RandomVector(kDims);
+
+  const auto traversal_bytes = CoordinateBytes(VectorStorageKind::kInt8, kDims);
+  const auto rerank_bytes = CoordinateBytes(VectorStorageKind::kFloat16, kDims);
+  std::vector<std::byte> record(kRecordHeader + traversal_bytes + rerank_bytes);
+
+  NarrowCoordinates(
+      VectorStorageKind::kInt8, kScale, in.data(), kDims, record.data() + kRecordHeader);
+  NarrowCoordinates(
+      VectorStorageKind::kFloat16, in.data(), kDims,
+      record.data() + kRecordHeader + traversal_bytes);
+
+  std::vector<float> traversal(kDims), rerank(kDims);
+  WidenCoordinates(
+      VectorStorageKind::kInt8, kScale, record.data() + kRecordHeader, kDims, traversal.data());
+  WidenCoordinates(
+      VectorStorageKind::kFloat16, record.data() + kRecordHeader + traversal_bytes, kDims,
+      rerank.data());
+
+  ASSERT_EQ(traversal, Widen(
+      VectorStorageKind::kInt8, kScale, Narrow(VectorStorageKind::kInt8, kScale, in), kDims));
+  ASSERT_EQ(rerank, Widen(
+      VectorStorageKind::kFloat16, Narrow(VectorStorageKind::kFloat16, in), kDims));
+
+  // The rerank copy has to be materially closer to the original, or it cannot correct anything.
+  float traversal_worst = 0, rerank_worst = 0;
+  for (size_t i = 0; i != kDims; ++i) {
+    traversal_worst = std::max(traversal_worst, std::fabs(traversal[i] - in[i]));
+    rerank_worst = std::max(rerank_worst, std::fabs(rerank[i] - in[i]));
+  }
+  LOG(INFO) << "traversal worst error " << traversal_worst << ", rerank worst error "
+            << rerank_worst;
+  ASSERT_LT(rerank_worst, traversal_worst);
+}
+
+TEST_F(CoordinateCodecTest, StorageKindForRerankMapsEveryTier) {
+  ASSERT_EQ(StorageKindForRerank(RerankStorageKind::kFloat16), VectorStorageKind::kFloat16);
+  ASSERT_EQ(StorageKindForRerank(RerankStorageKind::kFloat32), VectorStorageKind::kFloat32);
+}
+
+}  // namespace yb::vector_index

--- a/src/yb/vector_index/coordinate_codec.cc
+++ b/src/yb/vector_index/coordinate_codec.cc
@@ -1,0 +1,151 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/vector_index/coordinate_codec.h"
+
+#include <cmath>
+#include <cstring>
+
+#include "fp16/fp16.h"
+
+#include "yb/util/logging.h"
+
+namespace yb::vector_index {
+
+namespace {
+
+// Records sit at whatever offset the surrounding layout gives them (YbHnsw coordinates start 20
+// bytes into a record whose stride is not a multiple of 4), so every access goes through memcpy
+// rather than a typed load.
+uint16_t LoadU16(const void* src, size_t index) {
+  uint16_t result;
+  memcpy(&result, static_cast<const std::byte*>(src) + index * sizeof(uint16_t), sizeof(result));
+  return result;
+}
+
+void StoreU16(void* dst, size_t index, uint16_t value) {
+  memcpy(static_cast<std::byte*>(dst) + index * sizeof(uint16_t), &value, sizeof(value));
+}
+
+}  // namespace
+
+size_t CoordinateBytes(VectorStorageKind kind, size_t dimensions) {
+  switch (kind) {
+    case VectorStorageKind::kFloat32:
+      return dimensions * sizeof(float);
+    case VectorStorageKind::kFloat16:
+      return dimensions * sizeof(uint16_t);
+    case VectorStorageKind::kInt8:
+      return dimensions * sizeof(int8_t);
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageKind, kind);
+}
+
+void NarrowCoordinates(
+    VectorStorageKind kind, const float* src, size_t dimensions, void* dst,
+    size_t* num_clamped) {
+  DCHECK_NE(kind, VectorStorageKind::kInt8)
+      << "kInt8 needs a scale: use the overload that takes one";
+  return NarrowCoordinates(kind, 0.0f, src, dimensions, dst, num_clamped);
+}
+
+void NarrowCoordinates(
+    VectorStorageKind kind, float scale, const float* src, size_t dimensions, void* dst,
+    size_t* num_clamped) {
+  switch (kind) {
+    case VectorStorageKind::kFloat32:
+      memcpy(dst, src, dimensions * sizeof(float));
+      return;
+    case VectorStorageKind::kFloat16: {
+      size_t clamped = 0;
+      for (size_t i = 0; i != dimensions; ++i) {
+        auto value = src[i];
+        // NaN fails both comparisons, so it takes the same branch as an out-of-range magnitude.
+        // TODO(vector_index): vectorize with _mm256_cvtps_ph. The scalar conversion costs ~8us
+        // per query at 1536 dimensions, once per chunk per search.
+        if (PREDICT_FALSE(!(value >= -kMaxFloat16 && value <= kMaxFloat16))) {
+          ++clamped;
+          value = std::isnan(value) ? 0.0f : std::copysign(kMaxFloat16, value);
+        }
+        StoreU16(dst, i, fp16_ieee_from_fp32_value(value));
+      }
+      if (num_clamped) {
+        *num_clamped += clamped;
+      }
+      return;
+    }
+    case VectorStorageKind::kInt8: {
+      // Zero would make every coordinate infinite and a negative scale would invert the
+      // ordering; neither is recoverable downstream.
+      DCHECK_GT(scale, 0.0f);
+      const auto inv_scale = 1.0f / scale;
+      auto* out = static_cast<int8_t*>(dst);
+      size_t clamped = 0;
+      for (size_t i = 0; i != dimensions; ++i) {
+        // Checked before scaling so NaN is counted, not turned into a zero that passes the
+        // range test below.
+        if (PREDICT_FALSE(std::isnan(src[i]))) {
+          ++clamped;
+          out[i] = 0;
+          continue;
+        }
+        // Round before the range test, not after: a coordinate just past 127 steps rounds back
+        // to 127 and has lost nothing, so it is not clamping. The clamp itself is load-bearing --
+        // an out-of-range float -> int8_t conversion is undefined behaviour, not saturating.
+        auto value = std::round(src[i] * inv_scale);
+        if (PREDICT_FALSE(!(value >= -kMaxInt8 && value <= kMaxInt8))) {
+          ++clamped;
+          value = std::copysign(kMaxInt8, value);
+        }
+        out[i] = static_cast<int8_t>(value);
+      }
+      if (num_clamped) {
+        *num_clamped += clamped;
+      }
+      return;
+    }
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageKind, kind);
+}
+
+void WidenCoordinates(
+    VectorStorageKind kind, const void* src, size_t dimensions, float* dst) {
+  DCHECK_NE(kind, VectorStorageKind::kInt8)
+      << "kInt8 needs a scale: use the overload that takes one";
+  return WidenCoordinates(kind, 0.0f, src, dimensions, dst);
+}
+
+void WidenCoordinates(
+    VectorStorageKind kind, float scale, const void* src, size_t dimensions, float* dst) {
+  switch (kind) {
+    case VectorStorageKind::kFloat32:
+      memcpy(dst, src, dimensions * sizeof(float));
+      return;
+    case VectorStorageKind::kFloat16:
+      for (size_t i = 0; i != dimensions; ++i) {
+        dst[i] = fp16_ieee_to_fp32_value(LoadU16(src, i));
+      }
+      return;
+    case VectorStorageKind::kInt8: {
+      DCHECK_GT(scale, 0.0f);
+      const auto* in = static_cast<const int8_t*>(src);
+      for (size_t i = 0; i != dimensions; ++i) {
+        dst[i] = static_cast<float>(in[i]) * scale;
+      }
+      return;
+    }
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageKind, kind);
+}
+
+}  // namespace yb::vector_index

--- a/src/yb/vector_index/coordinate_codec.h
+++ b/src/yb/vector_index/coordinate_codec.h
@@ -1,0 +1,72 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+// Conversion between full-precision coordinates and the narrowed encodings a served vector
+// index stores on disk (VectorStorageKind).
+//
+// The writer and the query path must round identically, or a vector stops being at distance zero
+// from itself and the graph's neighbor choices stop agreeing with the distances used to search
+// it -- which is why both directions live here and nothing else narrows coordinates.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "yb/vector_index/vector_storage_kind.h"
+
+namespace yb::vector_index {
+
+// Largest finite value in IEEE 754 binary16, used as the clamp threshold.
+constexpr float kMaxFloat16 = 65504.0f;
+
+// Largest magnitude kInt8 storage represents. 127 rather than 128 keeps the range symmetric, so
+// -128 never occurs and negation needs no special case.
+constexpr float kMaxInt8 = 127.0f;
+
+// Bytes occupied by `dimensions` coordinates stored as `kind`.
+size_t CoordinateBytes(VectorStorageKind kind, size_t dimensions);
+
+// Narrows `dimensions` float32 coordinates from `src` into `dst` in the `kind` encoding. `dst`
+// must have room for CoordinateBytes(kind, dimensions) bytes and need not be aligned.
+//
+// Unrepresentable values are clamped to the encoding's finite extremes and NaN becomes zero;
+// `num_clamped`, when non-null, is incremented per such coordinate. Clamping rather than letting
+// the conversion saturate matters: an infinite coordinate makes every distance to that vector
+// NaN, which corrupts the search heaps' ordering silently instead of failing.
+void NarrowCoordinates(
+    VectorStorageKind kind, const float* src, size_t dimensions, void* dst,
+    size_t* num_clamped = nullptr);
+
+// As above, for encodings that quantize: stored = round(coordinate / scale).
+//
+// `scale` must be the one in the header of the chunk these records will be compared against,
+// never a freshly computed one -- it is derived per chunk, so quantizing a query with the wrong
+// scale silently degrades recall for that chunk alone. Ignored by encodings that do not quantize.
+void NarrowCoordinates(
+    VectorStorageKind kind, float scale, const float* src, size_t dimensions, void* dst,
+    size_t* num_clamped = nullptr);
+
+// Widens `dimensions` coordinates in the `kind` encoding at `src` back to float32 in `dst`.
+// `src` need not be aligned.
+//
+// Exact for the float encodings. kInt8 recovers scale * stored, not the original coordinate, but
+// narrow(widen(narrow(x))) == narrow(x) at a fixed scale so a value does not drift further. That
+// fixed point does not survive a merge, which derives a new scale -- hence the rerank tier.
+void WidenCoordinates(
+    VectorStorageKind kind, const void* src, size_t dimensions, float* dst);
+
+// As above, for encodings that quantize. See NarrowCoordinates for what `scale` must be.
+void WidenCoordinates(
+    VectorStorageKind kind, float scale, const void* src, size_t dimensions, float* dst);
+
+}  // namespace yb::vector_index

--- a/src/yb/vector_index/hnsw_options.cc
+++ b/src/yb/vector_index/hnsw_options.cc
@@ -50,6 +50,18 @@ scalar_kind_t ConvertCoordinateKind(CoordinateKind coordinate_kind) {
   FATAL_INVALID_ENUM_VALUE(CoordinateKind, coordinate_kind);
 }
 
+scalar_kind_t ScalarKindFromStorageKind(VectorStorageKind storage_kind) {
+  switch (storage_kind) {
+    case VectorStorageKind::kFloat32:
+      return scalar_kind_t::f32_k;
+    case VectorStorageKind::kFloat16:
+      return scalar_kind_t::f16_k;
+    case VectorStorageKind::kInt8:
+      return scalar_kind_t::i8_k;
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageKind, storage_kind);
+}
+
 } // namespace
 
 std::string HNSWOptions::ToString() const {
@@ -61,11 +73,13 @@ std::string HNSWOptions::ToString() const {
       num_neighbors_per_vertex_base,
       max_neighbors_per_vertex_base,
       ef_construction,
-      robust_prune_alpha);
+      robust_prune_alpha,
+      storage_kind,
+      rerank_kind);
 }
 
 template <class Vector>
-unum::usearch::metric_punned_t HNSWOptions::CreateMetric() const {
+unum::usearch::metric_punned_t HNSWOptions::CreateBuildMetric() const {
   return unum::usearch::metric_punned_t(
       dimensions,
       MetricKindFromDistanceType(distance_kind),
@@ -73,6 +87,14 @@ unum::usearch::metric_punned_t HNSWOptions::CreateMetric() const {
 }
 
 template
-unum::usearch::metric_punned_t HNSWOptions::CreateMetric<FloatVector>() const;
+unum::usearch::metric_punned_t HNSWOptions::CreateBuildMetric<FloatVector>() const;
+
+unum::usearch::metric_punned_t HNSWOptions::CreateStoredMetric(
+    size_t dimensions_arg, VectorStorageKind storage_kind_arg) const {
+  return unum::usearch::metric_punned_t(
+      dimensions_arg,
+      MetricKindFromDistanceType(distance_kind),
+      ScalarKindFromStorageKind(storage_kind_arg));
+}
 
 }  // namespace yb::vector_index

--- a/src/yb/vector_index/hnsw_options.h
+++ b/src/yb/vector_index/hnsw_options.h
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "yb/vector_index/distance.h"
+#include "yb/vector_index/vector_storage_kind.h"
 
 namespace unum::usearch {
 class metric_punned_t;
@@ -61,9 +62,24 @@ struct HNSWOptions {
 
   DistanceKind distance_kind = DistanceKind::kL2Squared;
 
+  // Encoding for coordinates written into immutable, file-backed chunks. Graph construction is
+  // unaffected: it always runs at the index's in-memory coordinate type.
+  VectorStorageKind storage_kind = VectorStorageKind::kFloat32;
+
+  // Encoding of the rerank copy stored alongside them. Only meaningful with a lossy
+  // storage_kind, which in turn requires it.
+  RerankStorageKind rerank_kind = RerankStorageKind::kNone;
+
   std::string ToString() const;
+
+  // Metric over Vector::value_type, the in-memory type the graph is built at.
   template <class Vector>
-  unum::usearch::metric_punned_t CreateMetric() const;
+  unum::usearch::metric_punned_t CreateBuildMetric() const;
+
+  // Metric over stored records. Takes the encoding explicitly rather than reading storage_kind,
+  // because YbHnsw::Init must use what the file it just opened records, not what this says now.
+  unum::usearch::metric_punned_t CreateStoredMetric(
+      size_t dimensions, VectorStorageKind storage_kind) const;
 };
 
 }  // namespace yb::vector_index

--- a/src/yb/vector_index/usearch_include_wrapper_internal.h
+++ b/src/yb/vector_index/usearch_include_wrapper_internal.h
@@ -65,8 +65,25 @@
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
 #endif
 
+// SimSIMD keys each target family off the corresponding -march macro, and x86-64 builds at
+// -march=ivybridge (top-level CMakeLists.txt), so no AVX-512 family enables itself. Forcing one
+// on is safe: every kernel carries its own target attribute so it compiles under the baseline,
+// and simsimd_capabilities() dispatches on CPUID, so a kernel the host cannot run is never
+// called.
+//
+// ICE is needed because SimSIMD has no *_i8_skylake -- without it the int8 ladder drops from
+// AVX-512 to 256-bit Haswell kernels. cos/l2sq/dot_i8_ice accumulate into int32 exactly as the
+// Haswell kernels do, so results are bit-identical. See
+// architecture/design/docdb-vector-index-quantization.md.
+//
+// SAPPHIRE is deliberately not enabled: it is the only way to get a 512-bit float16 kernel, but
+// cos_f16_sapphire accumulates in fp16 where cos_f16_haswell widens to fp32, which measured
+// -0.5 recall points. It also reaches int8, whose rerank tier is float16. GENOA is left to
+// auto-detection: it only adds bf16 kernels and nothing stores bf16.
 #define SIMSIMD_TARGET_HASWELL 1
 #define SIMSIMD_TARGET_SKYLAKE 1
+#define SIMSIMD_TARGET_ICE 1
+
 #endif
 
 // Getting these errors with both Clang and GCC on Linux, as well as with in an x86_64 build with

--- a/src/yb/vector_index/vector_storage_kind.cc
+++ b/src/yb/vector_index/vector_storage_kind.cc
@@ -1,0 +1,32 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/vector_index/vector_storage_kind.h"
+
+#include "yb/util/logging.h"
+
+namespace yb::vector_index {
+
+VectorStorageKind StorageKindForRerank(RerankStorageKind kind) {
+  switch (kind) {
+    case RerankStorageKind::kNone:
+      break;
+    case RerankStorageKind::kFloat16:
+      return VectorStorageKind::kFloat16;
+    case RerankStorageKind::kFloat32:
+      return VectorStorageKind::kFloat32;
+  }
+  FATAL_INVALID_ENUM_VALUE(RerankStorageKind, kind);
+}
+
+}  // namespace yb::vector_index

--- a/src/yb/vector_index/vector_storage_kind.h
+++ b/src/yb/vector_index/vector_storage_kind.h
@@ -1,0 +1,45 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <cstdint>
+
+#include "yb/util/enums.h"
+
+namespace yb::vector_index {
+
+// On-disk encoding of a served vector index's coordinates. Separate from CoordinateKind: the
+// HNSW graph is always built at full precision, and this narrows only the copy written into the
+// immutable YbHnsw chunk, which search then computes distances on directly.
+//
+// kInt8 quantizes to a per-chunk scale recorded in the footer, so its distances are in quantized
+// units and it is only valid together with a rerank tier. The recall it costs cannot be
+// recovered by raising ef -- the search ranks candidates by that quantized distance -- so
+// reranking an over-fetch is what buys it back.
+//
+// Serialized as the underlying uint8 in the YbHnsw footer: kFloat32 must stay 0, since version-1
+// footers carry no such field and are read back as kFloat32.
+YB_DEFINE_TYPED_ENUM(VectorStorageKind, uint8_t, (kFloat32)(kFloat16)(kInt8));
+
+// Encoding of a second copy of each vector, stored after the traversal coordinates in the same
+// record. Candidates the traversal retained are rescored against it, so what crosses the chunk
+// boundary is a distance in true units that VectorLSM can merge against other chunks.
+//
+// kNone must stay 0: footers predating this field are read back as having no rerank tier.
+YB_DEFINE_TYPED_ENUM(RerankStorageKind, uint8_t, (kNone)(kFloat16)(kFloat32));
+
+// Panics on kNone: callers must check for a tier before asking what encoding it uses.
+VectorStorageKind StorageKindForRerank(RerankStorageKind kind);
+
+}  // namespace yb::vector_index

--- a/src/yb/yql/pgwrapper/pg_vector_index-test.cc
+++ b/src/yb/yql/pgwrapper/pg_vector_index-test.cc
@@ -11,7 +11,10 @@
 // under the License.
 //
 
+#include <cmath>
+#include <map>
 #include <queue>
+#include <set>
 
 #include "yb/client/client_error.h"
 #include "yb/client/client_fwd.h"
@@ -93,6 +96,7 @@ DECLARE_int64(db_block_size_bytes);
 DECLARE_int64(db_write_buffer_size);
 DECLARE_int64(tablet_force_split_threshold_bytes);
 DECLARE_string(vector_index_backend);
+DECLARE_string(vector_index_storage_coordinate_type);
 DECLARE_uint64(post_split_compaction_input_size_threshold_bytes);
 DECLARE_bool(vector_index_allow_parallel_compactions);
 DECLARE_int32(vector_index_files_number_compaction_trigger);
@@ -100,6 +104,7 @@ DECLARE_uint32(vector_index_compaction_chunk_max_mem_store_size_percentage);
 DECLARE_uint32(vector_index_concurrent_reads);
 DECLARE_uint32(vector_index_concurrent_writes);
 DECLARE_uint32(vector_index_num_compactions_limit);
+DECLARE_uint32(vector_index_rerank_overfetch_factor);
 DECLARE_uint64(vector_index_compaction_chunk_max_mem_store_size_mb);
 DECLARE_uint64(vector_index_initial_chunk_size);
 DECLARE_uint64(vector_index_max_insert_tasks);
@@ -1883,124 +1888,6 @@ struct TestParamTraits<PgVectorIndexColocatedPackingTestParam> {
 template <typename TestClass>
 using PgVectorIndexColocatedPackingTestParamsDecorator =
     PgVectorIndexTestParamsDecoratorBase<TestClass, PgVectorIndexColocatedPackingTestParam>;
-
-// Colocation only; engine and packing stay kUsearch / kNone.
-using PgVectorIndexColocationOnlyParam = bool;
-
-template <>
-struct TestParamTraits<PgVectorIndexColocationOnlyParam> {
-  using ParamType = PgVectorIndexColocationOnlyParam;
-
-  static bool IsColocated(const ParamType& param) {
-    return param;
-  }
-
-  static VectorIndexEngine Engine(const ParamType&) {
-    return VectorIndexEngine::kUsearch;
-  }
-
-  static PackingMode GetPackingMode(const ParamType&) {
-    return PackingMode::kNone;
-  }
-
-  static auto TestParamGenerator() {
-    return testing::Bool();
-  }
-
-  static auto TestParamNameGenerator() {
-    return [](const testing::TestParamInfo<ParamType>& param_info) -> std::string {
-      return param_info.param ? "Colocated" : "Distributed";
-    };
-  }
-};
-
-class PgVectorIndexColocationOnlyTest
-    : public PgVectorIndexTestParamsDecoratorBase<
-          PgVectorIndexTestBase, PgVectorIndexColocationOnlyParam> {};
-
-MAKE_VECTOR_INDEX_PARAM_TEST_SUITE(PgVectorIndexColocationOnlyTest);
-
-// The bootstrap variant of #33276: restoring past the ADD COLUMN that introduced the vector column
-// leaves the tablet heap schema without the column, while the vector index stays registered on the
-// tablet and has lost its chunks (the restored checkpoint predates the index). The next bootstrap
-// launches a backfill for the chunkless index, and the backfill projects the vector column out of
-// the live schema, so DoCreateIndex must skip such an index at tablet open instead of letting the
-// backfill read out of bounds.
-TEST_P(PgVectorIndexColocationOnlyTest, SnapshotScheduleRestoreBeforeVectorColumn) {
-  constexpr size_t kNumRows = 16;
-
-  // The suite's quick-split setup lets the indexed table split before the index exists, and the
-  // restore then reverts to the pre-split parent, which never hosted the index at all.
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_automatic_tablet_splitting) = false;
-
-  // The read below runs against a table that has no vector index in the catalog, so it is a plain
-  // scan while the tablets may still host the index.
-  ANNOTATE_UNPROTECTED_WRITE(tablet::TEST_fail_on_seq_scan_with_vector_indexes) = false;
-
-  client::SnapshotTestUtil snapshot_util;
-  snapshot_util.SetProxy(&client_->proxy_cache());
-  snapshot_util.SetCluster(cluster_.get());
-
-  // The table starts without the vector column, so MakeTable does not fit here.
-  auto conn = ASSERT_RESULT(PgMiniTestBase::Connect());
-  std::string create_suffix;
-  if (IsColocated()) {
-    create_suffix = " WITH (COLOCATED = 1)";
-    ASSERT_OK(conn.Execute("CREATE DATABASE colocated_db COLOCATION = true"));
-    conn = ASSERT_RESULT(Connect());
-  } else {
-    create_suffix = " SPLIT INTO 1 TABLETS";
-  }
-  ASSERT_OK(conn.Execute("CREATE EXTENSION vector"));
-  ASSERT_OK(conn.ExecuteFormat("CREATE TABLE test (id bigserial PRIMARY KEY)$0", create_suffix));
-
-  // The rows must predate the restore target: they are what the backfill scans after the restore.
-  ASSERT_OK(conn.StartTransaction(IsolationLevel::SNAPSHOT_ISOLATION));
-  for (size_t i = 1; i <= kNumRows; ++i) {
-    ASSERT_OK(conn.ExecuteFormat("INSERT INTO test VALUES ($0)", i));
-  }
-  ASSERT_OK(conn.CommitTransaction());
-
-  auto schedule_id = ASSERT_RESULT(snapshot_util.CreateSchedule(
-      nullptr, YQL_DATABASE_PGSQL, DbName(),
-      client::WaitSnapshot::kTrue, 1s * kTimeMultiplier, 60s * kTimeMultiplier));
-
-  auto hybrid_time = cluster_->mini_master(0)->Now();
-  ASSERT_OK(snapshot_util.WaitScheduleSnapshot(schedule_id, hybrid_time));
-
-  ASSERT_OK(conn.Execute("ALTER TABLE test ADD COLUMN embedding vector(3)"));
-  for (size_t i = 1; i <= kNumRows; ++i) {
-    ASSERT_OK(conn.ExecuteFormat("UPDATE test SET embedding = '[$0, 0, 0]' WHERE id = $0", i));
-  }
-  ASSERT_OK(CreateIndex(conn));
-
-  // The restore drops the index from the catalog, and CleanupHiddenObjects then unregisters it
-  // from the tablets, typically before the restart below gets to bootstrap. The removal is a
-  // replicated ChangeMetadata operation, so blocking the RPC on the master is what keeps the
-  // restarted tserver from replaying it during bootstrap.
-  auto* sync_point = yb::SyncPoint::GetInstance();
-  sync_point->LoadDependency({
-      {"SnapshotScheduleRestoreBeforeVectorColumn::Bootstrapped",
-       "AsyncRemoveTableFromTablet::SendRequest"}});
-  sync_point->EnableProcessing();
-  auto sync_point_cleanup = ScopeExit([sync_point] {
-    sync_point->DisableProcessing();
-    sync_point->ClearTrace();
-  });
-
-  ASSERT_OK(snapshot_util.RestoreSnapshotSchedule(schedule_id, hybrid_time));
-
-  // Bootstrap is what launches backfills for indexes that have no chunks. Restart a tserver that
-  // does not host PG, to keep the connection above usable; the master has a task thread parked on
-  // the sync point above, so it has to stay up.
-  auto* target_ts = cluster_->mini_tablet_server(kPgTsIndex == 0 ? 1 : 0);
-  ASSERT_OK(target_ts->Restart(tserver::WaitTabletsBootstrapped::kTrue));
-  TEST_SYNC_POINT("SnapshotScheduleRestoreBeforeVectorColumn::Bootstrapped");
-
-  ASSERT_EQ(
-      kNumRows,
-      make_unsigned(ASSERT_RESULT(conn.FetchRow<int64_t>("SELECT COUNT(*) FROM test"))));
-}
 
 class PgDistributedVectorIndexTest
     : public PgDistributedVectorIndexTestParamsDecorator<PgVectorIndexTestBase> {
@@ -4679,6 +4566,410 @@ TEST_P(PgVectorIndexTest, StatusResolutionDuringBootstrapBackfill) {
 
   // Reaching here without the tserver crashing means the fix holds.
   threads.Stop();
+}
+
+////////////////////////////////////////////////////////
+// Narrowed coordinate storage (float16)
+////////////////////////////////////////////////////////
+
+// Shared by the narrowed-storage fixtures below, each of which names one encoding, so the same
+// suite runs against all of them. The graph is still built at full precision, so what these cover
+// is whether narrowed records survive flush, restart, compaction and the query path.
+class PgVectorIndexNarrowStorageTest : public PgVectorIndexTestBase {
+ protected:
+  virtual std::string StorageCoordinateType() const = 0;
+
+  bool IsColocated() const override { return false; }
+  VectorIndexEngine Engine() const override { return VectorIndexEngine::kYbHnswHnswlib; }
+  PackingMode GetPackingMode() const override { return PackingMode::kV1; }
+
+  void SetUp() override {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_storage_coordinate_type) =
+        StorageCoordinateType();
+    PgVectorIndexTestBase::SetUp();
+    // The base fixture forces brute-force search; these tests want the real graph walk over
+    // narrowed records.
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_vector_index_exact) = false;
+  }
+
+  // Ids of the `limit` nearest rows by exact float32 distance, computed from the vectors the test
+  // inserted rather than from anything the index stored.
+  std::vector<int64_t> ExactNearest(const FloatVector& query_vector, size_t limit) {
+    unum::usearch::metric_punned_t metric(
+        dimensions_, UsearchMetricKind(), unum::usearch::scalar_kind_t::f32_k);
+    std::vector<int64_t> ids(vectors_.size());
+    std::generate(ids.begin(), ids.end(), [n{0LL}]() mutable { return n++; });
+    std::sort(ids.begin(), ids.end(), [&](int64_t lhs, int64_t rhs) {
+      return metric(VectorToBytePtr(query_vector), VectorToBytePtr(vectors_[lhs])) <
+             metric(VectorToBytePtr(query_vector), VectorToBytePtr(vectors_[rhs]));
+    });
+    ids.resize(std::min(ids.size(), limit));
+    return ids;
+  }
+
+  // Fraction of the exact top-`limit` that the index actually returned, averaged over
+  // `iterations` random queries.
+  Result<double> MeasureRecall(PGConn& conn, size_t limit, size_t iterations) {
+    size_t found = 0;
+    for (size_t i = 0; i != iterations; ++i) {
+      auto query_vector = RandomVector();
+      auto rows = VERIFY_RESULT(conn.FetchRows<int64_t>(
+          "SELECT id FROM test" + IndexQuerySuffix(query_vector, limit)));
+      auto expected = ExactNearest(query_vector, limit);
+      std::set<int64_t> expected_set(expected.begin(), expected.end());
+      for (auto id : rows) {
+        found += expected_set.contains(id);
+      }
+    }
+    return static_cast<double>(found) / (limit * iterations);
+  }
+
+  // Storage type recorded on every vector index this cluster is serving.
+  std::map<VectorStorageType, size_t> StorageTypeCounts() {
+    std::map<VectorStorageType, size_t> counts;
+    for (const auto& peer : ListTabletPeersWithVectorIndexes(cluster_.get())) {
+      auto tablet = CHECK_RESULT(peer->shared_tablet());
+      auto indexes = tablet->vector_indexes().List();
+      CHECK(indexes);
+      for (const auto& index : *indexes) {
+        ++counts[index->options().hnsw().storage_type()];
+      }
+    }
+    return counts;
+  }
+};
+
+class PgVectorIndexFloat16Test : public PgVectorIndexNarrowStorageTest {
+ protected:
+  std::string StorageCoordinateType() const override { return "float16"; }
+};
+
+// int8 traversal coordinates with a float16 rerank copy. The rerank tier is what makes the
+// encoding usable: int8 alone loses recall that no amount of ef recovers, because the search
+// still keeps only max_num_results entries ranked by the quantized distance.
+class PgVectorIndexInt8Test : public PgVectorIndexNarrowStorageTest {
+ protected:
+  std::string StorageCoordinateType() const override { return "int8"; }
+};
+
+// The encoding is fixed per index at creation time so every replica agrees on it. A tserver-local
+// setting would let replicas of the same tablet disagree about the accuracy of their answers.
+TEST_F(PgVectorIndexFloat16Test, StorageTypeIsRecordedInTheCatalog) {
+  auto conn = ASSERT_RESULT(MakeIndex());
+
+  size_t checked = 0;
+  for (const auto& peer : ListTabletPeersWithVectorIndexes(cluster_.get())) {
+    auto tablet = ASSERT_RESULT(peer->shared_tablet());
+    auto indexes = tablet->vector_indexes().List();
+    ASSERT_TRUE(indexes);
+    for (const auto& index : *indexes) {
+      ASSERT_EQ(index->options().hnsw().storage_type(), VectorStorageType::STORAGE_FLOAT16);
+      ++checked;
+    }
+  }
+  ASSERT_GT(checked, 0);
+}
+
+// Narrowing changes which rows come back, not the distances the user sees: ybvectorgettuple
+// leaves xs_orderbyvals unset and xs_recheckorderby false, so the executor evaluates `<->` over
+// the full-precision heap value. They are not even the same quantity -- `<->` is sqrt(L2 squared)
+// where the index ranks on L2 squared -- so a leaked index distance fails this by a wide margin.
+TEST_F(PgVectorIndexFloat16Test, ReportedDistancesStayFullPrecision) {
+  constexpr size_t kNumRows = 500;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+
+  // Mirrors pgvector's l2_distance: float32 accumulation, then sqrt in double.
+  auto exact_l2_distance = [](const FloatVector& lhs, const FloatVector& rhs) {
+    float squared = 0.0f;
+    for (size_t i = 0; i != lhs.size(); ++i) {
+      const float diff = lhs[i] - rhs[i];
+      squared += diff * diff;
+    }
+    return std::sqrt(static_cast<double>(squared));
+  };
+
+  for (size_t i = 0; i != 10; ++i) {
+    auto query_vector = RandomVector();
+    auto rows = ASSERT_RESULT((conn.FetchRows<int64_t, double>(Format(
+        "SELECT id, $0 FROM test$1",
+        DistanceToQuery(query_vector), IndexQuerySuffix(query_vector, kLimit)))));
+    ASSERT_FALSE(rows.empty());
+
+    for (const auto& [id, reported] : rows) {
+      const auto exact = exact_l2_distance(query_vector, vectors_[id]);
+      // 1e-5 sits two orders of magnitude above float32 accumulation noise and two below the
+      // ~5e-4 relative error of a float16 distance, so it tells the two apart.
+      ASSERT_LE(std::fabs(reported - exact), 1e-5 * std::max<double>(exact, 1.0))
+          << "id: " << id << ", reported: " << reported << ", exact: " << exact;
+    }
+  }
+}
+
+TEST_F(PgVectorIndexFloat16Test, Recall) {
+  constexpr size_t kNumRows = 2000;
+  constexpr size_t kLimit = 10;
+  constexpr size_t kIterations = 20;
+
+  dimensions_ = 32;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+
+  auto recall = ASSERT_RESULT(MeasureRecall(conn, kLimit, kIterations));
+  LOG(INFO) << "float16 recall@" << kLimit << ": " << recall;
+  ASSERT_GE(recall, 0.8);
+}
+
+// Flush turns the mutable chunk into a narrowed file, and restart reopens it through
+// YbHnsw::Init -- the path where the metric has to be rebuilt from the file's own footer.
+TEST_F(PgVectorIndexFloat16Test, SurvivesFlushAndRestart) {
+  constexpr size_t kNumRows = 1000;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+  ASSERT_OK(cluster_->FlushTablets());
+
+  auto before = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  ASSERT_OK(RestartCluster());
+  conn = ASSERT_RESULT(Connect());
+
+  auto after = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+  LOG(INFO) << "recall before restart: " << before << ", after: " << after;
+  ASSERT_GE(after, 0.8);
+}
+
+// Compaction reads source chunks back through YbHnswIterator, which has to decode narrowed
+// records rather than copy float32-wide out of them. Re-narrowing what it read is idempotent, so
+// recall should not decay across compactions either.
+TEST_F(PgVectorIndexFloat16Test, SurvivesCompaction) {
+  constexpr size_t kRowsPerChunk = 300;
+  constexpr size_t kNumChunks = 4;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndex(dimensions_));
+  for (size_t chunk = 0; chunk != kNumChunks; ++chunk) {
+    ASSERT_OK(InsertRandomRows(conn, kRowsPerChunk));
+    ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+    ASSERT_OK(cluster_->FlushTablets());
+  }
+
+  auto before = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  ASSERT_OK(cluster_->CompactTablets());
+  auto after = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  LOG(INFO) << "recall before compaction: " << before << ", after: " << after;
+  ASSERT_GE(after, 0.8);
+}
+
+// A float16 index has to coexist with a float32 one in the same cluster: the encoding is a
+// per-index property, and each chunk records its own.
+TEST_F(PgVectorIndexFloat16Test, CoexistsWithFloat32Index) {
+  constexpr size_t kNumRows = 500;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_storage_coordinate_type) = "float32";
+  ASSERT_OK(conn.Execute(
+      "CREATE INDEX vi_f32 ON test USING ybhnsw (embedding vector_l2_ops) WITH (m=16)"));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 60s * kTimeMultiplier));
+  ASSERT_OK(cluster_->FlushTablets());
+
+  auto counts = StorageTypeCounts();
+  LOG(INFO) << "indexes by storage type: " << AsString(counts);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_FLOAT16], 0);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_FLOAT32], 0);
+
+  ASSERT_GE(ASSERT_RESULT(MeasureRecall(conn, kLimit, 10)), 0.8);
+}
+
+
+TEST_F(PgVectorIndexInt8Test, StorageTypeIsRecordedInTheCatalog) {
+  auto conn = ASSERT_RESULT(MakeIndex());
+
+  auto counts = StorageTypeCounts();
+  LOG(INFO) << "indexes by storage type: " << AsString(counts);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_INT8], 0);
+  ASSERT_EQ(counts[VectorStorageType::STORAGE_FLOAT32], 0);
+  ASSERT_EQ(counts[VectorStorageType::STORAGE_FLOAT16], 0);
+}
+
+// As above, and int8 is its strongest form: a leaked index distance would be in quantized units,
+// off by orders of magnitude rather than by rounding.
+TEST_F(PgVectorIndexInt8Test, ReportedDistancesStayFullPrecision) {
+  constexpr size_t kNumRows = 500;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+
+  // Mirrors pgvector's l2_distance: float32 accumulation, then sqrt in double.
+  auto exact_l2_distance = [](const FloatVector& lhs, const FloatVector& rhs) {
+    float squared = 0.0f;
+    for (size_t i = 0; i != lhs.size(); ++i) {
+      const float diff = lhs[i] - rhs[i];
+      squared += diff * diff;
+    }
+    return std::sqrt(static_cast<double>(squared));
+  };
+
+  for (size_t i = 0; i != 10; ++i) {
+    auto query_vector = RandomVector();
+    auto rows = ASSERT_RESULT((conn.FetchRows<int64_t, double>(Format(
+        "SELECT id, $0 FROM test$1",
+        DistanceToQuery(query_vector), IndexQuerySuffix(query_vector, kLimit)))));
+    ASSERT_FALSE(rows.empty());
+
+    for (const auto& [id, reported] : rows) {
+      const auto exact = exact_l2_distance(query_vector, vectors_[id]);
+      ASSERT_LE(std::fabs(reported - exact), 1e-5 * std::max<double>(exact, 1.0))
+          << "id: " << id << ", reported: " << reported << ", exact: " << exact;
+    }
+  }
+}
+
+// The threshold matches the float16 suite's, which is the whole point: reranking should leave the
+// user-visible recall indistinguishable from storing float16 outright.
+TEST_F(PgVectorIndexInt8Test, Recall) {
+  constexpr size_t kNumRows = 2000;
+  constexpr size_t kLimit = 10;
+  constexpr size_t kIterations = 20;
+
+  dimensions_ = 32;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+
+  auto recall = ASSERT_RESULT(MeasureRecall(conn, kLimit, kIterations));
+  LOG(INFO) << "int8 recall@" << kLimit << ": " << recall;
+  ASSERT_GE(recall, 0.8);
+}
+
+// Proves the over-fetch flag reaches the search path: turning it off must change which rows come
+// back. Not asserted on recall -- the gap size is data-dependent, and the YbHnsw unit tests pin
+// the mechanism deterministically. What this adds is that the tserver flag is wired through.
+TEST_F(PgVectorIndexInt8Test, OverFetchFlagReachesTheSearchPath) {
+  constexpr size_t kNumRows = 2000;
+  constexpr size_t kLimit = 10;
+  constexpr size_t kIterations = 30;
+
+  dimensions_ = 32;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+
+  std::vector<FloatVector> queries;
+  for (size_t i = 0; i != kIterations; ++i) {
+    queries.push_back(RandomVector());
+  }
+
+  auto fetch_all = [this, &conn, &queries]() -> Result<std::vector<std::string>> {
+    std::vector<std::string> result;
+    for (const auto& query : queries) {
+      result.push_back(AsString(VERIFY_RESULT(conn.FetchRows<int64_t>(
+          "SELECT id FROM test" + IndexQuerySuffix(query, kLimit)))));
+    }
+    return result;
+  };
+
+  auto with_overfetch = ASSERT_RESULT(fetch_all());
+  auto recall_with = ASSERT_RESULT(MeasureRecall(conn, kLimit, kIterations));
+
+  // Factor 1 retains exactly the requested count, so reranking can only reorder it. The flag is
+  // runtime-settable and the tservers share this process, so writing it here is enough.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_rerank_overfetch_factor) = 1;
+  auto without_overfetch = ASSERT_RESULT(fetch_all());
+  auto recall_without = ASSERT_RESULT(MeasureRecall(conn, kLimit, kIterations));
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_rerank_overfetch_factor) = 2;
+
+  LOG(INFO) << "int8 recall@" << kLimit << " with over-fetch: " << recall_with
+            << ", without: " << recall_without;
+  ASSERT_NE(with_overfetch, without_overfetch)
+      << "disabling the over-fetch returned identical rows for all " << kIterations
+      << " queries, so the flag is not reaching the search";
+  ASSERT_GE(recall_with, recall_without);
+}
+
+// Flush writes the two-tier records, and restart reopens them through YbHnsw::Init -- the path
+// where both metrics and the quantization scale have to be rebuilt from the file's own footer.
+TEST_F(PgVectorIndexInt8Test, SurvivesFlushAndRestart) {
+  constexpr size_t kNumRows = 1000;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+  ASSERT_OK(cluster_->FlushTablets());
+
+  auto before = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  ASSERT_OK(RestartCluster());
+  conn = ASSERT_RESULT(Connect());
+
+  auto after = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+  LOG(INFO) << "recall before restart: " << before << ", after: " << after;
+  ASSERT_GE(after, 0.8);
+}
+
+// The hazard specific to a quantized encoding: each merged chunk derives its own scale, so if
+// compaction read the int8 coordinates instead of the rerank copy, error would compound once per
+// merge. Several chunks merged in sequence is what makes that visible.
+TEST_F(PgVectorIndexInt8Test, SurvivesRepeatedCompaction) {
+  constexpr size_t kRowsPerChunk = 300;
+  constexpr size_t kNumChunks = 4;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndex(dimensions_));
+  for (size_t chunk = 0; chunk != kNumChunks; ++chunk) {
+    ASSERT_OK(InsertRandomRows(conn, kRowsPerChunk));
+    ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+    ASSERT_OK(cluster_->FlushTablets());
+  }
+
+  auto before = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  for (size_t round = 0; round != 3; ++round) {
+    ASSERT_OK(cluster_->CompactTablets());
+    auto after = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+    LOG(INFO) << "recall after compaction round " << round << ": " << after
+              << " (before any compaction: " << before << ")";
+    ASSERT_GE(after, 0.8) << "recall decayed by compaction round " << round;
+  }
+}
+
+// All three encodings on one table. Each index records its own, and each chunk its own scale, so
+// nothing here may be cached across indexes.
+TEST_F(PgVectorIndexInt8Test, CoexistsWithOtherEncodings) {
+  constexpr size_t kNumRows = 500;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+
+  for (auto [encoding, name] : {std::pair{"float32", "vi_f32"}, std::pair{"float16", "vi_f16"}}) {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_storage_coordinate_type) = encoding;
+    ASSERT_OK(conn.Execute(Format(
+        "CREATE INDEX $0 ON test USING ybhnsw (embedding vector_l2_ops) WITH (m=16)", name)));
+    ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 60s * kTimeMultiplier));
+  }
+  ASSERT_OK(cluster_->FlushTablets());
+
+  auto counts = StorageTypeCounts();
+  LOG(INFO) << "indexes by storage type: " << AsString(counts);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_INT8], 0);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_FLOAT16], 0);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_FLOAT32], 0);
+
+  ASSERT_GE(ASSERT_RESULT(MeasureRecall(conn, kLimit, 10)), 0.8);
 }
 
 }  // namespace yb::pgwrapper


### PR DESCRIPTION
# Change Description
Added support for `float16`, or `int8` paired with a `float16` rerank tier. SIMD kernels related changes required to support this are added. Described in detail inline. 

## Vector index coordinate quantization

DocDB vector indexes (`ybhnsw`) can store the coordinates of a served chunk in a narrower encoding
than `float32`: either `float16`, or `int8` paired with a `float16` rerank tier. The HNSW graph is
always built at full `float32` precision — only the copies written into the immutable chunk file
are narrowed.

`float32` is the default. A `float32` index writes version 1 of the chunk format and dispatches
the same distance kernels it always has, so an index that does not opt in is unaffected.

## What to expect

VectorDBBench `Performance768D1M` (Cohere, 768 dimensions, 1M vectors, cosine), `k=100`,
`ef_search=200`, single-node `m8i.2xlarge`, RF1:

| encoding | QPS (30 clients) | vs `float32` | recall@100 | serial latency | p99 | load time | index size |
|---|---|---|---|---|---|---|---|
| `float32` (default) | 1337.3 | — | 0.9471 | 3.58 ms | 37.98 ms | 327 s | 3.19 GB |
| `float16` | 1352.2 | +1.1% | 0.9471 | 4.60 ms | 41.45 ms | 331 s | 1.65 GB |
| `int8` + `float16` rerank | 1669.7 | **+24.9%** | 0.9464 | 3.21 ms | 32.46 ms | 327 s | 2.42 GB |

The two encodings solve different problems:

- **`int8`** is the throughput option: **+24.9% QPS for 0.07 recall points**, and the only encoding
  that also improves tail latency. Its record is *larger* than `float16`'s — the rerank copy costs
  more than the narrowed traversal copy saves — so it is not the way to shrink an index.
- **`float16`** halves the index (3.19 → 1.65 GB) at identical recall, but is worth about 1% of
  throughput and *raises* serial latency and p99. Choose it for capacity, not for speed.

Load time is the same for all three: the 4-second spread is inside the run-to-run noise on this
benchmark, where two runs of one configuration differ by more than that.

## Record layout

`VectorStorageKind` names the traversal encoding and `RerankStorageKind` the optional second copy.
Per vector at 768 dimensions:

| encoding | traversal | rerank | record | vs `float32` | bytes per distance |
|---|---|---|---|---|---|
| `float32` | 3072 | — | 3092 | 1.00× | 3072 |
| `float16` | 1536 | — | 1556 | 0.50× | 1536 |
| `int8` | 768 | 1536 | 2324 | 0.75× | **768** |

The 20-byte overhead is the per-vector `YbHnswVectorData` header. The traversal touches thousands
of records per query while the rerank tier reads only the retained candidates, so `int8` spends
0.75× the disk to make the hot path read a quarter of the bytes.

`coordinate_codec.{h,cc}` owns both directions of the conversion, and nothing else narrows
coordinates: the writer and the query path must round identically, or a vector stops being at
distance zero from itself and the graph's neighbour choices stop agreeing with the distances used
to search it.

## The rerank tier, and why `ef` is not the knob

`int8` quantizes each coordinate to a per-chunk step, which costs several points of recall@k.
**Raising `ef` does not recover it** — a search retains `max_num_results` entries ranked by that
same quantized distance, so widening the candidate set does not improve the final selection. For
scalar quantization `ef` is not a recall knob.

What recovers it is retaining more candidates than requested and rescoring them at `float16`
before they leave the chunk. `MakeResult` is the only point at which distances cross the chunk
boundary, so it is also the only point at which they must be in the metric's own units for
VectorLSM to merge them against other chunks.

The over-fetch is free while `factor × k <= ef`, since the search already maintains `max(ef, k)`
candidates. Above that the candidate budget rises to `factor × k` and the traversal does
proportionally more work — the case to watch when querying with a large `LIMIT`.

## Per-chunk quantization scale

`int8` uses a symmetric scale, `max|coordinate| / 127`, derived from the chunk's own coordinates
and recorded in its footer. Scoping it to the chunk keeps it a pure function of data already in
hand — no sampling, no configuration, nothing to recalibrate as an index grows — at the cost that
two chunks of one index hold different scales. A query must therefore be quantized against the
scale of the chunk it is compared against, never a freshly computed one.

This is also why compaction reads the **rerank** copy rather than decoding the traversal
coordinates. A merged chunk derives a new scale, so decoding `int8` would feed already-quantized
values into a fresh quantization and lose a little more on every merge. The `float16` rerank copy
round-trips exactly, making a vector a fixed point across arbitrarily many compactions.

## Chunk format

Each chunk records its own encoding in its footer, under a serialization version:

| version | contents |
|---|---|
| 1 | base layout; always `float32` |
| 2 | adds `Header::storage_kind` |
| 3 | adds `Header::rerank_kind` and `Header::quantization_scale` |

The writer emits the lowest version that can represent the header, which is what keeps a `float32`
index at version 1. `Load` rejects a version it does not recognise rather than reading the fields
it knows and treating the remainder as block offsets, and `ValidateHeader` then checks the parsed
header against itself before any record is read through it — a `vector_data_size` disagreeing with
the encodings would otherwise read past every record into the next, and an unusable quantization
scale would decode coordinates to zero or infinity.

## SIMD kernels

x86-64 builds at `-march=ivybridge`, so no AVX-512 family enables itself from its `-march` macro
and `usearch_include_wrapper_internal.h` forces the three SimSIMD targets the encodings need:
`HASWELL`, `SKYLAKE` and `ICE`. Forcing a target is safe — each kernel carries its own target
attribute so it compiles under the Ivy Bridge baseline, and `simsimd_capabilities()` dispatches on
CPUID, so a kernel the host cannot run is never called.

`ICE` is the target the narrowed encodings depend on. SimSIMD has no `*_i8_skylake`, so without
it the `int8` ladder drops from AVX-512 straight to the 256-bit Haswell kernels while `float32`
keeps a 512-bit one. `cos/l2sq/dot_i8_ice` accumulate into `int32` exactly as the Haswell kernels
do, so they are bit-identical and cost no accuracy: the measured 0.9464 recall for `int8` is the
quantization's cost alone.

`float16` distances use the 256-bit `*_f16_haswell` kernels, which widen each coordinate to fp32
and accumulate there. That is the reason `float16` storage buys capacity rather than throughput —
halving the bytes does not halve the work when the kernel is narrower than `float32`'s.

## Enabling an encoding

A **master** flag chooses the encoding, which is stamped into the index's catalog entry at
`CREATE INDEX`. It is therefore fixed for the life of that index and identical on every replica,
rather than following each tserver's local flags.

```bash
# On every yb-master. Runtime-settable; no restart needed.
--vector_index_storage_coordinate_type=int8      # or float16, or float32 (default)
```

```bash
# On every yb-tserver. 1 disables the over-fetch, making reranking a no-op. Valid range 1-64.
--vector_index_rerank_overfetch_factor=2         # default
```

An index keeps the encoding it was created with, so the flag's value at query time says nothing
about an index created earlier. To see what an index actually got, read the footer from the index
flush log lines:

```
YbHnsw ... header: { dimensions: 768 vector_data_size: 2324 ... storage_kind: kInt8
                     rerank_kind: kFloat16 quantization_scale: 0.00418465 }
```

`vector_data_size` is the giveaway: `20 + 4·d` for `float32`, `20 + 2·d` for `float16`, and
`20 + 3·d` for `int8`.

### Downgrade

Selecting a narrow encoding is a one-way step for the chunks written while it is selected. A
version-2 or version-3 chunk is unreadable by a binary that only understands version 1. Clearing
the flag stops new chunks from using the encoding but does not rewrite existing ones, and an index
created while the flag was set keeps its encoding in the catalog. Moving such a cluster to a
binary without these encodings requires those indexes be dropped and rebuilt.

## Scope

The SimSIMD `#define`s take effect only in translation units that include
`usearch_include_wrapper_internal.h`, directly or through `hnsw.h`. That is 9 files: 5 production
(`hnsw.cc`, `yb_hnsw_wrapper.cc`, `hnswlib_wrapper.cc`, `usearch_wrapper.cc`, `hnsw_options.cc`)
and 4 tests. Every production one is vector-index code, and `hnsw.h` is included by no other
header, so there is no further fan-out and nothing in `tserver`, `master`, `rocksdb` or `postgres`
is reached. hnswlib's own SIMD is independent: it gates on `__AVX512F__`, which `-march=ivybridge`
does not define.

Disassembly confirms every AVX-512 instruction sits in a symbol suffixed `_ice` or `_skylake`. The
`ICE` kernels add about 5 KB of text, of which 3 of 7 are reachable from any YB code path. With
the default `float32` encoding the target is a runtime no-op, because the `float32` ladder has no
`ICE` rung.

Vector indexes are **YSQL-only**. YCQL cannot create one — `add_vector_options` has no callers and
a CQL `DataType::VECTOR` hits `FATAL_INVALID_ENUM_VALUE` — so neither the encodings nor the SIMD
targets can reach a YCQL workload.

`int32` accumulator headroom for `int8` inputs is 8.3×: saturation needs `d > 133,144` against a
`VECTOR_MAX_DIM` of 16,000.

## Tests

- `coordinate_codec-test.cc` — round-trip error bounds for both encodings, clamping of
  unrepresentable values and NaN, and that one input always narrows to the same bytes.
- `hnsw-test.cc` — that reranking recovers what `int8` costs *and* that the un-reranked
  configuration is measurably worse, without which the test would pass just as happily when the
  rerank tier does nothing; that over-fetch works when `ef <= max_num_results`, the regime a naive
  candidate budget silently breaks; that an infinite coordinate cannot set the quantization scale.
- `yb_hnsw_storage-test.cc` — iteration and `Distance` through the `VectorIndexIf` stack, and that
  compaction reads the rerank copy rather than decoding `int8`.
- `pg_vector_index-test.cc` — the same suite against each encoding end-to-end through flush,
  restart, compaction and the query path; that the distance the user sees is unaffected by the
  storage encoding; and that the tserver over-fetch flag is wired through.

## Caveats

- **The SIMD kernels have no sanitizer coverage.** SimSIMD is disabled under ASAN and TSAN, whose
  builds therefore exercise usearch's scalar metric. The wide intrinsic loads in the AVX-512
  kernels largely evade instrumentation, so a bad read inside one faults or is missed rather than
  being reported.
- **One CPU, one workload.** Every number above is `m8i.2xlarge` on Cohere 768d/1M at RF1. The
  Skylake/ICE dispatch split and the balance between bytes moved and kernel cost will differ on
  another host, at another dimension count, or under a mixed read/write load.
- **The `int32` overflow bound is implicit.** The 8.3× headroom follows from `VECTOR_MAX_DIM`; no
  assertion ties the two together, so raising that limit past ~133,000 would need it rechecked.
- **`float16` costs latency.** It is the only encoding that makes serial latency and p99 worse.
  Treat it as a capacity option, not a performance one.
- **Include order in `hnsw.cc`.** It includes `usearch/index.hpp` directly after `hnsw.h`, which
  already pulls in the wrapper. The wrapper's `#define`s land first, but reordering those includes
  would silently change which kernels compile in.
