### PR TITLE
[#33444] DocDB: Fence demotion of the deferred-verification capability flag

### DIFF
--- a/src/yb/master/master_auto_flags_manager.cc
+++ b/src/yb/master/master_auto_flags_manager.cc
@@ -13,13 +13,18 @@
 
 #include "yb/master/master_auto_flags_manager.h"
 
+#include "yb/common/wire_protocol.h"
 #include "yb/consensus/consensus.pb.h"
+#include "yb/master/catalog_entity_info.h"
 #include "yb/master/catalog_manager.h"
 #include "yb/master/master.h"
+#include "yb/master/ts_descriptor.h"
 #include "yb/master/ts_manager.h"
 #include "yb/master/xcluster/xcluster_manager_if.h"
 #include "yb/master/ysql/ysql_manager_if.h"
+#include "yb/rpc/rpc_controller.h"
 #include "yb/tablet/operations/change_auto_flags_config_operation.h"
+#include "yb/tserver/tserver_admin.proxy.h"
 #include "yb/util/enum_parse.h"
 #include "yb/util/scope_exit.h"
 
@@ -53,6 +58,8 @@ bool ValidateAutoFlagClass(const char* flag_name, int32_t value) {
 DEFINE_validator(limit_auto_flag_promote_for_new_universe, &ValidateAutoFlagClass);
 
 DECLARE_bool(disable_auto_flags_management);
+DECLARE_int32(follower_unavailable_considered_failed_sec);
+DECLARE_int32(master_ts_rpc_timeout_ms);
 
 namespace yb::master {
 
@@ -483,12 +490,108 @@ Result<std::pair<uint32_t, PromoteAutoFlagsOutcome>> MasterAutoFlagsManager::Pro
   return std::make_pair(new_config.config_version(), outcome);
 }
 
+namespace {
+
+// Demoting this flag re-admits binaries that replay marked backfill writes positionally
+// (byte divergence, #33444); the fence below refuses until the marked-write state drains.
+const char kDeferredUniqueIndexVerificationFlagName[] =
+    "ysql_enable_deferred_unique_index_verification";
+
+// Bound on table ids named in the fence's refusal message.
+constexpr size_t kMaxTablesToReport = 5;
+
+}  // namespace
+
+// The downgrade fence for deferred unique-index verification. Sound because generation
+// release persists released_marked_write_watermark and schedules a regular-DB flush: once
+// no job is active, no generation is active, and every released watermark is below its
+// tablet's flushed frontier, no marked WAL entry can replay on any binary.
+//
+// Residual window: a SKIP_ALL job created between this scan and the demoted config reaching
+// tservers is not seen here; its marked writes are then rejected by the write-time
+// capability check once the config propagates (seconds), but writes accepted inside the
+// window carry the usual hazard. Operators demote during drained maintenance, not while
+// concurrently issuing CREATE INDEX.
+Status MasterAutoFlagsManager::ValidateDeferredUniqueIndexVerificationDemotion() {
+  // (a) Active SKIP_ALL backfill jobs: chunks may still be appending marked writes.
+  std::vector<TableId> tables_with_jobs;
+  for (const auto& table : catalog_manager_->GetTables(GetTablesMode::kAll)) {
+    auto l = table->LockForRead();
+    for (const auto& job : l->pb.backfill_jobs()) {
+      if (job.unique_index_backfill_mode() ==
+          UniqueIndexBackfillMode::UNIQUE_INDEX_BACKFILL_SKIP_ALL) {
+        tables_with_jobs.push_back(table->id());
+        break;
+      }
+    }
+    if (tables_with_jobs.size() >= kMaxTablesToReport) {
+      break;
+    }
+  }
+  SCHECK_FORMAT(
+      tables_with_jobs.empty(), IllegalState,
+      "Cannot demote AutoFlag $0: table(s) $1 have active SKIP_ALL index-backfill jobs whose "
+      "marked writes an older binary would replay divergently. Wait for the CREATE INDEX "
+      "builds to finish (or abort them), then retry.",
+      kDeferredUniqueIndexVerificationFlagName, tables_with_jobs);
+
+  // (b) tserver probe: active ordering generations, or released ones whose marked WAL
+  // entries are not yet below the flushed frontier. Sequential synchronous fan-out: demotion
+  // is a rare admin operation. Every registered tserver is probed and an unreachable one
+  // FAILS the demotion (fail closed: a node dead for less than the eviction horizon still
+  // holds config-member replicas, possibly with unflushed marked WAL). The one exception is
+  // a tserver dead past follower_unavailable_considered_failed_sec: its replicas have been
+  // evicted and re-replicated, and if it ever returns on an old binary its stale local
+  // replay is confined to data that is tombstoned before serving.
+  const auto eviction_horizon =
+      MonoDelta::FromSeconds(FLAGS_follower_unavailable_considered_failed_sec);
+  for (const auto& desc : master_.ts_manager()->GetAllDescriptors()) {
+    if (!desc->IsLive() && desc->TimeSinceHeartbeat() > eviction_horizon) {
+      continue;
+    }
+    std::shared_ptr<tserver::TabletServerAdminServiceProxy> proxy;
+    RETURN_NOT_OK(desc->GetProxy(&proxy));
+    tserver::CheckIndexBackfillDowngradeSafetyRequestPB req;
+    req.set_dest_uuid(desc->permanent_uuid());
+    tserver::CheckIndexBackfillDowngradeSafetyResponsePB resp;
+    rpc::RpcController controller;
+    controller.set_timeout(MonoDelta::FromMilliseconds(FLAGS_master_ts_rpc_timeout_ms));
+    RETURN_NOT_OK_PREPEND(
+        proxy->CheckIndexBackfillDowngradeSafety(req, &resp, &controller),
+        Format(
+            "Cannot demote AutoFlag $0: tserver $1 is unreachable and may hold marked-write "
+            "state an older binary would replay divergently. Wait for it to return (or "
+            "decommission it), then retry",
+            kDeferredUniqueIndexVerificationFlagName, desc->permanent_uuid()));
+    if (resp.has_error()) {
+      return StatusFromPB(resp.error().status());
+    }
+    SCHECK_FORMAT(
+        resp.active_generation_tablets() == 0 && resp.unflushed_marked_wal_tablets() == 0,
+        IllegalState,
+        "Cannot demote AutoFlag $0: tserver $1 reports $2 tablet(s) with an active "
+        "index-backfill ordering generation and $3 with marked WAL entries not yet flushed. "
+        "An older binary would replay those writes divergently. Wait for the builds to "
+        "finish and the release flushes to converge (stragglers converge via the tablet "
+        "metadata validator), then retry.",
+        kDeferredUniqueIndexVerificationFlagName, desc->permanent_uuid(),
+        resp.active_generation_tablets(), resp.unflushed_marked_wal_tablets());
+  }
+  return Status::OK();
+}
+
 Result<std::pair<uint32_t, bool>> MasterAutoFlagsManager::DemoteSingleAutoFlag(
     const ProcessName& process_name, const std::string& flag_name) {
   SCHECK(!FLAGS_disable_auto_flags_management, NotSupported, "AutoFlags management is disabled.");
 
   // Make sure process and AutoFlag exists.
   RETURN_NOT_OK(GetFlagInfo(process_name, flag_name));
+
+  // Feature-state veto (promote-side precedent: the YSQL major-upgrade check above). This is
+  // deliberately not bypassable: every blocking condition drains on its own.
+  if (flag_name == kDeferredUniqueIndexVerificationFlagName) {
+    RETURN_NOT_OK(ValidateDeferredUniqueIndexVerificationDemotion());
+  }
 
   auto new_config = GetConfig();
   if (!VERIFY_RESULT(RemoveFlagFromConfig(process_name, flag_name, &new_config))) {

--- a/src/yb/master/master_auto_flags_manager.h
+++ b/src/yb/master/master_auto_flags_manager.h
@@ -110,6 +110,11 @@ class MasterAutoFlagsManager : public AutoFlagsManagerBase {
   Result<std::pair<uint32_t, bool>> DemoteSingleAutoFlag(
       const ProcessName& process_name, const std::string& flag_name);
 
+  // Downgrade fence for deferred unique-index verification (#33444): refuses to demote its
+  // capability flag while active SKIP_ALL backfill jobs exist or any live tserver still
+  // holds marked-write state an older binary would replay divergently.
+  Status ValidateDeferredUniqueIndexVerificationDemotion();
+
   Master& master_;
   CatalogManager* catalog_manager_;
   UniqueLock<std::shared_mutex> update_lock_;

--- a/src/yb/rocksdb/listener.h
+++ b/src/yb/rocksdb/listener.h
@@ -194,6 +194,11 @@ YB_DEFINE_ENUM(FlushReason,
   // modeled. Future lint may restrict use of this value to test-only translation units.
   // If the test code path mimics one of the above cases, use that reason instead.
   (kTestOnly)
+
+  // Index-backfill ordering-generation release: flushes marked writes below the flushed
+  // frontier so the downgrade fence's released_marked_write_watermark condition converges.
+  // (Appended at the end: nothing persists this enum, but ordinal stability costs nothing.)
+  (kIndexBackfillGenerationRelease)
 );
 
 struct TableFileDeletionInfo {

--- a/src/yb/tablet/metadata.proto
+++ b/src/yb/tablet/metadata.proto
@@ -262,6 +262,14 @@ message IndexBackfillOrderingGenerationPB {
   // Numbering starts at 1 for the initial floor (kIntraTxnWriteIdLimit, 2^31); 0 is reserved as
   // absent/unknown. Written by the master activation flow.
   optional uint32 write_id_floor_version = 5;
+
+  // Highest marked-write Raft index this tablet had applied when the generation was released
+  // (0 = never released or no marked writes). A regular-DB flushed frontier at or above this
+  // proves no marked write can replay from the WAL -- the per-tablet condition of the
+  // downgrade fence. Anchored to the last marked WRITE (not the release op itself) so the
+  // release-triggered flush is sufficient to converge it on an otherwise idle tablet.
+  // Survives until the next activation.
+  optional int64 released_marked_write_watermark = 6;
 }
 
 message FilePB {

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -238,6 +238,11 @@ DEFINE_RUNTIME_bool(batch_tablet_metrics_update, true,
     "Batch update of rocksdb and tablet metrics to once per request rather than "
     "updating immediately.");
 
+DEFINE_test_flag(bool, skip_index_backfill_generation_release_flush, false,
+    "Skip the regular-DB flush scheduled by an ordering-generation release, keeping released "
+    "marked writes above the flushed frontier so tests can pin the downgrade fence's "
+    "unflushed-marked-WAL arm.");
+
 DEFINE_test_flag(int32, slowdown_backfill_by_ms, 0,
     "If set > 0, slows down the backfill process by this amount.");
 
@@ -2060,6 +2065,15 @@ Status Tablet::ApplyOperation(
         raft_index, kBackfillWriteIdIndexMax, Corruption,
         "Raft operation index exhausted the fixed-hybrid-time write ID space");
     write_id_override = kBackfillWriteIdFloor | raft_index;
+    // Downgrade-fence watermark: the highest marked-write index this tablet has applied.
+    // Monotonic for the tablet's lifetime and re-seeded by bootstrap replay, which re-applies
+    // exactly the marked writes that are not yet below the flushed frontier -- the ones the
+    // fence still cares about.
+    auto old_max = max_marked_write_op_index_.load(std::memory_order_relaxed);
+    while (operation.op_id().index > old_max &&
+           !max_marked_write_op_index_.compare_exchange_weak(
+               old_max, operation.op_id().index, std::memory_order_acq_rel)) {
+    }
   }
 
   return ApplyKeyValueRowOperations(
@@ -3240,8 +3254,21 @@ Status Tablet::UpdateIndexBackfillOrderingGeneration(
                         << " index-backfill ordering generation for table " << table_id
                         << " at " << op_id;
   RETURN_NOT_OK(metadata_->ApplyIndexBackfillOrderingGenerationOp(
-      op_id, table_id, activate, retention_barrier_ht, write_id_floor_version));
-  return metadata_->Flush();
+      op_id, table_id, activate, retention_barrier_ht, write_id_floor_version,
+      max_marked_write_op_index_.load(std::memory_order_acquire)));
+  RETURN_NOT_OK(metadata_->Flush());
+  if (!activate && !FLAGS_TEST_skip_index_backfill_generation_release_flush) {
+    // Push the generation's marked writes below the flushed frontier so the downgrade
+    // fence's per-tablet condition (flushed frontier >= released_marked_write_watermark)
+    // converges without waiting for an organic flush. Async: this runs on the Raft apply
+    // path. Best effort -- the fence re-checks the frontier, so a lost flush only delays
+    // convergence.
+    WARN_NOT_OK(
+        Flush(FlushMode::kAsync, FlushFlags::kRegular,
+              rocksdb::FlushReason::kIndexBackfillGenerationRelease),
+        "Failed to schedule flush after ordering-generation release");
+  }
+  return Status::OK();
 }
 
 Result<docdb::UniqueIndexVerificationResult> Tablet::VerifyUniqueIndex(

--- a/src/yb/tablet/tablet.h
+++ b/src/yb/tablet/tablet.h
@@ -580,6 +580,11 @@ class Tablet : public AbstractTablet,
 
   std::atomic<int64_t>* monotonic_counter() { return &monotonic_counter_; }
 
+  // Highest marked-write Raft index applied by this tablet (0 = none); see the member note.
+  int64_t max_marked_write_op_index() const {
+    return max_marked_write_op_index_.load(std::memory_order_acquire);
+  }
+
   // Set the conter to at least 'value'.
   void UpdateMonotonicCounter(int64_t value);
 
@@ -1419,6 +1424,11 @@ class Tablet : public AbstractTablet,
   // variable to true right after the intents write -- by then those intents are in the intents
   // memtable, so GetFlushAbility() reports kHasNewData and the force-advance is skipped.
   std::atomic<bool> can_advance_intents_flush_op_id_{true};
+
+  // Highest marked-write (use_raft_index_for_write_id) Raft index this tablet has applied.
+  // Monotonic; re-seeded by bootstrap replay. Persisted into the generation record at
+  // release as the downgrade fence's flushed-frontier target.
+  std::atomic<int64_t> max_marked_write_op_index_{0};
 
   HybridTimeLeaseProvider ht_lease_provider_;
 

--- a/src/yb/tablet/tablet_metadata.cc
+++ b/src/yb/tablet/tablet_metadata.cc
@@ -1301,6 +1301,7 @@ Status RaftGroupMetadata::LoadFromSuperBlock(const RaftGroupReplicaSuperBlockPB&
           .base_op_index = generation_pb.base_op_index(),
           .retention_barrier_ht = HybridTime::FromPB(generation_pb.retention_barrier_ht()),
           .write_id_floor_version = generation_pb.write_id_floor_version(),
+          .released_marked_write_watermark = generation_pb.released_marked_write_watermark(),
       };
     } else {
       // LoadFromSuperBlock also runs on existing metadata (e.g. remote-bootstrap superblock
@@ -1488,15 +1489,20 @@ void RaftGroupMetadata::ToSuperBlockUnlocked(RaftGroupReplicaSuperBlockPB* super
   pb.set_cdc_min_replicated_index(cdc_min_replicated_index_);
   cdc_sdk_min_checkpoint_op_id_.ToPB(pb.mutable_cdc_sdk_min_checkpoint_op_id());
   pb.set_cdc_sdk_safe_time(cdc_sdk_safe_time_.ToUint64());
-  if (index_backfill_ordering_generation_.active) {
+  if (index_backfill_ordering_generation_.active ||
+      index_backfill_ordering_generation_.released_marked_write_watermark != 0) {
+    // A released record persists too: the watermark is the downgrade fence's proof that
+    // all marked WAL entries sit below the flushed frontier.
     auto* generation_pb = pb.mutable_index_backfill_ordering_generation();
-    generation_pb->set_active(true);
+    generation_pb->set_active(index_backfill_ordering_generation_.active);
     generation_pb->set_table_id(index_backfill_ordering_generation_.table_id);
     generation_pb->set_base_op_index(index_backfill_ordering_generation_.base_op_index);
     generation_pb->set_retention_barrier_ht(
         index_backfill_ordering_generation_.retention_barrier_ht.ToUint64());
     generation_pb->set_write_id_floor_version(
         index_backfill_ordering_generation_.write_id_floor_version);
+    generation_pb->set_released_marked_write_watermark(
+        index_backfill_ordering_generation_.released_marked_write_watermark);
   }
   pb.set_is_under_xcluster_replication(is_under_xcluster_replication_);
   pb.set_hidden(hidden_);
@@ -1882,16 +1888,22 @@ Status RaftGroupMetadata::set_cdc_sdk_safe_time(const HybridTime& cdc_sdk_safe_t
 
 Status RaftGroupMetadata::set_index_backfill_ordering_generation(
     const IndexBackfillOrderingGeneration& generation) {
-  // The durable form of an inactive generation is field absence (ToSuperBlockUnlocked persists
-  // only active generations), so an inactive record with populated fields would diverge from
-  // what a reload produces. Normalize so the in-memory and durable states stay identical; the
-  // contract for callers is "set an active generation or set {}".
-  DCHECK(generation.active || generation == IndexBackfillOrderingGeneration())
+  // The durable form of an inactive generation is field absence -- except for the release
+  // watermark, which by design outlives the generation (the downgrade fence reads it until
+  // the flushed frontier passes it). Normalize inactive records to watermark-only so the
+  // in-memory and durable states stay identical; the contract for callers is "set an active
+  // generation, or a watermark-only (possibly empty) release record".
+  IndexBackfillOrderingGeneration normalized;
+  if (generation.active) {
+    normalized = generation;
+  } else {
+    normalized.released_marked_write_watermark = generation.released_marked_write_watermark;
+  }
+  DCHECK(generation == normalized)
       << "Inactive ordering generation with populated fields: " << generation;
   {
     std::lock_guard lock(data_mutex_);
-    index_backfill_ordering_generation_ =
-        generation.active ? generation : IndexBackfillOrderingGeneration();
+    index_backfill_ordering_generation_ = normalized;
   }
   return Flush();
 }
@@ -2692,7 +2704,8 @@ Status RaftGroupMetadata::OnBackfillDone(
 
 Status RaftGroupMetadata::ApplyIndexBackfillOrderingGenerationOp(
     const OpId& op_id, const TableId& table_id, ActivateGeneration activate,
-    HybridTime retention_barrier_ht, uint32_t write_id_floor_version) {
+    HybridTime retention_barrier_ht, uint32_t write_id_floor_version,
+    int64_t released_marked_write_watermark) {
   std::lock_guard lock(data_mutex_);
   if (activate) {
     // The base is the activation operation's own Raft index: replicas and WAL replay derive it
@@ -2707,7 +2720,13 @@ Status RaftGroupMetadata::ApplyIndexBackfillOrderingGenerationOp(
         .write_id_floor_version = write_id_floor_version,
     };
   } else {
-    index_backfill_ordering_generation_ = IndexBackfillOrderingGeneration();
+    // Release keeps only the watermark (the highest marked-write index applied so far), so
+    // the downgrade fence can prove "no marked WAL entry above the flushed frontier" from
+    // this field alone. Idempotent release (the funnel is at-least-once) can only move the
+    // watermark up, which stays correct.
+    IndexBackfillOrderingGeneration released;
+    released.released_marked_write_watermark = released_marked_write_watermark;
+    index_backfill_ordering_generation_ = released;
   }
   // Advance the change-metadata replay marker with the flush below (mirrors OnBackfillDone);
   // without it the op would replay on every bootstrap until some later ChangeMetadata flush.

--- a/src/yb/tablet/tablet_metadata.h
+++ b/src/yb/tablet/tablet_metadata.h
@@ -344,6 +344,11 @@ struct IndexBackfillOrderingGeneration {
   HybridTime retention_barrier_ht = HybridTime::kInvalid;
   // Version of kBackfillWriteIdFloor the generation's marked writes were stored with.
   uint32_t write_id_floor_version = 0;
+  // Highest marked-write Raft index the tablet had applied at release (0 = never released
+  // or no marked writes). The downgrade fence's per-tablet condition is "active, or the
+  // regular-DB flushed frontier is below this"; anchoring to the last marked WRITE (not the
+  // release op) lets the release-triggered flush converge it on an otherwise idle tablet.
+  int64_t released_marked_write_watermark = 0;
 
   friend bool operator==(
       const IndexBackfillOrderingGeneration&, const IndexBackfillOrderingGeneration&) = default;
@@ -357,7 +362,7 @@ struct IndexBackfillOrderingGeneration {
 
   std::string ToString() const {
     return YB_STRUCT_TO_STRING(active, table_id, base_op_index, retention_barrier_ht,
-                               write_id_floor_version);
+                               write_id_floor_version, released_marked_write_watermark);
   }
 
   friend std::ostream& operator<<(
@@ -528,11 +533,13 @@ class RaftGroupMetadata : public RefCountedThreadSafe<RaftGroupMetadata>,
       const IndexBackfillOrderingGeneration& generation);
 
   // Applies the ChangeMetadataOperation variant: activates a generation with
-  // base_op_index = op_id.index, or releases any active one. Advances the change-metadata
-  // replay marker; the caller flushes (mirrors OnBackfillDone).
+  // base_op_index = op_id.index, or releases any active one, persisting the caller-supplied
+  // marked-write watermark for the downgrade fence. Advances the change-metadata replay
+  // marker; the caller flushes (mirrors OnBackfillDone).
   Status ApplyIndexBackfillOrderingGenerationOp(
       const OpId& op_id, const TableId& table_id, ActivateGeneration activate,
-      HybridTime retention_barrier_ht, uint32_t write_id_floor_version);
+      HybridTime retention_barrier_ht, uint32_t write_id_floor_version,
+      int64_t released_marked_write_watermark);
 
   IndexBackfillOrderingGeneration index_backfill_ordering_generation() const;
 

--- a/src/yb/tablet/tablet_peer-test.cc
+++ b/src/yb/tablet/tablet_peer-test.cc
@@ -809,10 +809,21 @@ TEST_F(TabletPeerTest, IndexBackfillOrderingGenerationPersistsAcrossReload) {
   ASSERT_EQ(generation.retention_barrier_ht, loaded.retention_barrier_ht);
   ASSERT_EQ(generation.write_id_floor_version, loaded.write_id_floor_version);
 
-  // Releasing the generation persists as an absent superblock field.
-  ASSERT_OK(metadata->set_index_backfill_ordering_generation({}));
+  // A released record keeps its watermark across reload: the downgrade fence proves "no
+  // marked WAL entry above the flushed frontier" from it, so losing the watermark on
+  // restart would reopen the divergent-replay window.
+  IndexBackfillOrderingGeneration released;
+  released.released_marked_write_watermark = 99;
+  ASSERT_OK(metadata->set_index_backfill_ordering_generation(released));
   auto reloaded = ASSERT_RESULT(RaftGroupMetadata::Load(fs_manager, tablet_id));
   ASSERT_FALSE(reloaded->index_backfill_ordering_generation().active);
+  ASSERT_EQ(99, reloaded->index_backfill_ordering_generation().released_marked_write_watermark);
+
+  // A never-released clear persists as an absent superblock field.
+  ASSERT_OK(reloaded->set_index_backfill_ordering_generation({}));
+  reloaded = ASSERT_RESULT(RaftGroupMetadata::Load(fs_manager, tablet_id));
+  ASSERT_FALSE(reloaded->index_backfill_ordering_generation().active);
+  ASSERT_EQ(0, reloaded->index_backfill_ordering_generation().released_marked_write_watermark);
 }
 
 TEST_F(TabletPeerTest, IndexBackfillOrderingGenerationClearedBySuperblockReplacement) {

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -870,6 +870,53 @@ void TabletServiceAdminImpl::VerifyUniqueIndexTablet(
   context.RespondSuccess();
 }
 
+void TabletServiceAdminImpl::CheckIndexBackfillDowngradeSafety(
+    const CheckIndexBackfillDowngradeSafetyRequestPB* req,
+    CheckIndexBackfillDowngradeSafetyResponsePB* resp, rpc::RpcContext context) {
+  if (!CheckUuidMatchOrRespond(
+          server_->tablet_manager(), "CheckIndexBackfillDowngradeSafety", req, resp, &context)) {
+    return;
+  }
+  uint32_t active_generation_tablets = 0;
+  uint32_t unflushed_marked_wal_tablets = 0;
+  for (const auto& peer : server_->tablet_manager()->GetTabletPeers()) {
+    const auto data_state = peer->tablet_metadata()->tablet_data_state();
+    if (data_state == tablet::TABLET_DATA_TOMBSTONED ||
+        data_state == tablet::TABLET_DATA_DELETED ||
+        data_state == tablet::TABLET_DATA_SPLIT_COMPLETED) {
+      // No replay hazard: tombstoning/deletion removes the WAL, and a completed split parent
+      // flushed (pre-checkpoint sync flush) before splitting, so its marked writes are below
+      // its frontier. Counting these husks would block demotion on the master's
+      // tombstone-cleanup schedule instead of the fence's own drain.
+      continue;
+    }
+    const auto generation = peer->tablet_metadata()->index_backfill_ordering_generation();
+    if (generation.active) {
+      ++active_generation_tablets;
+      continue;
+    }
+    if (generation.released_marked_write_watermark == 0) {
+      continue;
+    }
+    // Released: marked writes (all at or below the watermark) stop replaying once the
+    // regular DB's flushed frontier reaches it. Fail closed while the tablet cannot report
+    // a frontier (bootstrapping, shutting down).
+    const auto tablet = peer->shared_tablet_maybe_null();
+    if (!tablet) {
+      ++unflushed_marked_wal_tablets;
+      continue;
+    }
+    const auto persistent_op_ids = tablet->MaxPersistentOpId();
+    if (!persistent_op_ids.ok() ||
+        persistent_op_ids->regular.index < generation.released_marked_write_watermark) {
+      ++unflushed_marked_wal_tablets;
+    }
+  }
+  resp->set_active_generation_tablets(active_generation_tablets);
+  resp->set_unflushed_marked_wal_tablets(unflushed_marked_wal_tablets);
+  context.RespondSuccess();
+}
+
 void TabletServiceAdminImpl::UpdateIndexBackfillOrderingGeneration(
     const tablet::ChangeMetadataRequestPB* req, ChangeMetadataResponsePB* resp,
     rpc::RpcContext context) {

--- a/src/yb/tserver/tablet_service.h
+++ b/src/yb/tserver/tablet_service.h
@@ -360,6 +360,12 @@ class TabletServiceAdminImpl : public TabletServerAdminServiceIf {
       const VerifyUniqueIndexTabletRequestPB* req, VerifyUniqueIndexTabletResponsePB* resp,
       rpc::RpcContext context) override;
 
+  // Downgrade-fence probe: counts tablets whose marked-write state an old binary could
+  // replay divergently.
+  void CheckIndexBackfillDowngradeSafety(
+      const CheckIndexBackfillDowngradeSafetyRequestPB* req,
+      CheckIndexBackfillDowngradeSafetyResponsePB* resp, rpc::RpcContext context) override;
+
   // Starts tablet splitting by adding split tablet Raft operation into Raft log of the source
   // tablet.
   void SplitTablet(

--- a/src/yb/tserver/tablet_validator.cc
+++ b/src/yb/tserver/tablet_validator.cc
@@ -38,6 +38,7 @@
 
 #include "yb/qlexpr/index.h"
 
+#include "yb/tablet/tablet.h"
 #include "yb/tablet/tablet_metadata.h"
 #include "yb/tablet/tablet_peer.h"
 
@@ -607,10 +608,22 @@ void TabletMetadataValidator::Impl::TriggerMetadataUpdate(
         if (index_update.index_table_id != generation.table_id) {
           continue;
         }
+        // The release record must carry the marked-write watermark for the downgrade fence,
+        // which only the running tablet knows; skip this round if it is not available and
+        // heal on a later validator cycle.
+        const auto tablet = (*result)->shared_tablet_maybe_null();
+        if (!tablet) {
+          LOG_WITH_PREFIX(INFO) << "Tablet " << index_tablet_id
+                                << ": deferring ordering-generation release until the tablet "
+                                << "is running (marked-write watermark unavailable)";
+          break;
+        }
         LOG_WITH_PREFIX(INFO) << "Tablet " << index_tablet_id
                               << ": releasing index-backfill ordering generation for "
                               << generation.table_id << " (backfill confirmed complete)";
-        auto release_status = tablet_meta->set_index_backfill_ordering_generation({});
+        tablet::IndexBackfillOrderingGeneration released;
+        released.released_marked_write_watermark = tablet->max_marked_write_op_index();
+        auto release_status = tablet_meta->set_index_backfill_ordering_generation(released);
         LOG_IF_WITH_PREFIX(WARNING, !release_status.ok())
             << "Tablet " << index_tablet_id << " ordering-generation release failed: "
             << release_status;

--- a/src/yb/tserver/tserver_admin.proto
+++ b/src/yb/tserver/tserver_admin.proto
@@ -206,6 +206,23 @@ message VerifyUniqueIndexTabletResponsePB {
   optional string violation_fingerprint = 9;
 }
 
+message CheckIndexBackfillDowngradeSafetyRequestPB {
+  optional bytes dest_uuid = 1;
+}
+
+message CheckIndexBackfillDowngradeSafetyResponsePB {
+  optional TabletServerErrorPB error = 1;
+
+  // Tablet peers with an active index-backfill ordering generation: marked writes may still
+  // be appended to their WALs.
+  optional uint32 active_generation_tablets = 2;
+
+  // Tablet peers whose generation was released but whose regular-DB flushed frontier has not
+  // yet passed released_marked_write_watermark: their WALs may still replay marked writes. Includes
+  // peers that cannot currently report a frontier (fail closed).
+  optional uint32 unflushed_marked_wal_tablets = 3;
+}
+
 // A create tablet request.
 message CreateTabletRequestPB {
   // UUID of server this request is addressed to.
@@ -569,6 +586,14 @@ service TabletServerAdminService {
   // paginated). See VerifyUniqueIndexTabletRequestPB.
   rpc VerifyUniqueIndexTablet(VerifyUniqueIndexTabletRequestPB)
       returns (VerifyUniqueIndexTabletResponsePB) {
+    option (yb.rpc.send_metadata) = true;
+  }
+
+  // Downgrade-fence probe: reports whether any tablet on this server still has marked-write
+  // state an old binary could replay divergently (active ordering generation, or released
+  // one whose marked WAL entries are not yet below the flushed frontier).
+  rpc CheckIndexBackfillDowngradeSafety(CheckIndexBackfillDowngradeSafetyRequestPB)
+      returns (CheckIndexBackfillDowngradeSafetyResponsePB) {
     option (yb.rpc.send_metadata) = true;
   }
 

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -28,6 +28,7 @@
 #include "yb/master/master_admin.proxy.h"
 #include "yb/master/master_admin.pb.h"
 #include "yb/master/master_client.pb.h"
+#include "yb/master/master_cluster.proxy.h"
 #include "yb/master/master_error.h"
 
 #include "yb/tserver/tserver_admin.proxy.h"
@@ -1734,6 +1735,132 @@ TEST_P(PgIndexBackfillVerifier, RetentionBarrierMetricsReflectHeldGeneration) {
             "value")),
         0);
   }
+}
+
+namespace {
+
+// Attempts to demote the deferred-verification capability AutoFlag for yb-tserver. Fence
+// refusals surface as the response error; returns OK once demotion goes through.
+Status TryDemoteVerificationCapabilityFlag(ExternalMiniCluster* cluster) {
+  auto proxy = cluster->GetLeaderMasterProxy<master::MasterClusterProxy>();
+  master::DemoteSingleAutoFlagRequestPB req;
+  req.set_process_name("yb-tserver");
+  req.set_auto_flag_name("ysql_enable_deferred_unique_index_verification");
+  master::DemoteSingleAutoFlagResponsePB resp;
+  rpc::RpcController rpc;
+  rpc.set_timeout(MonoDelta::FromSeconds(30) * kTimeMultiplier);
+  RETURN_NOT_OK(proxy.DemoteSingleAutoFlag(req, &resp, &rpc));
+  if (resp.has_error()) {
+    return StatusFromPB(resp.error().status());
+  }
+  return Status::OK();
+}
+
+}  // namespace
+
+// Downgrade fence: the capability flag cannot be demoted while any tablet still holds an
+// active ordering generation -- its marked WAL entries would replay divergently on an old
+// binary the demotion would re-admit.
+TEST_P(PgIndexBackfillVerifier, DowngradeFenceBlocksWhileGenerationsHeld) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (1, 1)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+
+  // The fixture blocks the funnel's release: generations are held on every replica.
+  const auto status = TryDemoteVerificationCapabilityFlag(cluster_.get());
+  ASSERT_NOK(status);
+  ASSERT_STR_CONTAINS(status.ToString(), "active index-backfill ordering generation");
+}
+
+// After the terminal funnel releases the generations and the release-triggered flush pushes
+// the marked writes below the flushed frontier, demotion goes through.
+TEST_P(PgIndexBackfillVerifierReleased, DowngradeFenceClearsAfterRelease) {
+  std::vector<ExternalDaemon*> tserver_daemons;
+  for (auto* tserver : cluster_->tserver_daemons()) {
+    tserver_daemons.push_back(tserver);
+  }
+  LogWaiter release_waiter(
+      tserver_daemons, "Releasing index-backfill ordering generation");
+
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (1, 1)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+  ASSERT_OK(release_waiter.WaitFor(MonoDelta::FromSeconds(30) * kTimeMultiplier));
+
+  // Job deletion and the release flush converge within seconds; the fence rechecks both.
+  ASSERT_OK(WaitFor(
+      [this]() -> Result<bool> {
+        const auto status = TryDemoteVerificationCapabilityFlag(cluster_.get());
+        if (status.ok()) {
+          return true;
+        }
+        LOG(INFO) << "Demotion still fenced: " << status;
+        return false;
+      },
+      MonoDelta::FromSeconds(60) * kTimeMultiplier, "downgrade fence to clear"));
+}
+
+// The unflushed-marked-WAL arm, deterministically: with the release-triggered flush
+// disabled, released tablets keep their marked writes above the flushed frontier and the
+// fence must refuse with the not-yet-flushed message.
+class PgIndexBackfillVerifierReleasedNoFlush : public PgIndexBackfillVerifierReleased {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillVerifierReleased::UpdateMiniClusterOptions(options);
+    options->extra_tserver_flags.push_back(
+        "--TEST_skip_index_backfill_generation_release_flush=true");
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillVerifierReleasedNoFlush, ::testing::Bool());
+
+TEST_P(PgIndexBackfillVerifierReleasedNoFlush, DowngradeFenceBlocksWhileMarkedWalUnflushed) {
+  std::vector<ExternalDaemon*> tserver_daemons;
+  for (auto* tserver : cluster_->tserver_daemons()) {
+    tserver_daemons.push_back(tserver);
+  }
+  LogWaiter release_waiter(
+      tserver_daemons, "Releasing index-backfill ordering generation");
+
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (1, 1)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX $0 ON $1 (b HASH) SPLIT INTO 1 TABLETS", kIndexName, kTableName));
+  ASSERT_OK(release_waiter.WaitFor(MonoDelta::FromSeconds(30) * kTimeMultiplier));
+
+  const auto status = TryDemoteVerificationCapabilityFlag(cluster_.get());
+  ASSERT_NOK(status);
+  ASSERT_STR_CONTAINS(status.ToString(), "marked WAL entries not yet flushed");
+}
+
+// The fence also refuses while a SKIP_ALL job is active on the master -- before probing any
+// tserver: the job's chunks may still be appending marked writes.
+TEST_P(PgIndexBackfillSkipAllRaftOrdering, DowngradeFenceBlocksWhileJobActive) {
+  ASSERT_OK(cluster_->SetFlagOnMasters("TEST_block_do_backfill", "true"));
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (a int PRIMARY KEY, b int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (1, 1)", kTableName));
+
+  thread_holder_.AddThreadFunctor([this] {
+    auto create_conn = ASSERT_RESULT(Connect());
+    ASSERT_OK(create_conn.ExecuteFormat(
+        "CREATE UNIQUE INDEX $0 ON $1 (b ASC)", kIndexName, kTableName));
+  });
+  {
+    auto client = ASSERT_RESULT(cluster_->CreateClient());
+    const auto table_id = ASSERT_RESULT(GetTableIdByTableName(
+        client.get(), kYBTableName.namespace_name(), kYBTableName.table_name()));
+    ASSERT_OK(WaitForBackfillSafeTimeOn(
+        cluster_->GetLeaderMasterProxy<master::MasterDdlProxy>(), table_id));
+  }
+
+  const auto status = TryDemoteVerificationCapabilityFlag(cluster_.get());
+  ASSERT_NOK(status);
+  ASSERT_STR_CONTAINS(status.ToString(), "SKIP_ALL index-backfill jobs");
+
+  ASSERT_OK(cluster_->SetFlagOnMasters("TEST_block_do_backfill", "false"));
+  thread_holder_.JoinAll();
 }
 
 TEST_P(PgIndexBackfillVerifierReleased, RetentionBarrierMetricsClearOnRelease) {


### PR DESCRIPTION
## Summary

The downgrade fence for deferred unique-index verification (#33444), closing the stack's
carried divergent-replay hazard: an old binary replaying marked backfill writes computes
positional write IDs -- byte-divergent replicas. Binary downgrade to a pre-feature binary is
already hard-fenced by AutoFlags config validation while
`ysql_enable_deferred_unique_index_verification` stays promoted, and `RollbackAutoFlags`
refuses kLocalPersisted flags outright -- but `DemoteSingleAutoFlag` validated nothing
beyond flag existence. Demoting the capability flag clears the startup fence while marked
WAL entries may still replay.

`DemoteSingleAutoFlag` now refuses to demote this flag (the demote-side first; the
promote-side YSQL-major-upgrade veto is the precedent) while either holds:

- Any table has an active SKIP_ALL backfill job (sys-catalog scan): its chunks may still be
  appending marked writes.
- Any registered tserver reports marked-write state via the new
  `CheckIndexBackfillDowngradeSafety` admin RPC: a tablet with an active ordering
  generation, or a released one whose marked WAL entries are not yet below the regular-DB
  flushed frontier. An unreachable tserver FAILS the demotion (it may hold config-member
  replicas with unflushed marked WAL; wait for it or decommission it) -- with one exception:
  a node dead past `follower_unavailable_considered_failed_sec` is skipped, since its
  replicas have been evicted and re-replicated and a returning node's stale local replay is
  confined to data that is tombstoned before serving. The probe skips tombstoned/deleted
  peers (WAL removed) and completed split parents (flushed before the split checkpoint), so
  husks on the master's cleanup schedule cannot block a drain.

The per-tablet condition is made provable and convergent by two release-path changes:

- Release persists `released_marked_write_watermark` in the generation superblock record:
  the highest marked-write Raft index the tablet has applied (tracked in memory, monotonic,
  re-seeded by bootstrap replay, which re-applies exactly the marked writes still above the
  flushed frontier). Anchoring to the last marked WRITE rather than the release op matters:
  metadata ops never advance the RocksDB frontier, so a release-op watermark would never
  converge on an idle tablet -- the clears-after-release e2e caught exactly that bug during
  development.
- Release schedules an async regular-DB flush
  (`FlushReason::kIndexBackfillGenerationRelease`), pushing the marked writes below the
  frontier within seconds instead of waiting for an organic flush.

The released record now survives in the superblock (previously only active generations
persisted) until the next activation; the tablet validator's straggler heal records the
watermark too, deferring a cycle if the tablet is not running. Refusal messages carry the
drain procedure, and the veto is deliberately not bypassable: every blocking condition
drains on its own. Residual window documented at the validation function: a SKIP_ALL job
created between the scan and config propagation is not seen; its writes are then rejected by
the write-time capability check once the config lands.

Stacked on #33403, #33404, #33484, #33544, #33553, #33580, #33584, #33601, #33602, #33654,
#33655, #33656, #33657, #33685, and #33686, based on
`feature-stack/Shopify/uniq-idx-8c-violation-fingerprint` per the feature-stack workflow, so
the diff is exactly this PR's own commit. A failing pr-title check on stacked PRs is a known
gap in that check; the stack merges bottom-up and retargets as parents merge.

## Upgrade/Rollback safety

Two additive proto surfaces, both inert until the feature is active:

- Tablet superblock: `IndexBackfillOrderingGenerationPB.released_marked_write_watermark`
  (field 6, next free), inside the generation submessage (field 39) that only this
  AutoFlag-gated stack writes. An old tserver reads it as an unknown field inside a
  submessage it already ignores; a rolled-back tserver that rewrites the superblock
  preserves it. The fence itself guarantees the stronger property: demotion -- the act that
  re-admits old binaries -- is refused until every watermark is below its tablet's flushed
  frontier, i.e. until the field no longer protects anything an old binary could replay
  wrongly.
- `tserver_admin.proto`: the new `CheckIndexBackfillDowngradeSafety` RPC. Only the new
  master calls it, only during a demotion attempt of this specific flag. A mixed-version
  probe of an old tserver fails the RPC and therefore fails the demotion -- the safe
  direction (an old tserver cannot attest to its marked-WAL state).

No flag-default changes; the veto activates only for the one capability flag, and
`demote_single_auto_flag` of any other flag is untouched.

## Test plan

macOS arm64, release -- all green:

- [x] New: `PgIndexBackfillVerifier.DowngradeFenceBlocksWhileGenerationsHeld/0` -- release
      blocked by the fixture: demotion refused, message names the active ordering
      generation.
- [x] New: `PgIndexBackfillSkipAllRaftOrdering.DowngradeFenceBlocksWhileJobActive/0` -- job
      held at DoBackfill: demotion refused before any tserver probe, message names the
      SKIP_ALL job's table.
- [x] New: `PgIndexBackfillVerifierReleasedNoFlush.DowngradeFenceBlocksWhileMarkedWalUnflushed/0`
      -- deterministic pin of the unflushed arm: release flush disabled via test flag, fence
      refuses with the not-yet-flushed message.
- [x] New: `PgIndexBackfillVerifierReleased.DowngradeFenceClearsAfterRelease/0` -- after the
      funnel releases and the release flush converges, demotion goes through.
- [x] Extended: `TabletPeerTest.IndexBackfillOrderingGenerationPersistsAcrossReload` -- the
      released watermark survives reload; a never-released clear still persists as field
      absence.
- [x] Regressions: full `tablet_peer-test` (27), full `fixed_hybrid_time_write_id-itest`
      (7), funnel release e2e (`OrderingGenerationActivatedAndReleased`),
      `VerifyAfterReleaseFailsCleanly`, `RetentionPinMetricsClearOnRelease`.

AlmaLinux (x86_64, clang21), rebased onto master `c7253d204d`:

At this PR's own commit (`d55f928e2b`), ASAN -- all green:

- [x] `tablet_peer-test`, `auto_flags-itest` (the demotion path this PR fences).
- [x] All four downgrade-fence e2e tests, both params (8 runs), including
      `DowngradeFenceBlocksWhileMarkedWalUnflushed`.

That last case is what this PR exists for: it is the scenario every earlier PR in the stack
carried as a caveat ("rollback with unflushed marked WAL entries replays divergently on old
binaries"). The fence makes it structural rather than a warning.

Integrated at the stack tip (`334a1deb3d`), all green. Exact suites per build type:

- [x] TSAN (6): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `non_transactional_batch_writer-test`,
      `keyed_fingerprint-test`, `raft_consensus-itest`.
- [x] ASAN (15): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `keyed_fingerprint-test`,
      `non_transactional_batch_writer-test`, `clone-tablet-itest`,
      `remote_bootstrap-itest`, `tablet_bootstrap-test`, `auto_flags-itest`,
      `docdb-test`, `compaction_file_filter-test`,
      `xcluster_external_apply_bootstrap-test`, `pg_txn-test`, `pg_ash-test`,
      full `pg_index_backfill-test`.
- [x] Debug (19): the ASAN list minus `compaction_file_filter-test`, plus
      `master_failover-itest`, `snapshot-test`, `tablet_snapshots-test`,
      `compaction-test`, `tablet-split-itest`.
- [x] Release (5): `keyed_fingerprint-test`, `auto_flags-itest`, full
      `pg_index_backfill-test`, java `TestIndexBackfill`, java
      `TestPgRegressBackfillIndex`.
- [x] All three full `pg_index_backfill-test` runs (ASAN, debug, release) pass with no
      test failures.

Two known-upstream issues surfaced by the tip matrix, both shown not attributable to this
stack:

- TSAN `tablet-split-itest` reports 3 data races in `yb::client::YBTable::~YBTable()`
  (table.cc:81) racing its partition-refresh callback, inside the upstream test
  `AutomaticTabletSplitITest.SizeRatio` (93 cases ran, 0 gtest failures). This stack has zero
  diff under `src/yb/client/`, and that test passes 3/3 isolated at the new master base.
- `wait_states-itest` hangs 9 cases at the 601s timeout (`AshCql`, the `kYCQL_*` group,
  `kBackfillIndex_*`, `kConsensusMeta_Flush`, `kCreatingNewTablet`,
  `kSaveRaftGroupMetadataToDisk`). Reproduced identically on plain master `c7253d204d`
  carrying none of this stack's code: 53 ran, the same 9 failed, same ~600.5s expiries.
  Tracked upstream in #33729.

Disposition change since the previous revision: the
`PgIndexBackfillBackendsManager.NoAbortTxn/1` flake cited earlier was fixed upstream. It
passes 3/3 at the new base and in all three full `pg_index_backfill-test` runs here, so it is
no longer carried as a known flake.


