### PR TITLE
[#33680] build: csi_report: tag each retried item with its retry_kind

### DIFF
--- a/python/yugabyte/csi_report.py
+++ b/python/yugabyte/csi_report.py
@@ -213,6 +213,33 @@ def query_test(uniqueId: str, wait: bool) -> bool:
     return found_prev
 
 
+# Classify one execution before reporting: the ReportPortal 'retry' flag, the 'retry_kind'
+# item attribute (why this is not a plain first attempt - the empty string for one), and
+# whether a previous-item query must wait. The kinds:
+#   fail_repetition - intentional re-run of a test that failed earlier (--fail_repetitions);
+#                     exists only after a first-attempt failure, so it must never enter a
+#                     first-attempt failure rate;
+#   task_resubmit   - Spark re-ran the task because a worker died; an infra artifact;
+#   repetition      - unconditional extra run (--num_repetitions).
+# Known gap: a driver-level Spark JOB resubmit starts a fresh task with attempt 0 and is
+# indistinguishable from a first attempt here.
+def classify_execution(rerun: bool, attempt: int, reps: str,
+                       attempt_index: int) -> Tuple[bool, str, bool]:
+    if rerun:
+        # Intentionally re-running a completed (failed) test; serial, no wait needed.
+        return True, 'fail_repetition', False
+    if attempt > 0:
+        # Spark re-tries happen only if there is some failure, so attempts are serial.
+        # The previous attempt died before reporting completion; the query must wait to
+        # find out whether it reported a start.
+        return True, 'task_resubmit', True
+    # Repetitions are the same test intentionally run multiple times, in parallel and
+    # random order; only the first-indexed one may skip the wait.
+    if reps != '1':
+        return True, 'repetition', attempt_index != 1
+    return False, '', False
+
+
 # Normally, we want to use asynchronous reporting of results to not slow down test runs.
 # For test re-try, though, if the prior attempt did not get reported, then the re-try report will
 # fail and then there is no record. So we need to query to check for the prior attempt and in the
@@ -228,31 +255,14 @@ def create_test(test: TestDescriptor, time_sec: float, attempt: int, rerun: bool
     pt = SimpleTestDescriptor.parse(full_name)
     tname = f"{pt.class_name} - {pt.test_name}"
 
-    if rerun:
-        # In this case, we are intentionally re-running a completed test.
-        retry = True
-    else:
-        if attempt > 0:
-            # Spark re-tries happen only if there is some failure, so attempts are serial.
-            retry = True
-            wait = True
-            # In this case the previous attempt died before having a chance to report completion.
-            # We need to query to find out if the previous attempt reported start or not.
-        else:
-            # Repetitions are same test intentionally run multiple times, in parallel and random
-            # order. We need to query to make sure one has at least started before reporting these
-            # as retry.
-            retry = (csi['reps'] != '1')
-            if test.attempt_index == 1:
-                wait = False
-            else:
-                wait = True
-
-        if retry:
-            prev_test = query_test(full_name, wait)
-            if not prev_test:
-                # Found no previous test, so do not call this one a retry.
-                retry = False
+    retry, retry_kind, wait = classify_execution(rerun, attempt, csi['reps'], test.attempt_index)
+    if retry and not rerun:
+        prev_test = query_test(full_name, wait)
+        if not prev_test:
+            # Found no previous test, so do not call this one a retry. The retry_kind
+            # attribute is kept: the execution is still a repetition/resubmit, it just
+            # happens to be the first one that reported.
+            retry = False
 
     # TestCase ID (used to compare across test runs) seems to depend on codeRef & parameters
     # instead we give uniqueId with fully-specified name.  uniqueID is not shown in web UI.
@@ -269,6 +279,8 @@ def create_test(test: TestDescriptor, time_sec: float, attempt: int, rerun: bool
             {'key': 'lang',  'value': test.language}
         ]
     }
+    if retry_kind:
+        req_data['attributes'].append({'key': 'retry_kind', 'value': retry_kind})
     # For cxx tests, the name might not be unique if in different directories, so we add
     # parameter indicating the cxx_rel_binary that is included in test descriptor.
     if pt.cxx_rel_test_binary:

--- a/python/yugabyte/csi_report.py
+++ b/python/yugabyte/csi_report.py
@@ -215,18 +215,27 @@ def query_test(uniqueId: str, wait: bool) -> bool:
 
 # Classify one execution before reporting: the ReportPortal 'retry' flag, the 'retry_kind'
 # item attribute (why this is not a plain first attempt - the empty string for one), and
-# whether a previous-item query must wait. The kinds:
+# whether a previous-item query must wait. The kinds, in precedence order:
 #   fail_repetition - intentional re-run of a test that failed earlier (--fail_repetitions);
 #                     exists only after a first-attempt failure, so it must never enter a
 #                     first-attempt failure rate;
 #   task_resubmit   - Spark re-ran the task because a worker died; an infra artifact;
 #   repetition      - unconditional extra run (--num_repetitions).
+# The shapes overlap: a Spark task resubmit (attempt > 0) can happen inside the
+# fail-repetition job or inside a --num_repetitions job, since both dispatch through the same
+# task path. Only fail_repetition vs repetition is exclusive by construction. The order above
+# resolves the overlap on purpose: a resubmitted fail-repetition is still a run of a test whose
+# first attempt failed, so it keeps the fail_repetition tag (the "first attempt failed"
+# implication stays exact for consumers), and a resubmitted repetition reports task_resubmit
+# because it needs the resubmit wait semantics. Consequence: task_resubmit undercounts infra
+# resubmits by those that occur inside fail-repetition jobs; it is a best-effort signal.
 # Known gap: a driver-level Spark JOB resubmit starts a fresh task with attempt 0 and is
 # indistinguishable from a first attempt here.
 def classify_execution(rerun: bool, attempt: int, reps: str,
                        attempt_index: int) -> Tuple[bool, str, bool]:
     if rerun:
-        # Intentionally re-running a completed (failed) test; serial, no wait needed.
+        # Intentionally re-running a completed (failed) test; serial, no wait needed. Checked
+        # before attempt so a resubmit inside the rerun job keeps this kind (see above).
         return True, 'fail_repetition', False
     if attempt > 0:
         # Spark re-tries happen only if there is some failure, so attempts are serial.

--- a/python/yugabyte/test_csi_report.py
+++ b/python/yugabyte/test_csi_report.py
@@ -156,3 +156,25 @@ def test_delay_grows_with_the_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
     assert csi_report.get_with_retries('http://csi/x', {}, {}) is None
     assert slept == [csi_report.GET_RETRY_DELAY_SEC * attempt
                      for attempt in range(1, csi_report.GET_ATTEMPTS)]
+
+
+# ---------------------------------------------------------------------------------------------
+# classify_execution: the retry_kind decision table. The four execution shapes are mutually
+# exclusive by construction (--fail_repetitions is rejected alongside --num_repetitions > 1),
+# and the kind attribute is what lets downstream consumers separate a fail-repetition (which
+# must never enter a first-attempt failure rate) from a Spark task resubmit (infra artifact)
+# and a plain repetition.
+
+@pytest.mark.parametrize('rerun,attempt,reps,attempt_index,expected', [
+    # expected = (retry, retry_kind, wait)
+    (False, 0, '1', 1, (False, '', False)),                # plain first attempt
+    (True, 0, '1', 1, (True, 'fail_repetition', False)),   # --fail_repetitions re-run
+    (True, 0, '1', 3, (True, 'fail_repetition', False)),
+    (False, 1, '1', 1, (True, 'task_resubmit', True)),     # Spark re-ran a dead task
+    (False, 2, '1', 1, (True, 'task_resubmit', True)),
+    (False, 0, '10', 1, (True, 'repetition', False)),      # first repetition may skip the wait
+    (False, 0, '10', 3, (True, 'repetition', True)),
+])
+def test_classify_execution(rerun: bool, attempt: int, reps: str, attempt_index: int,
+                            expected: Any) -> None:
+    assert csi_report.classify_execution(rerun, attempt, reps, attempt_index) == expected

--- a/python/yugabyte/test_csi_report.py
+++ b/python/yugabyte/test_csi_report.py
@@ -159,11 +159,14 @@ def test_delay_grows_with_the_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # ---------------------------------------------------------------------------------------------
-# classify_execution: the retry_kind decision table. The four execution shapes are mutually
-# exclusive by construction (--fail_repetitions is rejected alongside --num_repetitions > 1),
-# and the kind attribute is what lets downstream consumers separate a fail-repetition (which
-# must never enter a first-attempt failure rate) from a Spark task resubmit (infra artifact)
-# and a plain repetition.
+# classify_execution: the retry_kind decision table. Only fail_repetition vs repetition is
+# exclusive by construction (--fail_repetitions is rejected alongside --num_repetitions > 1);
+# a Spark task resubmit (attempt > 0) can occur inside either job, and the branch order in
+# classify_execution resolves those overlaps: fail_repetition wins (the "first attempt failed"
+# implication must stay exact for consumers), then task_resubmit (needs the resubmit wait),
+# then repetition. The kind attribute is what lets downstream consumers separate a
+# fail-repetition (which must never enter a first-attempt failure rate) from a Spark task
+# resubmit (infra artifact) and a plain repetition.
 
 @pytest.mark.parametrize('rerun,attempt,reps,attempt_index,expected', [
     # expected = (retry, retry_kind, wait)
@@ -174,6 +177,9 @@ def test_delay_grows_with_the_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
     (False, 2, '1', 1, (True, 'task_resubmit', True)),
     (False, 0, '10', 1, (True, 'repetition', False)),      # first repetition may skip the wait
     (False, 0, '10', 3, (True, 'repetition', True)),
+    # Overlaps, resolved by precedence:
+    (True, 1, '1', 2, (True, 'fail_repetition', False)),   # resubmit inside the rerun job
+    (False, 1, '10', 3, (True, 'task_resubmit', True)),    # resubmit inside a repetitions job
 ])
 def test_classify_execution(rerun: bool, attempt: int, reps: str, attempt_index: int,
                             expected: Any) -> None:


### PR DESCRIPTION
Today an intentional re-run of a failed test (--fail_repetitions), a Spark
task resubmit after a worker death, and an unconditional repetition
(--num_repetitions) all reach ReportPortal as an identical bare
'retry: true'. Consumers that need the distinction cannot recover it: the
CSI summary's baseline logic wants "did the FIRST attempt fail" (a
fail-repetition retry exists only after a first-attempt failure, so counting
it into a rate biases the rate upward by construction), and telling a task
resubmit from a real repetition today requires bulk-pulling retried items
and guessing.

