### PR TITLE
[#33444] DocDB: Add verification scan accounting and master outcome counters

### DIFF
--- a/src/yb/docdb/unique_index_verifier-test.cc
+++ b/src/yb/docdb/unique_index_verifier-test.cc
@@ -448,4 +448,29 @@ TEST_F(UniqueIndexVerifierTest, OversizedGroupFallsBackToReverseWalk) {
   ExpectOutcome(UniqueIndexVerificationOutcome::kClean, clean_result);
 }
 
+TEST_F(UniqueIndexVerifierTest, FallbackAccountingMatchesBuffered) {
+  // The same physical data verified through both replay paths must report identical
+  // versions_scanned: the forward pass owns the accounting, and the reverse walk's re-visits
+  // are recorded as fallback_groups instead of being re-counted.
+  WriteBackfillInsert(1, "ctid-A");
+  WriteRowTombstone(1, 4000_usec_ht);
+  WriteNonPackedInsert(1, "ctid-B", 5000_usec_ht, /* first_write_id= */ 0);
+  for (int i = 0; i != 8; ++i) {
+    WriteInPlaceIdentityUpdate(1, "ctid-B", HybridTime::FromMicros(6000 + i), /* write_id= */ 0);
+  }
+  WriteBackfillInsert(2, "ctid-C");
+
+  auto buffered = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, buffered);
+  ASSERT_EQ(0, buffered.fallback_groups);
+  ASSERT_GT(buffered.versions_scanned, 0);
+
+  auto fallback = ASSERT_RESULT(Verify(
+      /* max_dockey_groups= */ 0, std::string(), /* max_buffered= */ 4));
+  ExpectOutcome(UniqueIndexVerificationOutcome::kClean, fallback);
+  ASSERT_EQ(1, fallback.fallback_groups);  // Group 1 overflowed the bound; group 2 buffered.
+  ASSERT_EQ(buffered.dockey_groups_scanned, fallback.dockey_groups_scanned);
+  ASSERT_EQ(buffered.versions_scanned, fallback.versions_scanned);
+}
+
 }  // namespace yb::docdb

