### PR TITLE
[#33444] DocDB: Add ASH wait states for deferred unique-index verification

### DIFF
--- a/src/yb/ash/wait_state.cc
+++ b/src/yb/ash/wait_state.cc
@@ -265,6 +265,12 @@ std::string GetWaitStateDescription(WaitStateCode code) {
              "commit the transaction.";
     case WaitStateCode::kBackfillIndex_WaitToBackfillTablet:
       return "Waiting for index backfill chunk to be processed.";
+    case WaitStateCode::kUniqueIndexVerify_ResolveIntents:
+      return "Deferred unique-index verification is waiting for transactions committed within "
+             "the verification window to finish applying their intents.";
+    case WaitStateCode::kUniqueIndexVerify_Scan:
+      return "Deferred unique-index verification is scanning a unique-index tablet's history "
+             "for uniqueness violations.";
     case WaitStateCode::kVectorIndex_Search:
       return "The vector index is performing an approximate nearest neighbor search.";
   }
@@ -651,6 +657,7 @@ WaitStateType GetWaitStateType(WaitStateCode code) {
     case WaitStateCode::kWaitForReadTime:
     case WaitStateCode::kBackfillIndex_WaitToBackfillTablet:
     case WaitStateCode::kXCluster_WaitForSafeTime:
+    case WaitStateCode::kUniqueIndexVerify_ResolveIntents:
       return WaitStateType::kWaitOnCondition;
 
     case WaitStateCode::kCreatingNewTablet:
@@ -721,6 +728,7 @@ WaitStateType GetWaitStateType(WaitStateCode code) {
       return WaitStateType::kWaitOnCondition;
 
     case WaitStateCode::kRocksDB_NewIterator:
+    case WaitStateCode::kUniqueIndexVerify_Scan:
       return WaitStateType::kDiskIO;
 
     case WaitStateCode::kYCQL_Parse:
@@ -796,6 +804,8 @@ const char* GetWaitStateAuxDescription(WaitStateCode code) {
     case WaitStateCode::kBackfillIndex_WaitToBackfillTablet:
     case WaitStateCode::kXCluster_RateLimiter:
     case WaitStateCode::kXCluster_WaitForSafeTime:
+    case WaitStateCode::kUniqueIndexVerify_ResolveIntents:
+    case WaitStateCode::kUniqueIndexVerify_Scan:
     case WaitStateCode::kVectorIndex_Search:
       return "This contains tablet ID.";
 

--- a/src/yb/ash/wait_state.h
+++ b/src/yb/ash/wait_state.h
@@ -191,6 +191,8 @@ YB_DEFINE_TYPED_ENUM(WaitStateCode, uint32_t,
     (kBackfillIndex_WaitToBackfillTablet)
     (kXCluster_WaitForSafeTime)
     (kXCluster_RateLimiter)
+    (kUniqueIndexVerify_ResolveIntents)
+    (kUniqueIndexVerify_Scan)
 
     // Wait states related to consensus
     ((kRaft_WaitingForReplication, YB_ASH_MAKE_EVENT(Consensus)))

--- a/src/yb/integration-tests/wait_states-itest.cc
+++ b/src/yb/integration-tests/wait_states-itest.cc
@@ -60,9 +60,11 @@ DECLARE_bool(enable_flush_retryable_requests);
 DECLARE_bool(enable_wait_queues);
 DECLARE_int32(rpc_slow_query_threshold_ms);
 DECLARE_int32(rpc_workers_limit);
+DECLARE_int32(timestamp_history_retention_interval_sec);
 DECLARE_int64(transaction_abort_check_interval_ms);
 DECLARE_uint64(transaction_manager_workers_limit);
 DECLARE_bool(transactions_poll_check_aborted);
+DECLARE_bool(ysql_disable_index_backfill);
 DECLARE_bool(enable_ysql);
 DECLARE_bool(master_auto_run_initdb);
 
@@ -79,7 +81,9 @@ DECLARE_uint32(TEST_yb_ash_sleep_at_wait_state_ms);
 DECLARE_string(TEST_yb_ash_wait_code_to_sleep_at);
 DECLARE_int32(num_concurrent_backfills_allowed);
 DECLARE_int32(TEST_slowdown_backfill_by_ms);
+DECLARE_string(TEST_ysql_index_backfill_unique_check_mode);
 DECLARE_int32(backfill_index_rate_rows_per_sec);
+DECLARE_bool(ysql_index_backfill_shadow_verification);
 DECLARE_int32(memstore_size_mb);
 DECLARE_int64(rocksdb_compact_flush_rate_limit_bytes_per_sec);
 DECLARE_bool(TEST_export_wait_state_names);
@@ -726,6 +730,17 @@ class AshTestVerifyOccurrenceBase : public AshTestWithCompactions {
       ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_flush_retryable_requests) = true;
     }
 
+    if (code_to_look_for_ == ash::WaitStateCode::kUniqueIndexVerify_ResolveIntents ||
+        code_to_look_for_ == ash::WaitStateCode::kUniqueIndexVerify_Scan) {
+      // Deferred unique-index verification runs after a SKIP_ALL build; the mode is
+      // production-hardcoded to CHECK_ALL, so drive it through the test override. The
+      // override is read through the gflags registry, so it must go through SET_FLAG, not a
+      // direct FLAGS_ write. Base-table retention keeps the backfill reads valid (#32565).
+      ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_index_backfill_shadow_verification) = true;
+      ASSERT_OK(SET_FLAG(TEST_ysql_index_backfill_unique_check_mode, "skip_all"));
+      ANNOTATE_UNPROTECTED_WRITE(FLAGS_timestamp_history_retention_interval_sec) = 900;
+    }
+
     if (code_to_look_for_ == ash::WaitStateCode::kRocksDB_Flush ||
         code_to_look_for_ == ash::WaitStateCode::kRocksDB_Compaction) {
       ANNOTATE_UNPROTECTED_WRITE(FLAGS_memstore_size_mb) = 1;
@@ -744,6 +759,17 @@ class AshTestVerifyOccurrenceBase : public AshTestWithCompactions {
     do_compactions_ = (code_class == ash::Class::kRocksDB);
 
     WaitStateTestCheckMethodCounts::SetUp();
+  }
+
+  void BeforePgProcessStart() override {
+    AshTestWithCompactions::BeforePgProcessStart();
+    if (code_to_look_for_ == ash::WaitStateCode::kUniqueIndexVerify_ResolveIntents ||
+        code_to_look_for_ == ash::WaitStateCode::kUniqueIndexVerify_Scan) {
+      // PgMiniTestBase::SetUp disables YSQL index backfill for speed, and the PG side
+      // latches it at postmaster start; verification only runs on backfilled builds, so
+      // re-enable it in this pre-postmaster hook.
+      ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_disable_index_backfill) = false;
+    }
   }
 
   void SetCompactionAndFlushRate(int run_id) override {
@@ -842,6 +868,7 @@ class AshTestVerifyOccurrenceBase : public AshTestWithCompactions {
   const bool verify_code_was_pulled_;
 
   void CreateIndexesUntilStopped(std::atomic<bool>& stop);
+  void CreatePgUniqueIndexesUntilStopped(std::atomic<bool>& stop);
   void AddNodesUntilStopped(std::atomic<bool>& stop);
   void DoPgDeferrableReadsUntilStopped(std::atomic<bool>& stop);
   void CreateAndRestoreSnapshot();
@@ -878,6 +905,22 @@ void AshTestVerifyOccurrenceBase::CreateIndexesUntilStopped(std::atomic<bool>& s
     LOG(INFO) << "Created index " << i;
     ++num_indexes_created_;
     SleepFor(10ms);
+  }
+}
+
+void AshTestVerifyOccurrenceBase::CreatePgUniqueIndexesUntilStopped(std::atomic<bool>& stop) {
+  auto conn = ASSERT_RESULT(Connect());
+  constexpr auto kTableName = "uniq_verify_ash_test";
+  ASSERT_OK(conn.ExecuteFormat(
+      "CREATE TABLE $0 (k INT PRIMARY KEY, v INT) SPLIT INTO 1 TABLETS", kTableName));
+  ASSERT_OK(conn.ExecuteFormat(
+      "INSERT INTO $0 SELECT i, i FROM generate_series(1, 1000) AS i", kTableName));
+  // Every unique-index build runs the deferred verification scan (the fixture selects
+  // SKIP_ALL and enables shadow verification), entering both UniqueIndexVerify states.
+  for (int i = 1; !stop; i++) {
+    ASSERT_OK(conn.ExecuteFormat(
+        "CREATE UNIQUE INDEX uniq_verify_ash_idx_$0 ON $1 (v)", i, kTableName));
+    ASSERT_OK(conn.ExecuteFormat("DROP INDEX uniq_verify_ash_idx_$0", i));
   }
 }
 
@@ -974,6 +1017,11 @@ void AshTestVerifyOccurrenceBase::LaunchWorkers(TestThreadHolder* thread_holder)
       thread_holder->AddThreadFunctor(
           [this, &stop = thread_holder->stop_flag()] { DoPgDeferrableReadsUntilStopped(stop); });
       break;
+    case ash::WaitStateCode::kUniqueIndexVerify_ResolveIntents:
+    case ash::WaitStateCode::kUniqueIndexVerify_Scan:
+      thread_holder->AddThreadFunctor(
+          [this, &stop = thread_holder->stop_flag()] { CreatePgUniqueIndexesUntilStopped(stop); });
+      break;
     case ash::WaitStateCode::kSnapshot_WaitingForFlush:
     case ash::WaitStateCode::kSnapshot_RestoreCheckpoint:
     case ash::WaitStateCode::kSnapshot_CleanupSnapshotDir:
@@ -1007,6 +1055,8 @@ INSTANTIATE_TEST_SUITE_P(
       ash::WaitStateCode::kLockedBatchEntry_Lock,
       ash::WaitStateCode::kBackfillIndex_WaitForAFreeSlot,
       ash::WaitStateCode::kBackfillIndex_WaitToBackfillTablet,
+      ash::WaitStateCode::kUniqueIndexVerify_ResolveIntents,
+      ash::WaitStateCode::kUniqueIndexVerify_Scan,
       ash::WaitStateCode::kCreatingNewTablet,
       ash::WaitStateCode::kSaveRaftGroupMetadataToDisk,
       ash::WaitStateCode::kDumpRunningRpc_WaitOnReactor,

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -814,6 +814,7 @@ void TabletServiceAdminImpl::VerifyUniqueIndexTablet(
   }
   auto* participant = tablet.tablet->transaction_participant();
   if (participant) {
+    SCOPED_WAIT_STATUS(UniqueIndexVerify_ResolveIntents);
     const auto resolve_status = participant->ResolveIntents(verify_upper_ht, deadline);
     if (!resolve_status.ok()) {
       SetupErrorAndRespond(resp->mutable_error(), resolve_status, &context);
@@ -821,6 +822,7 @@ void TabletServiceAdminImpl::VerifyUniqueIndexTablet(
     }
   }
 
+  SCOPED_WAIT_STATUS(UniqueIndexVerify_Scan);
   const auto result = tablet.tablet->VerifyUniqueIndex(*req, deadline);
   if (!result.ok()) {
     // Typed codes so callers do not burn a retry budget on deterministic failures:

--- a/src/yb/yql/pgwrapper/pg_ash-test.cc
+++ b/src/yb/yql/pgwrapper/pg_ash-test.cc
@@ -1021,6 +1021,48 @@ TEST_F(PgBgWorkersTest, TestBgWorkersQueryId) {
   ASSERT_GE(bgworker_query_id_cnt, 1);
 }
 
+// Deferred unique-index verification (#33444): the scan runs on the tserver under the
+// originating CREATE INDEX statement's ASH metadata, threaded through the master's backfill
+// task. The Scan wait state is short on small data, so pin the sleep-at-wait-state hook to
+// it and sample fast.
+class PgAshUniqueIndexVerifyTest : public PgAshTest {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgAshTest::UpdateMiniClusterOptions(options);
+    options->extra_master_flags.push_back("--ysql_index_backfill_shadow_verification=true");
+    options->extra_master_flags.push_back(
+        "--TEST_ysql_index_backfill_unique_check_mode=skip_all");
+    // Base-table retention for the backfill reads (#32565), mirroring the verifier fixtures.
+    options->extra_tserver_flags.push_back("--timestamp_history_retention_interval_sec=900");
+    options->extra_tserver_flags.push_back(Format(
+        "--TEST_yb_ash_wait_code_to_sleep_at=$0",
+        std::to_underlying(ash::WaitStateCode::kUniqueIndexVerify_Scan)));
+    options->extra_tserver_flags.push_back("--TEST_yb_ash_sleep_at_wait_state_ms=1000");
+    options->extra_tserver_flags.push_back("--ysql_yb_ash_sampling_interval_ms=50");
+  }
+};
+
+TEST_F(PgAshUniqueIndexVerifyTest, UniqueIndexVerifyScanCarriesQueryId) {
+  constexpr auto kTableName = "uniq_verify_ash";
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE TABLE $0 (k INT PRIMARY KEY, v INT) SPLIT INTO 1 TABLETS", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 SELECT i, i FROM generate_series(1, 1000) AS i", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE UNIQUE INDEX uniq_verify_ash_idx ON $0 (v)", kTableName));
+
+  const auto query_id = ASSERT_RESULT(conn_->FetchRow<int64_t>(
+      "SELECT queryid FROM pg_stat_statements WHERE query LIKE 'CREATE UNIQUE INDEX%'"));
+  // Only Scan is pinned on purpose: UniqueIndexVerify_ResolveIntents shares the identical
+  // RPC/metadata path but is typically instantaneous on an idle cluster, and the sleep hook
+  // above targets one code.
+  ASSERT_OK(WaitFor([&]() -> Result<bool> {
+    return VERIFY_RESULT(conn_->FetchRow<int64_t>(Format(
+        "SELECT COUNT(*) FROM yb_active_session_history "
+        "WHERE query_id = $0 AND wait_event = 'UniqueIndexVerify_Scan'", query_id))) > 0;
+  }, 30s * kTimeMultiplier, "wait for UniqueIndexVerify_Scan ASH sample"));
+}
+
 TEST_F(PgAshTest, TestTServerMetadataSerializer) {
   static constexpr auto kTableName = "test_table";
 


### PR DESCRIPTION
## Summary

ASH visibility for deferred unique-index verification (#33444): the scan can run for
minutes on a large index while CREATE INDEX waits on it, and without wait states that time
is invisible. Two new `TabletWait` codes cover the verify RPC's blocking phases:

- `UniqueIndexVerify_ResolveIntents` (`kWaitOnCondition`) -- waiting for transactions
  committed within the verification window to finish applying their intents (the
  applied-intents barrier).
- `UniqueIndexVerify_Scan` (`kDiskIO`) -- the uniqueness scan itself, a cold history pass;
  inner RocksDB read states show through during actual block reads.

The safe-time wait ahead of them deliberately gets no new code: the MVCC layer already
reports `kMVCC_WaitForSafeTime` from inside that wait, and a wrapper state would only be
overridden.

Attribution needed no new plumbing -- the master's backfill task already captures the
originating statement's ASH metadata and adopts it when sending, and the verify RPC already
carries `send_metadata` -- but it is now proven end to end: the pg_ash test pins that
`UniqueIndexVerify_Scan` samples carry the CREATE UNIQUE INDEX statement's
`pg_stat_statements` queryid. Both codes report the tablet id via the standard leader-lookup
path, and all three no-default `wait_state.cc` switches (type, description, aux) are
covered.

Stacked on #33403, #33404, #33484, #33544, #33553, #33580, #33584, #33601, #33602, #33654,
#33655, #33656, #33657, #33685, #33686, and #33703, based on
`feature-stack/Shopify/uniq-idx-8d-downgrade-fence` per the feature-stack workflow, so the
diff is exactly this PR's own commit. A failing pr-title check on stacked PRs is a known gap
in that check; the stack merges bottom-up and retargets as parents merge.

## Upgrade/Rollback safety

A non-event: no wire, persisted-format, RPC, or flag changes. The two `WaitStateCode`
values are appended at the tail of their class group (no ordinal shift of existing codes),
and wait-state codes never cross node boundaries -- the sampler reads them in-process on
each tserver.

## Test plan

macOS arm64, release -- all green:

- [x] New: `WaitStateITest/AshTestVerifyOccurrence.VerifyWaitStateEntered/kUniqueIndexVerify_Scan`
      and `.../kUniqueIndexVerify_ResolveIntents` -- entered-state proof via the harness's
      sleep-at-wait-state hook; the harness gains a `CreatePgUniqueIndexesUntilStopped`
      worker, selects SKIP_ALL via the test override (through `SET_FLAG` -- the override is
      read through the gflags registry, so a direct `FLAGS_` write silently no-ops), and
      re-enables YSQL index backfill in `BeforePgProcessStart` (the base fixture disables it
      and the PG side latches it at postmaster start).
- [x] New: `PgAshUniqueIndexVerifyTest.UniqueIndexVerifyScanCarriesQueryId` -- the
      attribution pin: samples for `UniqueIndexVerify_Scan` carry the CREATE UNIQUE INDEX
      statement's `pg_stat_statements` queryid end to end. Only Scan is pinned on purpose:
      ResolveIntents shares the identical RPC/metadata path and is typically instantaneous
      on an idle cluster (commented in the test).
- [x] Regressions: the `kMVCC_WaitForSafeTime` itest instance and the shadow verification
      clean e2e.

AlmaLinux (x86_64, clang21), rebased onto master `c7253d204d`:

At this PR's own commit (`334a1deb3d`), ASAN -- all green:

- [x] `wait_states-itest` filtered to each new code (`UniqueIndexVerify_ResolveIntents`,
      `UniqueIndexVerify_Scan`).
- [x] `pg_ash-test` filtered to `UniqueIndexVerifyScanCarriesQueryId`.

Both codes are entered, and the query-id test confirms ASH metadata threads from the master
coordinator through to the tserver handler (`VerifyUniqueIndexTablet` carries
`send_metadata`). The full `wait_states-itest` suite hangs 9 unrelated cases on this hardware;
that is reproduced identically on plain master -- see the tip-matrix note below.

Integrated at the stack tip (`334a1deb3d`), all green. Exact suites per build type:

- [x] TSAN (6): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `non_transactional_batch_writer-test`,
      `keyed_fingerprint-test`, `raft_consensus-itest`.
- [x] ASAN (15): `tablet_peer-test`, `fixed_hybrid_time_write_id-itest`,
      `unique_index_verifier-test`, `keyed_fingerprint-test`,
      `non_transactional_batch_writer-test`, `clone-tablet-itest`,
      `remote_bootstrap-itest`, `tablet_bootstrap-test`, `auto_flags-itest`,
      `docdb-test`, `compaction_file_filter-test`,
      `xcluster_external_apply_bootstrap-test`, `pg_txn-test`, `pg_ash-test`,
      full `pg_index_backfill-test`.
- [x] Debug (19): the ASAN list minus `compaction_file_filter-test`, plus
      `master_failover-itest`, `snapshot-test`, `tablet_snapshots-test`,
      `compaction-test`, `tablet-split-itest`.
- [x] Release (5): `keyed_fingerprint-test`, `auto_flags-itest`, full
      `pg_index_backfill-test`, java `TestIndexBackfill`, java
      `TestPgRegressBackfillIndex`.
- [x] All three full `pg_index_backfill-test` runs (ASAN, debug, release) pass with no
      test failures.

Two known-upstream issues surfaced by the tip matrix, both shown not attributable to this
stack:

- TSAN `tablet-split-itest` reports 3 data races in `yb::client::YBTable::~YBTable()`
  (table.cc:81) racing its partition-refresh callback, inside the upstream test
  `AutomaticTabletSplitITest.SizeRatio` (93 cases ran, 0 gtest failures). This stack has zero
  diff under `src/yb/client/`, and that test passes 3/3 isolated at the new master base.
- `wait_states-itest` hangs 9 cases at the 601s timeout (`AshCql`, the `kYCQL_*` group,
  `kBackfillIndex_*`, `kConsensusMeta_Flush`, `kCreatingNewTablet`,
  `kSaveRaftGroupMetadataToDisk`). Reproduced identically on plain master `c7253d204d`
  carrying none of this stack's code: 53 ran, the same 9 failed, same ~600.5s expiries.
  Tracked upstream in #33729.

Disposition change since the previous revision: the
`PgIndexBackfillBackendsManager.NoAbortTxn/1` flake cited earlier was fixed upstream. It
passes 3/3 at the new base and in all three full `pg_index_backfill-test` runs here, so it is
no longer carried as a known flake.