All three cases are already decided at item-creation time, so this only
records the decision: a 'retry_kind' item attribute (fail_repetition |
task_resubmit | repetition) riding the existing item-creation POST. Plain
first attempts get no attribute. The attribute is kept even when the retry
flag is demoted because no prior item was found - the execution is still a
repetition or resubmit, it just reported first. The classification lives in
a pure classify_execution function (retry flag, retry_kind, whether the
previous-item query must wait), unit-testable without stubbing HTTP. Known
gap, documented in the comment: a driver-level Spark JOB resubmit starts a
fresh task with attempt 0 and still looks like a first attempt.

No behavior change for any existing consumer: the retry flag, statuses, and
existing attributes are untouched; ReportPortal accepts additional keyed
attributes in the same array (create_test already sends keyed attributes).

Test plan: python3 -m py_compile passes; test_csi_report.py carries a
seven-row decision table over classify_execution (runs in CI codecheck).
The read side that consumes the attribute (jenkins-helpers csi summary
baseline change) is being prepared separately and must land after this is
deployed on the lanes it reads.




CI note: the full 8-lane matrix ran on the first head (c8ddc581bdd) and produced tagged retries on every lane (CSI launches PR33682-*). The second commit changes comments and the pytest table only (20 tests pass locally), so the run for the required status is restricted to one lane and one small test rather than repeating the matrix.

Jenkins: cpp only
Jenkins: build type: fastdebug
Jenkins: test regex: tests-util/status-test

