### PR TITLE
[#33444] DocDB: Add a keyed, per-job violation fingerprint to unique-index verification

### DIFF
--- a/src/yb/docdb/unique_index_verifier-test.cc
+++ b/src/yb/docdb/unique_index_verifier-test.cc
@@ -418,6 +418,8 @@ TEST_F(UniqueIndexVerifierTest, PaginationIsDocKeyAligned) {
   ExpectOutcome(UniqueIndexVerificationOutcome::kClean, first_page);
   ASSERT_EQ(1, first_page.dockey_groups_scanned);
   ASSERT_FALSE(first_page.resume_from_dockey.empty());
+  // The resume key is raw index key bytes; ToString renders only its size.
+  ASSERT_STR_NOT_CONTAINS(first_page.ToString(), first_page.resume_from_dockey);
 
   auto second_page = ASSERT_RESULT(
       Verify(/* max_dockey_groups= */ 0, first_page.resume_from_dockey));
@@ -446,6 +448,18 @@ TEST_F(UniqueIndexVerifierTest, OversizedGroupFallsBackToReverseWalk) {
   auto clean_result = ASSERT_RESULT(Verify(
       /* max_dockey_groups= */ 1, std::string(), /* max_buffered= */ 4));
   ExpectOutcome(UniqueIndexVerificationOutcome::kClean, clean_result);
+}
+
+TEST_F(UniqueIndexVerifierTest, ViolationExposesGroupPrefixInMemoryOnly) {
+  WriteBackfillInsert(1, "ctid-A", kBackfillWriteId);
+  WriteBackfillInsert(1, "ctid-B", kBackfillWriteId + 1);
+  auto result = ASSERT_RESULT(Verify());
+  ExpectOutcome(UniqueIndexVerificationOutcome::kViolation, result);
+  // The violating group's raw encoded DocKey is exposed for the caller's keyed fingerprint --
+  // in memory only: ToString must exclude it (raw index key bytes must not reach logs).
+  ASSERT_FALSE(result.violating_group_prefix.empty());
+  ASSERT_STR_NOT_CONTAINS(result.ToString(), "violating_group_prefix");
+  ASSERT_STR_NOT_CONTAINS(result.ToString(), result.violating_group_prefix);
 }
 
 TEST_F(UniqueIndexVerifierTest, FallbackAccountingMatchesBuffered) {

--- a/src/yb/docdb/unique_index_verifier.cc
+++ b/src/yb/docdb/unique_index_verifier.cc
@@ -122,6 +122,9 @@ class Verifier {
 
       RETURN_NOT_OK(VerifyGroup(group_prefix));
       if (result_.outcome != UniqueIndexVerificationOutcome::kClean) {
+        if (result_.outcome == UniqueIndexVerificationOutcome::kViolation) {
+          result_.violating_group_prefix = group_prefix_str;
+        }
         return result_;
       }
       ++result_.dockey_groups_scanned;
@@ -596,8 +599,11 @@ class Verifier {
 }  // namespace
 
 std::string UniqueIndexVerificationResult::ToString() const {
+  // resume_from_dockey is raw index key bytes -- the same contract as violating_group_prefix:
+  // never in logs. Its size still tells whether (and roughly where) the scan stopped early.
+  const auto resume_from_dockey_size = resume_from_dockey.size();
   return YB_STRUCT_TO_STRING(outcome, reason, dockey_groups_scanned, versions_scanned,
-                             fallback_groups, resume_from_dockey);
+                             fallback_groups, resume_from_dockey_size);
 }
 
 Result<UniqueIndexVerificationResult> VerifyUniqueIndexTablet(

--- a/src/yb/docdb/unique_index_verifier.h
+++ b/src/yb/docdb/unique_index_verifier.h
@@ -65,9 +65,13 @@ struct UniqueIndexVerificationResult {
   UniqueIndexVerificationOutcome outcome = UniqueIndexVerificationOutcome::kClean;
 
   // Value-free context for kViolation / kInconclusive: encoding classes and counts only,
-  // never key or value bytes. (A keyed diagnostic fingerprint is deliberately absent until
-  // the observability part lands; see the design document's privacy requirements.)
+  // never key or value bytes.
   std::string reason;
+
+  // Raw encoded DocKey group of the first violating group: the in-process input for the
+  // caller's keyed diagnostic fingerprint. Never serialized, and deliberately excluded from
+  // ToString() -- raw index key bytes must not reach logs, errors, or support bundles.
+  std::string violating_group_prefix;
 
   // Non-empty when the scan stopped early (group budget or deadline): the encoded DocKey to
   // resume from. Empty means the scan reached the end of the key bounds.

--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -30,6 +30,7 @@
 #include "yb/ash/wait_state.h"
 
 #include "yb/tserver/tserver_admin.proxy.h"
+#include "yb/tserver/tserver_admin_util.h"
 
 #include "yb/common/common_util.h"
 #include "yb/common/doc_hybrid_time.h"
@@ -59,6 +60,7 @@
 #include "yb/tablet/tablet_metadata.h"
 #include "yb/tablet/tablet_peer.h"
 
+#include "yb/util/keyed_fingerprint.h"
 #include "yb/util/logging.h"
 #include "yb/util/status_format.h"
 #include "yb/util/status_log.h"
@@ -743,12 +745,17 @@ BackfillTable::BackfillTable(
   if (pb.backfill_jobs_size() > 0) {
     unique_index_backfill_mode_ = pb.backfill_jobs(0).unique_index_backfill_mode();
     verification_gates_publication_ = pb.backfill_jobs(0).verification_gates_publication();
+    verification_fingerprint_key_ = pb.backfill_jobs(0).verification_fingerprint_key();
   } else {
     unique_index_backfill_mode_ = SelectUniqueIndexBackfillMode();
     verification_gates_publication_ =
         FLAGS_ysql_index_backfill_fail_closed_verification &&
         unique_index_backfill_mode_ == UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_SKIP_ALL &&
         pb.table_type() == TableType::PGSQL_TABLE_TYPE;
+    // Only SKIP_ALL jobs can run verification, so only they carry a fingerprint key.
+    if (unique_index_backfill_mode_ == UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_SKIP_ALL) {
+      verification_fingerprint_key_ = GenerateFingerprintKey();
+    }
   }
   if (pb.backfill_jobs_size() > 0 && pb.backfill_jobs(0).has_backfilling_timestamp() &&
       read_time_for_backfill_.FromUint64(pb.backfill_jobs(0).backfilling_timestamp()).ok()) {
@@ -819,6 +826,9 @@ Status BackfillTable::Launch() {
       }
       backfill_job->set_unique_index_backfill_mode(unique_index_backfill_mode_);
       backfill_job->set_verification_gates_publication(verification_gates_publication_);
+      if (!verification_fingerprint_key_.empty()) {
+        backfill_job->set_verification_fingerprint_key(verification_fingerprint_key_);
+      }
       LOG_WITH_PREFIX(INFO) << "Selected unique-index backfill mode "
                             << UniqueIndexBackfillMode_Name(unique_index_backfill_mode_)
                             << (verification_gates_publication_
@@ -1536,7 +1546,7 @@ void BackfillTable::ShadowVerificationTabletDone(
         outcome = UniqueIndexVerificationStatePB::VERIFY_INCONCLUSIVE;
         reason = "response without an outcome";
       }
-      auto s = RecordShadowVerificationOutcome(outcome, reason);
+      auto s = RecordShadowVerificationOutcome(outcome, reason, resp.violation_fingerprint());
       if (s.ok()) {
         s = StartShadowVerificationForNextIndex();
       }
@@ -1588,7 +1598,8 @@ void BackfillTable::ShadowVerificationPhaseFailed(
 }
 
 Status BackfillTable::RecordShadowVerificationOutcome(
-    UniqueIndexVerificationStatePB::State state, const std::string& reason) {
+    UniqueIndexVerificationStatePB::State state, const std::string& reason,
+    const std::string& violation_fingerprint) {
   TableId index_table_id;
   uint64_t dockey_groups_scanned = 0;
   uint64_t versions_scanned = 0;
@@ -1606,10 +1617,14 @@ Status BackfillTable::RecordShadowVerificationOutcome(
     fallback_groups = shadow_verification_.fallback_groups;
   }
   RETURN_NOT_OK(MutateVerificationState(
-      index_table_id, [state, &reason](UniqueIndexVerificationStatePB* state_pb) {
+      index_table_id,
+      [state, &reason, &violation_fingerprint](UniqueIndexVerificationStatePB* state_pb) {
         state_pb->set_state(state);
         if (!reason.empty()) {
           state_pb->set_reason(reason);
+        }
+        if (!violation_fingerprint.empty()) {
+          state_pb->set_violation_fingerprint(violation_fingerprint);
         }
       }));
   master_->catalog_manager_impl()->RecordUniqueIndexVerificationOutcome(state);
@@ -1758,8 +1773,11 @@ Status BackfillTable::MarkIndexesAsDesired(
     for (const auto& idx_id : index_ids_set) {
       auto iter = backfill_state_pb->find(idx_id);
       if (iter == backfill_state_pb->end()) {
+        // The fingerprint key is a secret; never log it.
+        auto job_for_log = indexed_table_pb.backfill_jobs(0);
+        job_for_log.clear_verification_fingerprint_key();
         LOG(INFO) << "Index " << idx_id << " is not being backfilled. Current backfill_job: "
-                  << indexed_table_pb.backfill_jobs(0).ShortDebugString();
+                  << job_for_log.ShortDebugString();
         return STATUS_FORMAT(InvalidArgument, "Index $0 is not being backfilled", idx_id);
       }
       backfill_state_pb->at(idx_id) = state;
@@ -2456,10 +2474,13 @@ bool VerifyUniqueIndexForTablet::SendRequest(int attempt) {
   if (FLAGS_index_backfill_shadow_verification_dockey_groups_per_rpc > 0) {
     req.set_max_dockey_groups(FLAGS_index_backfill_shadow_verification_dockey_groups_per_rpc);
   }
+  if (!backfill_table_->verification_fingerprint_key().empty()) {
+    req.set_verification_fingerprint_key(backfill_table_->verification_fingerprint_key());
+  }
 
   ts_admin_proxy_->VerifyUniqueIndexTabletAsync(req, &resp_, &rpc_, BindRpcCallback());
   VLOG(1) << "Send " << description() << " to " << permanent_uuid()
-          << " (attempt " << attempt << "):\n" << req.DebugString();
+          << " (attempt " << attempt << "):\n" << tserver::RedactedDebugString(req);
   return true;
 }
 

--- a/src/yb/master/backfill_index.h
+++ b/src/yb/master/backfill_index.h
@@ -183,6 +183,12 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
     return verification_gates_publication_;
   }
 
+  // Per-job secret for keyed violation fingerprints; latched and persisted like the mode.
+  // In-process use only (verification requests): it must never reach logs or RPC responses.
+  const std::string& verification_fingerprint_key() const {
+    return verification_fingerprint_key_;
+  }
+
   const std::unordered_set<TableId> indexes_to_build() const;
 
   const TableId& indexed_table_id() const { return indexed_table_->id(); }
@@ -252,7 +258,8 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
   Status LaunchShadowVerificationTablet(
       const TabletInfoPtr& tablet, const std::string& start_key) EXCLUDES(mutex_);
   Status RecordShadowVerificationOutcome(
-      UniqueIndexVerificationStatePB::State state, const std::string& reason) EXCLUDES(mutex_);
+      UniqueIndexVerificationStatePB::State state, const std::string& reason,
+      const std::string& violation_fingerprint = std::string()) EXCLUDES(mutex_);
   Status FinishShadowVerification();
 
   // Coordinator failure: the phase is on the CREATE INDEX critical path and must never
@@ -320,6 +327,7 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
   UniqueIndexBackfillMode unique_index_backfill_mode_ =
       UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_CHECK_ALL;
   bool verification_gates_publication_ = false;
+  std::string verification_fingerprint_key_;
 
   std::atomic<State> state_{State::kRunning};
   std::atomic_bool timestamp_chosen_{false};

--- a/src/yb/master/catalog_entity_info.proto
+++ b/src/yb/master/catalog_entity_info.proto
@@ -68,6 +68,11 @@ message BackfillJobPB {
   // immutable for the job's lifetime, across master failover, retries, and runtime flag
   // changes. Missing means observational (shadow) semantics.
   optional bool verification_gates_publication = 8;
+
+  // Per-job secret for keyed violation fingerprints. Generated with the job and deleted with
+  // it: fingerprints correlate across the job's retries and failover, and are unconfirmable
+  // once the job is gone.
+  optional bytes verification_fingerprint_key = 9;
 }
 
 message UniqueIndexVerificationStatePB {
@@ -89,8 +94,13 @@ message UniqueIndexVerificationStatePB {
   repeated bytes clean_tablet_ids = 3;
 
   // Value-free context for VERIFY_VIOLATION / VERIFY_INCONCLUSIVE: encoding classes and
-  // counts only, never key or value bytes.
+  // counts, plus an appended keyed fingerprint token when the job carries a key (see
+  // violation_fingerprint) -- never key or value bytes.
   optional string reason = 4;
+
+  // Keyed, scope-limited correlation token for the violating index key (see the tserver
+  // response field of the same name); never the key or value bytes.
+  optional string violation_fingerprint = 5;
 }
 
   message YsqlDdlTxnVerifierStatePB {

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -6823,6 +6823,11 @@ Status CatalogManager::GetBackfillJobs(
     auto l = indexed_table->LockForRead();
     resp->mutable_backfill_jobs()->CopyFrom(l->pb.backfill_jobs());
   }
+  // The fingerprint key is a master/tserver secret: without it, fingerprints are
+  // unconfirmable opaque tokens, which is their contract. Never hand it to RPC callers.
+  for (auto& job : *resp->mutable_backfill_jobs()) {
+    job.clear_verification_fingerprint_key();
+  }
   return Status::OK();
 }
 

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -108,6 +108,7 @@
 #include "yb/tserver/tablet_server.h"
 #include "yb/tserver/ts_local_lock_manager.h"
 #include "yb/tserver/ts_tablet_manager.h"
+#include "yb/tserver/tserver_admin_util.h"
 #include "yb/tserver/tserver_error.h"
 #include "yb/tserver/tserver_fwd.h"
 #include "yb/tserver/tserver_types.pb.h"
@@ -128,6 +129,7 @@
 #include "yb/util/file_util.h"
 #include "yb/util/flags.h"
 #include "yb/util/format.h"
+#include "yb/util/keyed_fingerprint.h"
 #include "yb/util/logging.h"
 #include "yb/util/math_util.h"
 #include "yb/util/mem_tracker.h"
@@ -748,7 +750,7 @@ void TabletServiceAdminImpl::VerifyUniqueIndexTablet(
           server_->tablet_manager(), "VerifyUniqueIndexTablet", req, resp, &context)) {
     return;
   }
-  DVLOG(3) << "Received VerifyUniqueIndexTablet RPC: " << req->DebugString();
+  DVLOG(3) << "Received VerifyUniqueIndexTablet RPC: " << RedactedDebugString(*req);
 
   if (PREDICT_FALSE(FLAGS_TEST_pause_verify_unique_index_tablet_rpc)) {
     // Retryable rejection: keeps the coordinator's task alive while a test arranges a master
@@ -845,6 +847,18 @@ void TabletServiceAdminImpl::VerifyUniqueIndexTablet(
   }
   if (!result->reason.empty()) {
     resp->set_reason(result->reason);
+  }
+  if (result->outcome == docdb::UniqueIndexVerificationOutcome::kViolation &&
+      req->has_verification_fingerprint_key() && !result->violating_group_prefix.empty()) {
+    // The reason rides backfill_error_message into the CREATE INDEX error and support
+    // bundles; the token makes reports of the same duplicate correlatable within this job
+    // without exposing the indexed value.
+    const auto token = KeyedFingerprintToken(
+        req->verification_fingerprint_key(), result->violating_group_prefix);
+    resp->set_violation_fingerprint(token);
+    resp->set_reason(
+        resp->reason().empty() ? Format("fingerprint=$0", token)
+                               : Format("$0; fingerprint=$1", resp->reason(), token));
   }
   if (!result->resume_from_dockey.empty()) {
     resp->set_resume_key(result->resume_from_dockey);

--- a/src/yb/tserver/tserver_admin.proto
+++ b/src/yb/tserver/tserver_admin.proto
@@ -163,6 +163,10 @@ message VerifyUniqueIndexTabletRequestPB {
 
   // Stop with a resume key after this many DocKey groups; 0 = bounded only by the deadline.
   optional uint64 max_dockey_groups = 9;
+
+  // Per-job secret for the keyed violation fingerprint (see the response's
+  // violation_fingerprint). Absent disables fingerprinting.
+  optional bytes verification_fingerprint_key = 10;
 }
 
 message VerifyUniqueIndexTabletResponsePB {
@@ -178,8 +182,9 @@ message VerifyUniqueIndexTabletResponsePB {
   }
   optional Outcome outcome = 3;
 
-  // Value-free context for VIOLATION / INCONCLUSIVE: encoding classes and counts only, never
-  // key or value bytes.
+  // Value-free context for VIOLATION / INCONCLUSIVE: encoding classes and counts, plus an
+  // appended keyed fingerprint token when the request carried a key (see
+  // violation_fingerprint) -- never key or value bytes.
   optional string reason = 4;
 
   // Non-empty when the scan stopped early (group budget or deadline): the encoded DocKey to
@@ -193,6 +198,12 @@ message VerifyUniqueIndexTabletResponsePB {
   // Groups that exceeded the buffering bound and took the bounded-memory reverse walk,
   // which re-reads the group (roughly doubling its scan cost).
   optional uint64 fallback_groups = 8;
+
+  // Keyed, scope-limited correlation token ("<jobtag>-<digest>", truncated HMAC-SHA256 under
+  // the request's fingerprint key) for the first violating index key: non-reversible,
+  // incomparable across jobs, never the key or value bytes. Set only for VIOLATION when the
+  // request carried a key.
+  optional string violation_fingerprint = 9;
 }
 
 // A create tablet request.

--- a/src/yb/tserver/tserver_admin_util.h
+++ b/src/yb/tserver/tserver_admin_util.h
@@ -1,0 +1,37 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <string>
+
+#include "yb/tserver/tserver_admin.pb.h"
+
+#include "yb/util/format.h"
+
+namespace yb::tserver {
+
+// DebugString with sensitive material masked, for the request-log sites on both ends of the
+// RPC: the fingerprint key is a secret, and start_key is a raw index DocKey -- indexed
+// values must not reach logs or support bundles. Takes a copy on purpose.
+inline std::string RedactedDebugString(VerifyUniqueIndexTabletRequestPB req) {
+  if (req.has_verification_fingerprint_key()) {
+    req.set_verification_fingerprint_key("<redacted>");
+  }
+  if (req.has_start_key()) {
+    req.set_start_key(Format("<$0 bytes>", req.start_key().size()));
+  }
+  return req.DebugString();
+}
+
+}  // namespace yb::tserver

--- a/src/yb/util/CMakeLists.txt
+++ b/src/yb/util/CMakeLists.txt
@@ -162,6 +162,7 @@ set(UTIL_SRCS
   jsonwriter.cc
   jwt_util.cc
   jwtcpp_util.cc
+  keyed_fingerprint.cc
   locks.cc
   logging.cc
   malloc.cc
@@ -406,6 +407,7 @@ ADD_YB_TEST(inline_slice-test)
 ADD_YB_TEST(json_document-test)
 ADD_YB_TEST(jwt_util-test)
 ADD_YB_TEST(jwtcpp_util-test)
+ADD_YB_TEST(keyed_fingerprint-test)
 ADD_YB_TEST(lockfree-test)
 ADD_YB_TEST(logging-test)
 ADD_YB_TEST(lru_cache-test)

--- a/src/yb/util/keyed_fingerprint-test.cc
+++ b/src/yb/util/keyed_fingerprint-test.cc
@@ -1,0 +1,50 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include <regex>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "yb/util/keyed_fingerprint.h"
+
+namespace yb {
+
+TEST(KeyedFingerprintTest, TokenFormatAndDeterminism) {
+  const auto key = GenerateFingerprintKey();
+  ASSERT_EQ(32, key.size());
+
+  const auto token = KeyedFingerprintToken(key, "some-value");
+  ASSERT_TRUE(std::regex_match(token, std::regex("[0-9a-f]{8}-[0-9a-f]{16}"))) << token;
+  // Deterministic under one key: the correlation property.
+  ASSERT_EQ(token, KeyedFingerprintToken(key, "some-value"));
+}
+
+TEST(KeyedFingerprintTest, TagIdentifiesKeyScope) {
+  const auto key = GenerateFingerprintKey();
+  const auto token_a = KeyedFingerprintToken(key, "value-a");
+  const auto token_b = KeyedFingerprintToken(key, "value-b");
+  // Same key: same scope tag, different digests.
+  ASSERT_EQ(token_a.substr(0, 8), token_b.substr(0, 8));
+  ASSERT_NE(token_a.substr(9), token_b.substr(9));
+
+  // Different key: different scope tag AND a different digest for the same value -- tokens
+  // from different scopes are incomparable, and a value cannot be confirmed across scopes.
+  const auto other_key = GenerateFingerprintKey();
+  ASSERT_NE(key, other_key);
+  const auto other_token_a = KeyedFingerprintToken(other_key, "value-a");
+  ASSERT_NE(token_a.substr(0, 8), other_token_a.substr(0, 8));
+  ASSERT_NE(token_a.substr(9), other_token_a.substr(9));
+}
+
+}  // namespace yb

--- a/src/yb/util/keyed_fingerprint.cc
+++ b/src/yb/util/keyed_fingerprint.cc
@@ -1,0 +1,60 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/util/keyed_fingerprint.h"
+
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/rand.h>
+#include <openssl/sha.h>
+
+#include "yb/gutil/casts.h"
+#include "yb/gutil/strings/escaping.h"
+
+#include "yb/util/logging.h"
+
+namespace yb {
+
+namespace {
+
+constexpr size_t kFingerprintKeyBytes = 32;
+constexpr size_t kScopeTagBytes = 4;
+constexpr size_t kDigestBytes = 8;
+// Fixed label whose HMAC identifies the key (and thus the scope) itself.
+const char kScopeTagLabel[] = "yb-fingerprint-scope-tag";
+
+std::string HmacSha256HexPrefix(Slice key, Slice data, size_t out_bytes) {
+  unsigned char digest[SHA256_DIGEST_LENGTH];
+  unsigned int digest_len = 0;
+  // HMAC() can realistically fail only on allocation failure; make the assumption explicit.
+  CHECK_NOTNULL(HMAC(
+      EVP_sha256(), key.data(), narrow_cast<int>(key.size()), data.data(), data.size(), digest,
+      &digest_len));
+  DCHECK_GE(digest_len, out_bytes);
+  return strings::b2a_hex(pointer_cast<const char*>(digest), narrow_cast<int>(out_bytes));
+}
+
+}  // namespace
+
+std::string GenerateFingerprintKey() {
+  std::string key(kFingerprintKeyBytes, '\0');
+  CHECK_EQ(1, RAND_bytes(pointer_cast<unsigned char*>(key.data()), kFingerprintKeyBytes));
+  return key;
+}
+
+std::string KeyedFingerprintToken(Slice key, Slice data) {
+  return HmacSha256HexPrefix(key, Slice(kScopeTagLabel), kScopeTagBytes) + "-" +
+         HmacSha256HexPrefix(key, data, kDigestBytes);
+}
+
+}  // namespace yb

--- a/src/yb/util/keyed_fingerprint.h
+++ b/src/yb/util/keyed_fingerprint.h
@@ -1,0 +1,38 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <string>
+
+#include "yb/util/slice.h"
+
+namespace yb {
+
+// Keyed diagnostic fingerprints: non-reversible, scope-limited correlation tokens for values
+// that must never appear in logs, errors, or support bundles. Safe for low-cardinality values
+// because confirming a candidate requires the key; limiting the key's lifetime to one scope
+// (e.g. one job) limits how long that confirmation is possible at all.
+
+// 32 crypto-random bytes (OpenSSL RAND_bytes).
+std::string GenerateFingerprintKey();
+
+// Renders "<tag8hex>-<digest16hex>". The tag is derived from the key alone, so every token
+// under one key shares it: two tokens with different tags are visibly incomparable. The
+// digest is HMAC-SHA256(key, data), truncated -- the required property is unconfirmability
+// without the key, not collision resistance against a key holder. The 4-byte tag is a
+// visual aid, not a boundary: distinct keys collide on it around 2^16 concurrent scopes
+// (birthday), which can only make two incomparable tokens look comparable.
+std::string KeyedFingerprintToken(Slice key, Slice data);
+
+}  // namespace yb

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -1949,6 +1949,9 @@ TEST_P(PgIndexBackfillFailClosedVerification, ViolationFailsCreateIndex) {
       "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName);
   ASSERT_NOK(status);
   ASSERT_STR_CONTAINS(status.message().ToBuffer(), "verification");
+  // The keyed violation fingerprint rides the reason into the CREATE INDEX error: a
+  // correlatable, non-reversible token in place of the (never-exposed) duplicate value.
+  ASSERT_STR_CONTAINS(status.message().ToBuffer(), "fingerprint=");
 
   // Never published: the index exists but is invalid; the base table is unaffected and the
   // invalid index is droppable.
@@ -3135,6 +3138,9 @@ TEST_P(PgIndexBackfillMultiMaster, UniqueCheckModePersistedAcrossMasterFailover)
     auto job = ASSERT_RESULT(GetBackfillJobs(cluster_.get(), table_id));
     ASSERT_EQ(job.unique_index_backfill_mode(),
               UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_SKIP_ALL);
+    // SKIP_ALL jobs carry a fingerprint key, and GetBackfillJobs must scrub it: the key is
+    // a master/tserver secret, never handed to RPC callers.
+    ASSERT_TRUE(job.verification_fingerprint_key().empty());
 
     // Clear the selection override everywhere before the failover, so a (wrong) re-selection
     // on the new leader would produce CHECK_ALL.


### PR DESCRIPTION
## Summary

Verification failure reports have been value-free by design (#33444): encoding classes and
counts, never the duplicate key. That satisfies the privacy contract but leaves support
blind to correlation -- "is this the same duplicate as the last retry?" This adds the design
document's keyed, scope-limited diagnostic fingerprint: a non-reversible token identifying
the violating index key, safe for low-cardinality values because confirming a candidate
requires the key, and the key's per-job scope bounds how long confirmation is possible at
all.

- Per-job secret (32 bytes, OpenSSL `RAND_bytes`) generated in the `BackfillTable`
  constructor for SKIP_ALL jobs (other modes never verify and carry no key), persisted in
  `BackfillJobPB` (field 9, latched-per-job like the mode and the gate), and deleted with
  the job: fingerprints correlate across the job's retries and master failover, and are
  unconfirmable once the job is gone.
- The verifier exposes the first violating group's raw encoded DocKey in-process only
  (excluded from `ToString`; never serialized). The tserver handler renders the token --
  `<jobtag8hex>-<digest16hex>`, both truncated HMAC-SHA256 under the job key
  (`yb/util/keyed_fingerprint.{h,cc}`) -- into a structured response field and a
  `fingerprint=` suffix on the still-value-free reason. The job tag is derived from the key
  alone, so tokens from different jobs are visibly incomparable; the raw violating key never
  leaves the tserver process.
- The reason rides the existing paths into the persisted verification state, the master
  outcome log, and (in gating mode) `backfill_error_message` -> the CREATE INDEX error. The
  structured token is also persisted (`UniqueIndexVerificationStatePB` field 5) for support
  tooling.
- The key never leaves the master/tserver trust domain: `GetBackfillJobs` scrubs it from RPC
  responses (pinned by test), both request-log sites (master send VLOG, tserver receive
  DVLOG) share `RedactedDebugString` -- which also elides `start_key`, a raw index DocKey --
  and the one log that printed a whole `BackfillJobPB` clears the key first. The verifier
  result's `ToString` renders the resume key's size only, for the same reason.

Stacked on #33403, #33404, #33484, #33544, #33553, #33580, #33584, #33601, #33602, #33654,
#33655, #33656, #33657, and #33685, based on
`feature-stack/Shopify/uniq-idx-8b-verification-observability` per the feature-stack
workflow, so the diff is exactly this PR's own commit. A failing pr-title check on stacked
PRs is a known gap in that check; the stack merges bottom-up and retargets as parents merge.

## Upgrade/Rollback safety

Sys-catalog: `BackfillJobPB.verification_fingerprint_key` (field 9) follows the same
analysis as #33654's field 7 and #33656's field 8 -- pure data with no apply-time dispatch;
an old master parses it as an unknown field and preserves it on row rewrite (sys-catalog
writes serialize the parsed message; nothing discards unknown fields), and master WAL replay
carries sys-catalog writes as opaque bytes. A rollback and re-upgrade therefore resumes the
job with the same key, so already-emitted fingerprints stay comparable.

One rollback-specific caveat, because this field is a secret: an old master lacks this PR's
`GetBackfillJobs` scrub, so while a keyed job's PB survives on a rolled-back master, that
admin RPC returns the key as preserved unknown-field bytes. The exposure is bounded -- the
caller must already hold admin RPC access in the same trust domain that operates the
cluster, the stranded job is deleted by the existing invalid-index cleanup (which deletes
the key with it), and a key holder gains only the ability to confirm candidate values
against that one job's tokens -- but operators rolling back mid-build should know the
window exists.

RPC surface is additive and tolerant in both directions: an old tserver ignores the
request's key (field 10) and emits no fingerprint -- the reason stays plain, exactly the
pre-8c behavior; an old master never sends a key, and ignores the response token (field 9)
and the persisted-state field (field 5) as unknown fields.

All of it is production-unreachable until activation (SKIP_ALL-only key generation, the
CHECK_ALL selector, default-off flags). No flag-default changes.

## Test plan

macOS arm64, release -- all green:

- [x] New: `KeyedFingerprintTest.TokenFormatAndDeterminism` and
      `KeyedFingerprintTest.TagIdentifiesKeyScope` -- token format, determinism under one
      key, shared scope tag per key, cross-key incomparability.
- [x] New: `UniqueIndexVerifierTest.ViolationExposesGroupPrefixInMemoryOnly` -- the privacy
      pin: the raw group prefix is exposed in memory for the caller and excluded from
      `ToString` (by field name and by raw bytes); `PaginationIsDocKeyAligned` extended to
      pin the resume key's size-only rendering.
- [x] Extended: `PgIndexBackfillFailClosedVerification.ViolationFailsCreateIndex/0` -- the
      CREATE INDEX error carries `fingerprint=<token>`; live rendering verified
      (`fingerprint=2d929cea-dbf259e3ff0d7297`).
- [x] Extended: `PgIndexBackfillMultiMaster.UniqueCheckModePersistedAcrossMasterFailover/0`
      -- a SKIP_ALL job carries a key, and `GetBackfillJobs` must return it scrubbed.
- [x] Full `unique_index_verifier-test` (20/20 at this layer). Regressions: shadow
      violation (waiter matches the enriched line), shadow clean multi-tablet, failover
      resume.

AlmaLinux (x86_64, clang21), rebased onto master `c7253d204d`:

At this PR's own commit (`2e95ed15a8`), ASAN -- all green:

- [x] `keyed_fingerprint-test` (this PR's new target).
- [x] `unique_index_verifier-test` (carries `ViolationExposesGroupPrefixInMemoryOnly`, the
      assertion that raw index key bytes stay out of logs).
- [x] `ViolationFailsCreateIndex`, both params -- the fingerprint token reaching the
      CREATE INDEX error.

Integrated at the stack tip (`334a1deb3d`), all green. Exact suites per build type:

- [x] TSAN (6): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `non_transactional_batch_writer-test`,
      `keyed_fingerprint-test`, `raft_consensus-itest`.
- [x] ASAN (15): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `keyed_fingerprint-test`,
      `non_transactional_batch_writer-test`, `clone-tablet-itest`,
      `remote_bootstrap-itest`, `tablet_bootstrap-test`, `auto_flags-itest`,
      `docdb-test`, `compaction_file_filter-test`,
      `xcluster_external_apply_bootstrap-test`, `pg_txn-test`, `pg_ash-test`,
      full `pg_index_backfill-test`.
- [x] Debug (19): the ASAN list minus `compaction_file_filter-test`, plus
      `master_failover-itest`, `snapshot-test`, `tablet_snapshots-test`,
      `compaction-test`, `tablet-split-itest`.
- [x] Release (5): `keyed_fingerprint-test`, `auto_flags-itest`, full
      `pg_index_backfill-test`, java `TestIndexBackfill`, java
      `TestPgRegressBackfillIndex`.
- [x] All three full `pg_index_backfill-test` runs (ASAN, debug, release) pass with no
      test failures.

Two known-upstream issues surfaced by the tip matrix, both shown not attributable to this
stack:

- TSAN `tablet-split-itest` reports 3 data races in `yb::client::YBTable::~YBTable()`
  (table.cc:81) racing its partition-refresh callback, inside the upstream test
  `AutomaticTabletSplitITest.SizeRatio` (93 cases ran, 0 gtest failures). This stack has zero
  diff under `src/yb/client/`, and that test passes 3/3 isolated at the new master base.
- `wait_states-itest` hangs 9 cases at the 601s timeout (`AshCql`, the `kYCQL_*` group,
  `kBackfillIndex_*`, `kConsensusMeta_Flush`, `kCreatingNewTablet`,
  `kSaveRaftGroupMetadataToDisk`). Reproduced identically on plain master `c7253d204d`
  carrying none of this stack's code: 53 ran, the same 9 failed, same ~600.5s expiries.
  Tracked upstream in #33729.

Disposition change since the previous revision: the
`PgIndexBackfillBackendsManager.NoAbortTxn/1` flake cited earlier was fixed upstream. It
passes 3/3 at the new base and in all three full `pg_index_backfill-test` runs here, so it is
no longer carried as a known flake.