--- a/src/yb/docdb/unique_index_verifier.cc
+++ b/src/yb/docdb/unique_index_verifier.cc
@@ -146,9 +146,12 @@ class Verifier {
     bool buffering = true;
 
     while (iter_.Valid() && iter_.key().starts_with(group_prefix)) {
+      // The forward pass visits every physical version of the group exactly once, whichever
+      // replay path runs, so it owns the versions_scanned accounting; the reverse walk's
+      // re-visits are deliberately not re-counted (fallback_groups records that extra work).
+      ++result_.versions_scanned;
       if (buffering) {
         auto record = VERIFY_RESULT(DecodeRecord(group_prefix, iter_.key(), iter_.value()));
-        ++result_.versions_scanned;
         if (record) {
           buffered.push_back(std::move(*record));
         }
@@ -167,6 +170,7 @@ class Verifier {
     if (buffering) {
       return ReplayBuffered(std::move(buffered));
     }
+    ++result_.fallback_groups;
     return ReverseWalkGroup(group_prefix);
   }
 
@@ -280,7 +284,6 @@ class Verifier {
             return Status::OK();
           }
           if (!record) {  // Outside the window.
-            ++result_.versions_scanned;
             cursor.Advance();
             continue;
           }
@@ -296,7 +299,6 @@ class Verifier {
       if (next == nullptr) {
         break;
       }
-      ++result_.versions_scanned;
       next->Advance();
 
       if (!ht_batch.empty() &&
@@ -595,7 +597,7 @@ class Verifier {
 
 std::string UniqueIndexVerificationResult::ToString() const {
   return YB_STRUCT_TO_STRING(outcome, reason, dockey_groups_scanned, versions_scanned,
-                             resume_from_dockey);
+                             fallback_groups, resume_from_dockey);
 }
 
 Result<UniqueIndexVerificationResult> VerifyUniqueIndexTablet(

--- a/src/yb/docdb/unique_index_verifier.h
+++ b/src/yb/docdb/unique_index_verifier.h
@@ -74,7 +74,13 @@ struct UniqueIndexVerificationResult {
   std::string resume_from_dockey;
 
   size_t dockey_groups_scanned = 0;
+  // Physical versions in the scanned groups, counted exactly once per version regardless of
+  // which replay path ran (the bounded-memory reverse walk's re-visits are not re-counted;
+  // fallback_groups records that extra work instead).
   size_t versions_scanned = 0;
+  // Groups that exceeded max_buffered_versions_per_group and took the bounded-memory
+  // reverse walk, which re-reads the group (roughly doubling its scan cost).
+  size_t fallback_groups = 0;
 
   std::string ToString() const;
 };

--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -1332,6 +1332,9 @@ Status BackfillTable::StartShadowVerificationForNextIndex() {
       sv.pending_tablets.clear();
       sv.in_flight = 0;
       sv.terminal = false;
+      sv.dockey_groups_scanned = 0;
+      sv.versions_scanned = 0;
+      sv.fallback_groups = 0;
     }
   }
   if (!index_table) {
@@ -1432,6 +1435,13 @@ void BackfillTable::ShadowVerificationTabletDone(
   const bool clean = status.ok() &&
                      resp.outcome() == tserver::VerifyUniqueIndexTabletResponsePB::CLEAN;
 
+  if (status.ok()) {
+    // Cluster-wide scan accounting counts every completed scan segment's work, including
+    // late responses dropped by the single-winner guard below -- the scan happened.
+    master_->catalog_manager_impl()->RecordUniqueIndexVerificationScan(
+        resp.versions_scanned(), resp.fallback_groups());
+  }
+
   // Single-winner protocol: the terminal check and the launch-next / index-done decision are
   // one critical section, so a CLEAN callback racing a short-circuiting VIOLATION can neither
   // overwrite the recorded outcome nor double-advance to the next index. Exactly one callback
@@ -1447,6 +1457,11 @@ void BackfillTable::ShadowVerificationTabletDone(
       return;  // A winner already recorded this index's outcome; late responses are ignored.
     }
     index_table_id = sv.current_index->id();
+    if (status.ok()) {
+      sv.dockey_groups_scanned += resp.dockey_groups_scanned();
+      sv.versions_scanned += resp.versions_scanned();
+      sv.fallback_groups += resp.fallback_groups();
+    }
     if (clean && resp.has_resume_key()) {
       action = Action::kResume;  // Pagination: same tablet continues; join counts untouched.
     } else if (clean) {
@@ -1559,7 +1574,9 @@ void BackfillTable::ShadowVerificationPhaseFailed(
     // marked when the chunks completed), so whatever is still IN_PROGRESS is exactly the
     // unverified set: the in-flight index if Record's marking failed, indexes the phase never
     // reached, and indexes never selected because resolution itself failed. All are equally
-    // unverified; fail them rather than publish.
+    // unverified; fail them rather than publish. (Never-reached indexes get no per-index
+    // outcome counter -- only Record increments those -- so outcome_inconclusive undercounts
+    // in multi-index jobs; YSQL backfill jobs are single-index.)
     const auto unverified = indexes_to_build();
     if (!unverified.empty()) {
       WARN_NOT_OK(
@@ -1573,6 +1590,9 @@ void BackfillTable::ShadowVerificationPhaseFailed(
 Status BackfillTable::RecordShadowVerificationOutcome(
     UniqueIndexVerificationStatePB::State state, const std::string& reason) {
   TableId index_table_id;
+  uint64_t dockey_groups_scanned = 0;
+  uint64_t versions_scanned = 0;
+  uint64_t fallback_groups = 0;
   {
     std::lock_guard l(mutex_);
     if (!shadow_verification_.current_index) {
@@ -1581,6 +1601,9 @@ Status BackfillTable::RecordShadowVerificationOutcome(
       return Status::OK();
     }
     index_table_id = shadow_verification_.current_index->id();
+    dockey_groups_scanned = shadow_verification_.dockey_groups_scanned;
+    versions_scanned = shadow_verification_.versions_scanned;
+    fallback_groups = shadow_verification_.fallback_groups;
   }
   RETURN_NOT_OK(MutateVerificationState(
       index_table_id, [state, &reason](UniqueIndexVerificationStatePB* state_pb) {
@@ -1589,6 +1612,7 @@ Status BackfillTable::RecordShadowVerificationOutcome(
           state_pb->set_reason(reason);
         }
       }));
+  master_->catalog_manager_impl()->RecordUniqueIndexVerificationOutcome(state);
   const bool gating = verification_gates_publication();
   const auto severity_prefix =
       state == UniqueIndexVerificationStatePB::VERIFY_CLEAN ? "" : "NOT CLEAN: ";
@@ -1596,7 +1620,10 @@ Status BackfillTable::RecordShadowVerificationOutcome(
                         << ": " << severity_prefix
                         << UniqueIndexVerificationStatePB::State_Name(state)
                         << (reason.empty() ? "" : Format(" ($0)", reason))
-                        << (gating ? " [gating]" : " [observational]");
+                        << (gating ? " [gating]" : " [observational]")
+                        << Format(
+                               " (dockey_groups=$0, versions=$1, fallback_groups=$2)",
+                               dockey_groups_scanned, versions_scanned, fallback_groups);
   if (!gating) {
     // Observational: the outcome is recorded and logged, never enforced.
     return Status::OK();

--- a/src/yb/master/backfill_index.h
+++ b/src/yb/master/backfill_index.h
@@ -336,6 +336,11 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
     std::deque<TabletInfoPtr> pending_tablets;
     size_t in_flight = 0;
     bool terminal = false;  // Current index reached an outcome; late responses are ignored.
+    // Scan accounting for the current index, aggregated from per-tablet responses and logged
+    // with the recorded outcome. Resets when the next index starts.
+    uint64_t dockey_groups_scanned = 0;
+    uint64_t versions_scanned = 0;
+    uint64_t fallback_groups = 0;
   };
   ShadowVerificationState shadow_verification_ GUARDED_BY(mutex_);
   std::atomic_bool using_table_locks_{false};

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -562,6 +562,34 @@ METRIC_DEFINE_counter(cluster, backfill_aborted,
     yb::MetricUnit::kRequests,
     "Counts BackfillTable::Abort invocations on the master.");
 
+METRIC_DEFINE_counter(cluster, unique_index_verification_outcome_clean,
+    "Unique-Index Verifications Completed Clean", yb::MetricUnit::kUnits,
+    "Per-index outcomes of deferred unique-index verification that found no violation.");
+
+METRIC_DEFINE_counter(cluster, unique_index_verification_outcome_violation,
+    "Unique-Index Verifications That Found a Violation", yb::MetricUnit::kUnits,
+    "Per-index outcomes of deferred unique-index verification that found a uniqueness "
+    "violation. In fail-closed mode these fail the index build; in observational (shadow) "
+    "mode they are recorded and logged only.");
+
+METRIC_DEFINE_counter(cluster, unique_index_verification_outcome_inconclusive,
+    "Unique-Index Verifications That Were Inconclusive", yb::MetricUnit::kUnits,
+    "Per-index outcomes of deferred unique-index verification that could prove neither "
+    "cleanliness nor a violation (scan errors, unresolvable encodings, coordinator "
+    "failures). In fail-closed mode these fail the index build.");
+
+METRIC_DEFINE_counter(cluster, unique_index_verification_versions_scanned,
+    "Physical Versions Scanned by Unique-Index Verification", yb::MetricUnit::kKeys,
+    "Total physical versions scanned by deferred unique-index verification, aggregated from "
+    "per-tablet scan responses. Each version is counted once regardless of replay path.");
+
+METRIC_DEFINE_counter(cluster, unique_index_verification_fallback_groups,
+    "DocKey Groups That Took the Verifier's Bounded-Memory Fallback", yb::MetricUnit::kUnits,
+    "DocKey groups whose version count exceeded the verifier's buffering bound and were "
+    "replayed by the bounded-memory reverse walk, which re-reads the group (roughly doubling "
+    "its scan cost). A persistently high rate suggests raising "
+    "unique_index_verify_max_buffered_versions_per_group.");
+
 DEFINE_test_flag(bool, duplicate_addtabletotablet_request, false,
     "Send a duplicate AddTableToTablet request to the tserver to simulate a retry.");
 
@@ -1156,6 +1184,22 @@ Status CatalogManager::Init() {
 
   metric_backfill_aborted_ =
       METRIC_backfill_aborted.Instantiate(master_->metric_entity_cluster());
+
+  metric_unique_index_verification_outcome_clean_ =
+      METRIC_unique_index_verification_outcome_clean.Instantiate(
+          master_->metric_entity_cluster());
+  metric_unique_index_verification_outcome_violation_ =
+      METRIC_unique_index_verification_outcome_violation.Instantiate(
+          master_->metric_entity_cluster());
+  metric_unique_index_verification_outcome_inconclusive_ =
+      METRIC_unique_index_verification_outcome_inconclusive.Instantiate(
+          master_->metric_entity_cluster());
+  metric_unique_index_verification_versions_scanned_ =
+      METRIC_unique_index_verification_versions_scanned.Instantiate(
+          master_->metric_entity_cluster());
+  metric_unique_index_verification_fallback_groups_ =
+      METRIC_unique_index_verification_fallback_groups.Instantiate(
+          master_->metric_entity_cluster());
 
   metric_max_follower_heartbeat_delay_ =
     METRIC_max_follower_heartbeat_delay.Instantiate(master_->metric_entity_cluster(), 0);
@@ -11387,6 +11431,39 @@ Status CatalogManager::UpdateMastersListInMemoryAndDisk() {
 
 void CatalogManager::IncrementBackfillAborted() {
   IncrementCounter(metric_backfill_aborted_);
+}
+
+void CatalogManager::RecordUniqueIndexVerificationScan(
+    uint64_t versions_scanned, uint64_t fallback_groups) {
+  // static_cast, not narrow_cast: same-width sign conversion (narrow_cast requires a
+  // strictly narrower destination). Scan counts cannot approach int64 range.
+  IncrementCounterBy(
+      metric_unique_index_verification_versions_scanned_, static_cast<int64_t>(versions_scanned));
+  IncrementCounterBy(
+      metric_unique_index_verification_fallback_groups_, static_cast<int64_t>(fallback_groups));
+}
+
+// At-least-once across failover: a resumed job re-drives Record for an index whose outcome
+// persisted but whose marking did not, and the counters are process-local to the leader --
+// treat them as approximate across failover, never exact.
+void CatalogManager::RecordUniqueIndexVerificationOutcome(
+    UniqueIndexVerificationStatePB::State state) {
+  switch (state) {
+    case UniqueIndexVerificationStatePB::VERIFY_CLEAN:
+      IncrementCounter(metric_unique_index_verification_outcome_clean_);
+      return;
+    case UniqueIndexVerificationStatePB::VERIFY_VIOLATION:
+      IncrementCounter(metric_unique_index_verification_outcome_violation_);
+      return;
+    case UniqueIndexVerificationStatePB::VERIFY_INCONCLUSIVE:
+      IncrementCounter(metric_unique_index_verification_outcome_inconclusive_);
+      return;
+    case UniqueIndexVerificationStatePB::VERIFY_NONE: [[fallthrough]];
+    case UniqueIndexVerificationStatePB::VERIFY_IN_PROGRESS:
+      // Not terminal outcomes; nothing to count.
+      return;
+  }
+  FATAL_INVALID_ENUM_VALUE(UniqueIndexVerificationStatePB::State, state);
 }
 
 Status CatalogManager::EnableBgTasks() {

--- a/src/yb/master/catalog_manager.h
+++ b/src/yb/master/catalog_manager.h
@@ -1954,6 +1954,11 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
 
   void IncrementBackfillAborted();
 
+  // Deferred unique-index verification observability: scan accounting aggregated from
+  // per-tablet verification responses, and per-index terminal outcomes.
+  void RecordUniqueIndexVerificationScan(uint64_t versions_scanned, uint64_t fallback_groups);
+  void RecordUniqueIndexVerificationOutcome(UniqueIndexVerificationStatePB::State state);
+
  protected:
   // TODO Get rid of these friend classes and introduce formal interface.
   friend class TableLoader;
@@ -2660,6 +2665,12 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
   scoped_refptr<Counter> metric_create_table_too_many_tablets_;
 
   scoped_refptr<Counter> metric_backfill_aborted_;
+
+  scoped_refptr<Counter> metric_unique_index_verification_outcome_clean_;
+  scoped_refptr<Counter> metric_unique_index_verification_outcome_violation_;
+  scoped_refptr<Counter> metric_unique_index_verification_outcome_inconclusive_;
+  scoped_refptr<Counter> metric_unique_index_verification_versions_scanned_;
+  scoped_refptr<Counter> metric_unique_index_verification_fallback_groups_;
 
   scoped_refptr<AtomicGauge<uint64_t>> metric_max_follower_heartbeat_delay_;
 

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -851,6 +851,7 @@ void TabletServiceAdminImpl::VerifyUniqueIndexTablet(
   }
   resp->set_dockey_groups_scanned(result->dockey_groups_scanned);
   resp->set_versions_scanned(result->versions_scanned);
+  resp->set_fallback_groups(result->fallback_groups);
   resp->set_propagated_hybrid_time(server_->Clock()->Now().ToUint64());
   context.RespondSuccess();
 }

--- a/src/yb/tserver/tserver_admin.proto
+++ b/src/yb/tserver/tserver_admin.proto
@@ -187,7 +187,12 @@ message VerifyUniqueIndexTabletResponsePB {
   optional bytes resume_key = 5;
 
   optional uint64 dockey_groups_scanned = 6;
+  // Physical versions in the scanned groups, counted once per version regardless of which
+  // replay path ran.
   optional uint64 versions_scanned = 7;
+  // Groups that exceeded the buffering bound and took the bounded-memory reverse walk,
+  // which re-reads the group (roughly doubling its scan cost).
+  optional uint64 fallback_groups = 8;
 }
 
 // A create tablet request.

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -50,6 +50,8 @@
 
 METRIC_DECLARE_entity(cluster);
 METRIC_DECLARE_counter(backfill_aborted);
+METRIC_DECLARE_counter(unique_index_verification_outcome_clean);
+METRIC_DECLARE_counter(unique_index_verification_versions_scanned);
 
 using std::string;
 
@@ -1811,6 +1813,17 @@ TEST_P(PgIndexBackfillShadowVerification, CleanOutcomeRecordedMultiTablet) {
 
   ASSERT_OK(clean_waiter.WaitFor(MonoDelta::FromSeconds(60) * kTimeMultiplier));
   ASSERT_OK(CheckIndexConsistency(kIndexName));
+
+  // Master-side observability: the per-index outcome counter and the scan accounting
+  // aggregated from the per-tablet responses. Exactly one job with one unique index and no
+  // failover ran, so the outcome counter is exact -- this would catch a double-count.
+  auto* master = cluster_->GetLeaderMaster();
+  ASSERT_EQ(1, ASSERT_RESULT(master->GetMetric<int64>(
+      &METRIC_ENTITY_cluster, nullptr, &METRIC_unique_index_verification_outcome_clean,
+      "value")));
+  ASSERT_GT(ASSERT_RESULT(master->GetMetric<int64>(
+      &METRIC_ENTITY_cluster, nullptr, &METRIC_unique_index_verification_versions_scanned,
+      "value")), 0);
 }
 
 TEST_P(PgIndexBackfillShadowVerification, ViolationRecordedButDoesNotBlockPublication) {


### PR DESCRIPTION
## Summary

Verification/job observability for deferred unique-index verification (#33444), plus the
accounting fix deferred from the verifier-core review: `versions_scanned` was inconsistent
on the bounded-memory fallback path (the forward pass stopped counting at buffer overflow,
then the reverse walk re-counted its re-visits -- over- and under-counting the same group).
The forward pass now owns the accounting -- every physical version in a scanned group is
counted exactly once regardless of replay path -- and the new `fallback_groups` counter
records the reverse walk's extra work instead (a fallback group is read roughly twice; a
persistently high rate is the signal to raise
`unique_index_verify_max_buffered_versions_per_group`, and the counter description says so).

- `VerifyUniqueIndexTabletResponsePB` gains `fallback_groups` (field 8).
- The shadow coordinator aggregates per-index scan totals from every response and logs them
  with the recorded outcome:
  `... VERIFY_CLEAN [observational] (dockey_groups=300, versions=300, fallback_groups=0)`.
- Five cluster-level master counters (the `backfill_aborted` pattern):
  `unique_index_verification_outcome_{clean,violation,inconclusive}` -- one per recorded
  per-index outcome, at-least-once across failover resume and process-local to the leader,
  so approximate by design (documented) -- and
  `unique_index_verification_{versions_scanned,fallback_groups}`, aggregated from responses.
  Late responses dropped by the coordinator's single-winner guard still count scan work: the
  scan happened.

Stacked on #33403, #33404, #33484, #33544, #33553, #33580, #33584, #33601, #33602, #33654,
#33655, #33656, and #33657, based on
`feature-stack/Shopify/uniq-idx-8a-retention-observability` per the feature-stack workflow,
so the diff is exactly this PR's own commit. A failing pr-title check on stacked PRs is a
known gap in that check; the stack merges bottom-up and retargets as parents merge.

## Upgrade/Rollback safety

The wire change is one additive proto2 field, `VerifyUniqueIndexTabletResponsePB.fallback_groups`
(field 8), tolerant in both directions: an old tserver omits it and the master aggregates 0;
an old master ignores it as an unknown field. The verification RPC itself is
production-unreachable until activation (default-off flags, CHECK_ALL selector), and the
master counters are process-local metrics with no persisted state. No flag-default changes.

## Test plan

macOS arm64, release -- all green:

- [x] New: `UniqueIndexVerifierTest.FallbackAccountingMatchesBuffered` -- the accounting
      pin: identical data through the buffered and fallback paths reports identical
      `versions_scanned` and `dockey_groups_scanned`; the fallback run reports
      `fallback_groups = 1`.
- [x] Extended: `PgIndexBackfillShadowVerification.CleanOutcomeRecordedMultiTablet/0` --
      asserts the master outcome counter == 1 (exact on a fresh cluster: one job, one index,
      no failover -- catches double-counting) and `versions_scanned > 0` via the cluster
      metric entity.
- [x] Full `unique_index_verifier-test` (19/19 at this layer).
- [x] Regressions: `ViolationRecordedButDoesNotBlockPublication` (waiter matches the
      enriched log line), `ViolationFailsCreateIndex` (gating path through Record), failover
      resume, paginated clean.

AlmaLinux (x86_64, clang21), rebased onto master `c7253d204d`:

At this PR's own commit (`1d70d52997`), ASAN -- all green:

- [x] `unique_index_verifier-test` (carries this PR's scan-accounting changes).
- [x] `PgIndexBackfillShadowVerification.CleanOutcomeRecordedMultiTablet`, both params --
      the test carrying this PR's master-counter assertions.

Integrated at the stack tip (`334a1deb3d`), all green. Exact suites per build type:

- [x] TSAN (6): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `non_transactional_batch_writer-test`,
      `keyed_fingerprint-test`, `raft_consensus-itest`.
- [x] ASAN (15): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `keyed_fingerprint-test`,
      `non_transactional_batch_writer-test`, `clone-tablet-itest`,
      `remote_bootstrap-itest`, `tablet_bootstrap-test`, `auto_flags-itest`,
      `docdb-test`, `compaction_file_filter-test`,
      `xcluster_external_apply_bootstrap-test`, `pg_txn-test`, `pg_ash-test`,
      full `pg_index_backfill-test`.
- [x] Debug (19): the ASAN list minus `compaction_file_filter-test`, plus
      `master_failover-itest`, `snapshot-test`, `tablet_snapshots-test`,
      `compaction-test`, `tablet-split-itest`.
- [x] Release (5): `keyed_fingerprint-test`, `auto_flags-itest`, full
      `pg_index_backfill-test`, java `TestIndexBackfill`, java
      `TestPgRegressBackfillIndex`.
- [x] All three full `pg_index_backfill-test` runs (ASAN, debug, release) pass with no
      test failures.

Two known-upstream issues surfaced by the tip matrix, both shown not attributable to this
stack:

- TSAN `tablet-split-itest` reports 3 data races in `yb::client::YBTable::~YBTable()`
  (table.cc:81) racing its partition-refresh callback, inside the upstream test
  `AutomaticTabletSplitITest.SizeRatio` (93 cases ran, 0 gtest failures). This stack has zero
  diff under `src/yb/client/`, and that test passes 3/3 isolated at the new master base.
- `wait_states-itest` hangs 9 cases at the 601s timeout (`AshCql`, the `kYCQL_*` group,
  `kBackfillIndex_*`, `kConsensusMeta_Flush`, `kCreatingNewTablet`,
  `kSaveRaftGroupMetadataToDisk`). Reproduced identically on plain master `c7253d204d`
  carrying none of this stack's code: 53 ran, the same 9 failed, same ~600.5s expiries.
  Tracked upstream in #33729.

Disposition change since the previous revision: the
`PgIndexBackfillBackendsManager.NoAbortTxn/1` flake cited earlier was fixed upstream. It
passes 3/3 at the new base and in all three full `pg_index_backfill-test` runs here, so it is
no longer carried as a known flake.


