### PR TITLE
[#33684] DocDB: Add log_wal_sync_overdue_ms, a per-tablet gauge for overdue WAL fsync

### DIFF
--- a/src/yb/consensus/log-test.cc
+++ b/src/yb/consensus/log-test.cc
@@ -787,6 +787,82 @@ TEST_F(LogTest, TestLogMetricsWithSegmentReuse) {
   ASSERT_EQ(log_->metrics_->wal_size->value(), st.st_size);
 }
 
+// log_wal_sync_overdue_ms reads 0 while the oldest unsynced entry is within
+// interval_durable_wal_write_ms, grows once it is past it, and returns to 0 after the fsync.
+TEST_F(LogTest, TestWalSyncOverdueMetric) {
+  constexpr int kIntervalMs = 1000;
+  options_.interval_durable_wal_write = MonoDelta::FromMilliseconds(kIntervalMs);
+  // Keep the size arm out of reach so only the time arm decides when the fsync happens.
+  options_.bytes_durable_wal_write_mb = 1024;
+  BuildLog();
+  const auto& gauge = *log_->metrics_->wal_sync_overdue_ms;
+
+  ASSERT_EQ(gauge.value(), 0);
+
+  const auto appended_at = MonoTime::Now();
+  OpIdPB opid = MakeOpId(0, 1);
+  ASSERT_OK(AppendNoOp(&opid));
+  // The gauge is only ever the age beyond the interval, so a freshly appended entry reads 0 even
+  // though it is unsynced.
+  ASSERT_EQ(gauge.value(), 0);
+
+  SleepFor(MonoDelta::FromMilliseconds(kIntervalMs + 200));
+  const auto overdue_ms = gauge.value();
+  ASSERT_GT(overdue_ms, 0);
+  ASSERT_LE(overdue_ms, (MonoTime::Now() - appended_at).ToMilliseconds() - kIntervalMs);
+
+  // The next append finds the entry past the interval and fsyncs in line before acknowledging, so
+  // nothing is unsynced once it returns. Not via WaitUntilAllFlushed(): its flush marker re-arms
+  // periodic_sync_needed_ with zero bytes, which would make the 0 below come from the byte guard.
+  ASSERT_OK(AppendNoOp(&opid));
+  ASSERT_FALSE(log_->periodic_sync_needed_);
+  ASSERT_EQ(gauge.value(), 0);
+
+  // Reopening the log reuses the tablet metric entity. The gauge must follow the new Log rather
+  // than stay bound to the closed one, which reads a constant 0 once detached.
+  ASSERT_OK(log_->Close());
+  constexpr int kShortIntervalMs = 100;
+  options_.interval_durable_wal_write = MonoDelta::FromMilliseconds(kShortIntervalMs);
+  BuildLog();
+  ASSERT_OK(AppendNoOp(&opid));
+  SleepFor(MonoDelta::FromMilliseconds(kShortIntervalMs + 100));
+  ASSERT_GT(log_->metrics_->wal_sync_overdue_ms->value(), 0);
+
+  ASSERT_OK(log_->Close());
+}
+
+// With durable_wal_write every append is fsynced before it is acknowledged, so there is never an
+// overdue entry to report.
+TEST_F(LogTest, TestWalSyncOverdueMetricUnderDurableWalWrite) {
+  options_.durable_wal_write = true;
+  options_.interval_durable_wal_write = MonoDelta::FromMilliseconds(1);
+  options_.preallocate_segments = false;
+  BuildLog();
+
+  OpIdPB opid = MakeOpId(0, 1);
+  ASSERT_OK(AppendNoOp(&opid));
+  SleepFor(MonoDelta::FromMilliseconds(20));
+  ASSERT_EQ(log_->metrics_->wal_sync_overdue_ms->value(), 0);
+
+  ASSERT_OK(log_->Close());
+}
+
+// With the interval disabled there is no bound to be overdue against, so the gauge stays 0 however
+// long an entry sits unsynced.
+TEST_F(LogTest, TestWalSyncOverdueMetricWhenIntervalDisabled) {
+  // How LogOptions spells --interval_durable_wal_write_ms=0: an uninitialized MonoDelta.
+  options_.interval_durable_wal_write = MonoDelta();
+  options_.bytes_durable_wal_write_mb = 1024;
+  BuildLog();
+
+  OpIdPB opid = MakeOpId(0, 1);
+  ASSERT_OK(AppendNoOp(&opid));
+  SleepFor(MonoDelta::FromMilliseconds(200));
+  ASSERT_EQ(log_->metrics_->wal_sync_overdue_ms->value(), 0);
+
+  ASSERT_OK(log_->Close());
+}
+
 // Verify presence of min_start_time_running_txns in footer of closed segments.
 void VerifyClosedSegmentsHaveMinStartTimeRunningTxns(const SegmentSequence& segments) {
   VLOG(1) << "Found " << segments.size() << " log segments";

--- a/src/yb/consensus/log.cc
+++ b/src/yb/consensus/log.cc
@@ -95,6 +95,8 @@ using namespace yb::size_literals;  // NOLINT.
 using namespace std::literals;  // NOLINT.
 using namespace std::placeholders;
 
+METRIC_DECLARE_gauge_int64(log_wal_sync_overdue_ms);
+
 // Log retention configuration.
 // -----------------------------
 DEFINE_RUNTIME_int32(log_min_segments_to_retain, 2,
@@ -739,6 +741,13 @@ Log::Log(
   set_wal_retention_secs(options_.retention_secs);
   if (table_metric_entity_ && tablet_metric_entity_) {
     metrics_.reset(new LogMetrics(table_metric_entity_, tablet_metric_entity_));
+    // The tablet entity outlives any one Log and is reused when the tablet is opened again on this
+    // server. InstantiateFunctionGauge() would then hand back the previous Log's gauge, already
+    // detached to a constant, so drop it first.
+    tablet_metric_entity_->RemoveFromMetricMap(&METRIC_log_wal_sync_overdue_ms);
+    metrics_->wal_sync_overdue_ms = METRIC_log_wal_sync_overdue_ms.InstantiateFunctionGauge(
+        tablet_metric_entity_, Bind(&Log::WalSyncOverdueMs, Unretained(this)));
+    metrics_->wal_sync_overdue_ms->AutoDetach(&metric_detacher_, 0);
   }
   if (background_synchronizer_wait_state_) {
     background_synchronizer_wait_state_->set_root_request_id(yb::Uuid::Generate());
@@ -749,6 +758,25 @@ Log::Log(
     SET_WAIT_STATUS_TO(background_synchronizer_wait_state_, Idle);
     yb::ash::RaftLogWaitStatesTracker().Track(background_synchronizer_wait_state_);
   }
+}
+
+int64_t Log::WalSyncOverdueMs() const {
+  if (durable_wal_write_ || !interval_durable_wal_write_ || !periodic_sync_needed_) {
+    return 0;
+  }
+  // The appender publishes periodic_sync_needed_, then the timestamp, then the byte count, in that
+  // order, and DoSync() resets needed then bytes. Reading the byte count before the timestamp
+  // means a non-zero count came after the timestamp of the same batch, so a scrape that lands
+  // between the appender's first two stores reads 0 instead of pairing a fresh "needed" with the
+  // previous batch's timestamp. The remaining window is a background DoSync() whose two resets
+  // become visible out of step, which is store-buffer sized; a value read there is at most one
+  // previous cycle old.
+  if (periodic_sync_unsynced_bytes_ == 0) {
+    return 0;
+  }
+  const MonoTime earliest_unsync_entry_time = periodic_sync_earliest_unsync_entry_time_;
+  const auto overdue = MonoTime::Now() - earliest_unsync_entry_time - interval_durable_wal_write_;
+  return std::max<int64_t>(overdue.ToMilliseconds(), 0);
 }
 
 Status Log::Init() {

--- a/src/yb/consensus/log.h
+++ b/src/yb/consensus/log.h
@@ -436,6 +436,9 @@ class Log : public RefCountedThreadSafe<Log> {
   FRIEND_TEST(LogTest, TestWriteAndReadToAndFromInProgressSegment);
   FRIEND_TEST(LogTest, TestLogMetrics);
   FRIEND_TEST(LogTest, TestLogMetricsWithSegmentReuse);
+  FRIEND_TEST(LogTest, TestWalSyncOverdueMetric);
+  FRIEND_TEST(LogTest, TestWalSyncOverdueMetricUnderDurableWalWrite);
+  FRIEND_TEST(LogTest, TestWalSyncOverdueMetricWhenIntervalDisabled);
   FRIEND_TEST(LogTest, AsyncRolloverMarker);
   FRIEND_TEST(cdc::CDCServiceTestMaxRentionTime, TestLogRetentionByOpId_MaxRentionTime);
   FRIEND_TEST(cdc::CDCServiceTestMinSpace, TestLogRetentionByOpId_MinSpace);
@@ -466,6 +469,11 @@ class Log : public RefCountedThreadSafe<Log> {
       const PreLogRolloverCallback& pre_log_rollover_callback,
       CreateNewSegment create_new_segment = CreateNewSegment::kTrue,
       MinStartHTRunningTxnsCallback min_start_ht_running_txns_callback = {});
+
+  // Value of the log_wal_sync_overdue_ms gauge: how far past interval_durable_wal_write_ the
+  // oldest unsynced entry is, or 0 if nothing is unsynced or the interval does not apply. Read on
+  // the metrics thread, concurrently with the appender and the background fsync.
+  int64_t WalSyncOverdueMs() const;
 
   Env* get_env() {
     return options_.env;
@@ -738,6 +746,9 @@ class Log : public RefCountedThreadSafe<Log> {
   scoped_refptr<MetricEntity> table_metric_entity_;
   scoped_refptr<MetricEntity> tablet_metric_entity_;
   std::unique_ptr<LogMetrics> metrics_;
+  // Detaches the function gauge in metrics_ from this Log on destruction. Declared after the
+  // members the gauge reads.
+  std::shared_ptr<void> metric_detacher_;
 
   std::shared_ptr<MemTracker> read_wal_mem_tracker_;
 

--- a/src/yb/consensus/log_metrics.cc
+++ b/src/yb/consensus/log_metrics.cc
@@ -42,6 +42,15 @@ METRIC_DEFINE_gauge_uint64(tablet, log_wal_size, "Size of WAL Files",
                            yb::MetricUnit::kBytes,
                            "Size of wal files");
 
+METRIC_DEFINE_gauge_int64(tablet, log_wal_sync_overdue_ms, "WAL Sync Overdue",
+                          yb::MetricUnit::kMilliseconds,
+                          "Milliseconds by which the oldest unsynced WAL entry has exceeded "
+                          "interval_durable_wal_write_ms. 0 when every entry is fsynced or still "
+                          "within the interval, and when the interval does not apply "
+                          "(durable_wal_write, or the interval disabled). Aggregated as the "
+                          "maximum across tablets.",
+                          {0, yb::AggregationFunction::kMax} /* optional_args */);
+
 METRIC_DEFINE_event_stats(table, log_sync_latency, "Log Sync Latency",
                                yb::MetricUnit::kMicroseconds,
                                "Microseconds spent on synchronizing the log segment file");

--- a/src/yb/consensus/log_metrics.h
+++ b/src/yb/consensus/log_metrics.h
@@ -41,6 +41,8 @@ template<class T>
 class AtomicGauge;
 class Counter;
 class EventStats;
+template<class T>
+class FunctionGauge;
 class MetricEntity;
 
 namespace log {
@@ -52,6 +54,10 @@ struct LogMetrics {
   // Global stats
   scoped_refptr<Counter> bytes_logged;
   scoped_refptr<AtomicGauge<uint64_t>> wal_size;
+
+  // Computed from the Log's periodic-sync state at read time, so it is instantiated by the Log
+  // itself rather than by this constructor.
+  scoped_refptr<FunctionGauge<int64_t>> wal_sync_overdue_ms;
 
   // Per-group group commit stats
   scoped_refptr<EventStats> sync_latency;


### PR DESCRIPTION
Summary:
Add a tablet-level gauge, log_wal_sync_overdue_ms: the number of milliseconds by which the
oldest unsynced WAL entry has exceeded interval_durable_wal_write_ms. It is 0 when nothing is
unsynced, when the oldest unsynced entry is still within the interval, and when the interval does
not apply (durable_wal_write, or the interval disabled).

The value is computed at read time from the Log's existing periodic-sync state, since nothing
runs on an idle tablet to keep a stored value current. It is aggregated with max across tablets,
like follower_lag_ms, so table- and server-level values report the worst tablet.

Test Plan:
```
LogTest.TestWalSyncOverdueMetric
LogTest.TestWalSyncOverdueMetricUnderDurableWalWrite
LogTest.TestWalSyncOverdueMetricWhenIntervalDisabled
```
