### PR TITLE
[#33267] DocDB: lightweight exponential histogram class

### DIFF
--- a/src/yb/docdb/properties_collector/CMakeLists.txt
+++ b/src/yb/docdb/properties_collector/CMakeLists.txt
@@ -12,7 +12,26 @@
 #
 
 # DocDB-aware RocksDB table-properties collectors. Design: README.md in this directory.
-# The library (yb_docdb_properties_collector) is added by the stacked changes that bring its
-# sources; it sits below yb_docdb, depending only on dockv / common / util / rocksdb.
+# This library sits below yb_docdb (it depends only on dockv / common / util / rocksdb) so that
+# consumers such as the tablet can register collectors without pulling in docdb internals.
 
 set(YB_PCH_PATH ../)
+
+set(DOCDB_PROPERTIES_COLLECTOR_SRCS
+    exponential_histogram.cc
+    )
+
+set(DOCDB_PROPERTIES_COLLECTOR_DEPS
+    rocksdb
+    yb_common
+    yb_dockv
+    yb_util
+    )
+
+ADD_YB_LIBRARY(yb_docdb_properties_collector
+    SRCS ${DOCDB_PROPERTIES_COLLECTOR_SRCS}
+    DEPS ${DOCDB_PROPERTIES_COLLECTOR_DEPS})
+
+set(YB_TEST_LINK_LIBS yb_docdb_properties_collector ${YB_MIN_TEST_LIBS})
+
+ADD_YB_TEST(exponential_histogram-test)

--- a/src/yb/docdb/properties_collector/exponential_histogram-test.cc
+++ b/src/yb/docdb/properties_collector/exponential_histogram-test.cc
@@ -121,20 +121,23 @@ TEST_F(ExponentialHistogramTest, MergeIsBucketwiseAdd) {
 
 TEST_F(ExponentialHistogramTest, SerializeRoundTrip) {
   Hist hist;
-  EXPECT_EQ(hist.Serialize(), "s3;");
+  EXPECT_EQ(hist.Serialize(), "l3;");
   EXPECT_TRUE(hist.Empty());
   hist.Add(1, 12);
   hist.Add(18, 3);
   hist.Add(1u << 20, 1);
-  EXPECT_EQ(hist.Serialize(), "s3;0:12,17:3,144:1");
+  EXPECT_EQ(hist.Serialize(), "l3;0:12,17:3,144:1");
   const auto parsed = ASSERT_RESULT(Hist::Parse(hist.Serialize()));
   EXPECT_EQ(parsed, hist);
-  EXPECT_EQ(ASSERT_RESULT(Hist::Parse("s3;")), Hist());
+  EXPECT_EQ(ASSERT_RESULT(Hist::Parse("l3;")), Hist());
 
-  EXPECT_NOK(Hist::Parse("s2;0:1"));
-  EXPECT_NOK(Hist::Parse("s3;145:1"));
-  EXPECT_NOK(Hist::Parse("s3;0"));
-  EXPECT_NOK(Hist::Parse("s3;x:1"));
+  EXPECT_NOK(Hist::Parse("s3;0:1"));       // Wrong layout tag.
+  EXPECT_NOK(Hist::Parse("l3;145:1"));     // Index out of range.
+  EXPECT_NOK(Hist::Parse("l3;0"));         // No count.
+  EXPECT_NOK(Hist::Parse("l3;x:1"));       // Non-numeric index.
+  EXPECT_NOK(Hist::Parse("l3;0:-1"));      // Sign must not wrap to UINT64_MAX.
+  EXPECT_NOK(Hist::Parse("l3;0:1abc"));    // Trailing garbage.
+  EXPECT_NOK(Hist::Parse("l3;0:"));        // Empty count.
 }
 
 TEST_F(ExponentialHistogramTest, Quantile) {

--- a/src/yb/docdb/properties_collector/exponential_histogram-test.cc
+++ b/src/yb/docdb/properties_collector/exponential_histogram-test.cc
@@ -1,0 +1,155 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/docdb/properties_collector/exponential_histogram.h"
+
+#include <random>
+
+#include "yb/util/random_util.h"
+#include "yb/util/test_util.h"
+
+namespace yb::docdb {
+
+using Hist = ExponentialHistogram;
+
+class ExponentialHistogramTest : public YBTest {};
+
+TEST_F(ExponentialHistogramTest, SpotIndices) {
+  EXPECT_EQ(Hist::kNumBuckets, 145);
+  EXPECT_EQ(Hist::BucketIndex(0), 0);
+  EXPECT_EQ(Hist::BucketIndex(1), 0);
+  EXPECT_EQ(Hist::BucketIndex(2), 1);
+  EXPECT_EQ(Hist::BucketIndex(16), 15);
+  EXPECT_EQ(Hist::BucketIndex(17), 16);
+  EXPECT_EQ(Hist::BucketIndex(18), 17);
+  EXPECT_EQ(Hist::BucketIndex(19), 17);
+  EXPECT_EQ(Hist::BucketIndex(31), 23);
+  EXPECT_EQ(Hist::BucketIndex(32), 24);
+  EXPECT_EQ(Hist::BucketIndex(63), 31);
+  EXPECT_EQ(Hist::BucketIndex(64), 32);
+  // The incident row: bucket [73728, 81920), ~11% wide.
+  EXPECT_EQ(Hist::BucketIndex(80624), 113);
+  EXPECT_EQ(Hist::BucketLowerBound(113), 73728);
+  EXPECT_EQ(Hist::BucketUpperBound(113), 81920);
+  EXPECT_EQ(Hist::BucketIndex((1u << 20) - 1), 143);
+  EXPECT_EQ(Hist::BucketIndex(1u << 20), 144);
+  EXPECT_EQ(Hist::BucketIndex(std::numeric_limits<uint64_t>::max()), 144);
+}
+
+TEST_F(ExponentialHistogramTest, BoundsAreConsistentWithIndex) {
+  // Every bucket's bounds contain exactly the values that map to it.
+  for (size_t i = 0; i < Hist::kNumBuckets; ++i) {
+    const auto lower = Hist::BucketLowerBound(i);
+    ASSERT_EQ(Hist::BucketIndex(lower), i) << "bucket " << i << " lower " << lower;
+    if (i + 1 < Hist::kNumBuckets) {
+      const auto upper = Hist::BucketUpperBound(i);
+      ASSERT_GT(upper, lower) << "bucket " << i;
+      ASSERT_EQ(Hist::BucketIndex(upper - 1), i) << "bucket " << i << " upper " << upper;
+      ASSERT_EQ(Hist::BucketIndex(upper), i + 1) << "bucket " << i << " upper " << upper;
+    }
+  }
+  // Bucket edges are within 12.5% of each other above the exact region.
+  for (size_t i = Hist::kExactMax; i + 1 < Hist::kNumBuckets; ++i) {
+    const auto lower = Hist::BucketLowerBound(i);
+    const auto upper = Hist::BucketUpperBound(i);
+    ASSERT_LE(static_cast<double>(upper - lower) / static_cast<double>(lower), 0.125 + 1e-9)
+        << "bucket " << i;
+  }
+  // Exhaustive: every value from 1 to just past the ceiling lands within its bucket's bounds.
+  for (uint64_t v = 1; v <= (1u << 20) + 5; ++v) {
+    const auto i = Hist::BucketIndex(v);
+    ASSERT_LE(Hist::BucketLowerBound(i), v);
+    ASSERT_LT(v, Hist::BucketUpperBound(i));
+  }
+}
+
+TEST_F(ExponentialHistogramTest, DownscaleToPowersOfTwoIsExact) {
+  // Summing the 8 sub-buckets of a power-of-two range must equal a direct count of values in that
+  // range: the scale tag can be lowered without loss.
+  std::mt19937_64 rng(42);
+  std::vector<uint64_t> values;
+  Hist hist;
+  for (int i = 0; i < 100000; ++i) {
+    // Log-uniform over [1, 2^21) so every range gets samples.
+    const auto v = static_cast<uint64_t>(std::exp2(std::uniform_real_distribution<>(0, 21)(rng)));
+    values.push_back(v);
+    hist.Add(v);
+  }
+  for (int range_log2 = Hist::kMinRangeLog2; range_log2 < Hist::kCeilingLog2; ++range_log2) {
+    const uint64_t lo = 1ULL << range_log2;
+    const uint64_t hi = 1ULL << (range_log2 + 1);
+    uint64_t direct = 0;
+    for (auto v : values) {
+      // Value 16 sits in the exact region, not in the first split range.
+      if (v >= std::max<uint64_t>(lo, Hist::kExactMax + 1) && v < hi) {
+        ++direct;
+      }
+    }
+    uint64_t from_buckets = 0;
+    const size_t first = Hist::kExactMax + (range_log2 - Hist::kMinRangeLog2) * 8;
+    for (size_t i = first; i < first + 8; ++i) {
+      from_buckets += hist.bucket(i);
+    }
+    ASSERT_EQ(from_buckets, direct) << "range [" << lo << ", " << hi << ")";
+  }
+}
+
+TEST_F(ExponentialHistogramTest, MergeIsBucketwiseAdd) {
+  Hist a, b, both;
+  for (uint64_t v : {1, 1, 5, 17, 300, 80624}) {
+    a.Add(v);
+    both.Add(v);
+  }
+  for (uint64_t v : {2, 17, 17, 1 << 20}) {
+    b.Add(v, 3);
+    both.Add(v, 3);
+  }
+  a.Merge(b);
+  EXPECT_EQ(a, both);
+  EXPECT_EQ(a.TotalWeight(), 6 + 4 * 3);
+}
+
+TEST_F(ExponentialHistogramTest, SerializeRoundTrip) {
+  Hist hist;
+  EXPECT_EQ(hist.Serialize(), "s3;");
+  EXPECT_TRUE(hist.Empty());
+  hist.Add(1, 12);
+  hist.Add(18, 3);
+  hist.Add(1u << 20, 1);
+  EXPECT_EQ(hist.Serialize(), "s3;0:12,17:3,144:1");
+  const auto parsed = ASSERT_RESULT(Hist::Parse(hist.Serialize()));
+  EXPECT_EQ(parsed, hist);
+  EXPECT_EQ(ASSERT_RESULT(Hist::Parse("s3;")), Hist());
+
+  EXPECT_NOK(Hist::Parse("s2;0:1"));
+  EXPECT_NOK(Hist::Parse("s3;145:1"));
+  EXPECT_NOK(Hist::Parse("s3;0"));
+  EXPECT_NOK(Hist::Parse("s3;x:1"));
+}
+
+TEST_F(ExponentialHistogramTest, Quantile) {
+  Hist hist;
+  EXPECT_EQ(hist.QuantileLowerBound(0.5), 0);
+  for (uint64_t v = 1; v <= 100; ++v) {
+    hist.Add(v);
+  }
+  EXPECT_EQ(hist.QuantileLowerBound(0.0), 1);
+  EXPECT_EQ(hist.QuantileLowerBound(0.05), 5);
+  // p50 = 50 lies in bucket [48, 52).
+  EXPECT_EQ(hist.QuantileLowerBound(0.5), 48);
+  // p99 = 99 lies in bucket [96, 104).
+  EXPECT_EQ(hist.QuantileLowerBound(0.99), 96);
+  EXPECT_EQ(hist.QuantileLowerBound(1.0), 96);
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/exponential_histogram.cc
+++ b/src/yb/docdb/properties_collector/exponential_histogram.cc
@@ -19,6 +19,7 @@
 #include <limits>
 
 #include "yb/util/status_format.h"
+#include "yb/util/stol_utils.h"
 #include "yb/util/string_util.h"
 
 namespace yb::docdb {
@@ -104,7 +105,7 @@ uint64_t ExponentialHistogram::QuantileLowerBound(double q) const {
 }
 
 std::string ExponentialHistogram::Serialize() const {
-  std::string result = kScaleTag;
+  std::string result = kLayoutTag;
   bool first = true;
   for (size_t i = 0; i < kNumBuckets; ++i) {
     if (counts_[i] == 0) {
@@ -122,11 +123,11 @@ std::string ExponentialHistogram::Serialize() const {
 }
 
 Result<ExponentialHistogram> ExponentialHistogram::Parse(Slice serialized) {
-  if (!serialized.starts_with(kScaleTag)) {
+  if (!serialized.starts_with(kLayoutTag)) {
     return STATUS_FORMAT(
-        NotSupported, "Unsupported histogram scale tag in '$0'", serialized.ToDebugString());
+        NotSupported, "Unsupported histogram layout tag in '$0'", serialized.ToDebugString());
   }
-  serialized.remove_prefix(strlen(kScaleTag));
+  serialized.remove_prefix(strlen(kLayoutTag));
   ExponentialHistogram result;
   if (serialized.empty()) {
     return result;
@@ -136,14 +137,13 @@ Result<ExponentialHistogram> ExponentialHistogram::Parse(Slice serialized) {
     if (colon == std::string::npos) {
       return STATUS_FORMAT(Corruption, "Malformed histogram bucket '$0'", pair);
     }
-    size_t index = 0;
-    uint64_t count = 0;
-    try {
-      index = std::stoull(pair.substr(0, colon));
-      count = std::stoull(pair.substr(colon + 1));
-    } catch (const std::exception& e) {
-      return STATUS_FORMAT(Corruption, "Malformed histogram bucket '$0': $1", pair, e.what());
-    }
+    // CheckedStoull rejects signs, empty input and trailing garbage, unlike std::stoull.
+    const auto index = VERIFY_RESULT_PREPEND(
+        CheckedStoull(Slice(pair.data(), colon)),
+        Format("Malformed histogram bucket index in '$0'", pair));
+    const auto count = VERIFY_RESULT_PREPEND(
+        CheckedStoull(Slice(pair.data() + colon + 1, pair.size() - colon - 1)),
+        Format("Malformed histogram bucket count in '$0'", pair));
     if (index >= kNumBuckets) {
       return STATUS_FORMAT(Corruption, "Histogram bucket index out of range: $0", index);
     }

--- a/src/yb/docdb/properties_collector/exponential_histogram.cc
+++ b/src/yb/docdb/properties_collector/exponential_histogram.cc
@@ -1,0 +1,155 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/docdb/properties_collector/exponential_histogram.h"
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <limits>
+
+#include "yb/util/status_format.h"
+#include "yb/util/string_util.h"
+
+namespace yb::docdb {
+
+size_t ExponentialHistogram::BucketIndex(uint64_t value) {
+  if (value <= kExactMax) {
+    return value == 0 ? 0 : value - 1;
+  }
+  if (value >= (1ULL << kCeilingLog2)) {
+    return kNumBuckets - 1;
+  }
+  // Which power-of-two range: floor(log2(value)), i.e. the position of the top bit.
+  const int range_log2 = std::bit_width(value) - 1;
+  // Which of the 8 equal sub-buckets: the 3 bits below the top bit.
+  const uint64_t sub_bucket = (value >> (range_log2 - kScale)) - (1ULL << kScale);
+  return kExactMax + ((range_log2 - kMinRangeLog2) << kScale) + sub_bucket;
+}
+
+uint64_t ExponentialHistogram::BucketLowerBound(size_t index) {
+  if (index < kExactMax) {
+    return index + 1;
+  }
+  if (index >= kNumBuckets - 1) {
+    return 1ULL << kCeilingLog2;
+  }
+  const size_t k = index - kExactMax;
+  const int range_log2 = kMinRangeLog2 + static_cast<int>(k >> kScale);
+  const uint64_t sub_bucket = k & (kSubBucketsPerRange - 1);
+  const uint64_t lower = (1ULL << range_log2) + (sub_bucket << (range_log2 - kScale));
+  // The first split sub-bucket nominally starts at 16, but 16 itself belongs to the exact region.
+  return std::max<uint64_t>(lower, kExactMax + 1);
+}
+
+uint64_t ExponentialHistogram::BucketUpperBound(size_t index) {
+  if (index >= kNumBuckets - 1) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return BucketLowerBound(index + 1);
+}
+
+void ExponentialHistogram::Add(uint64_t value, uint64_t weight) {
+  counts_[BucketIndex(value)] += weight;
+}
+
+void ExponentialHistogram::Merge(const ExponentialHistogram& other) {
+  for (size_t i = 0; i < kNumBuckets; ++i) {
+    counts_[i] += other.counts_[i];
+  }
+}
+
+uint64_t ExponentialHistogram::TotalWeight() const {
+  uint64_t total = 0;
+  for (auto count : counts_) {
+    total += count;
+  }
+  return total;
+}
+
+bool ExponentialHistogram::Empty() const {
+  for (auto count : counts_) {
+    if (count != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+uint64_t ExponentialHistogram::QuantileLowerBound(double q) const {
+  const auto total = TotalWeight();
+  if (total == 0) {
+    return 0;
+  }
+  q = std::clamp(q, 0.0, 1.0);
+  const auto target = static_cast<uint64_t>(std::ceil(q * static_cast<double>(total)));
+  uint64_t cumulative = 0;
+  for (size_t i = 0; i < kNumBuckets; ++i) {
+    cumulative += counts_[i];
+    if (cumulative >= target && cumulative > 0) {
+      return BucketLowerBound(i);
+    }
+  }
+  return BucketLowerBound(kNumBuckets - 1);
+}
+
+std::string ExponentialHistogram::Serialize() const {
+  std::string result = kScaleTag;
+  bool first = true;
+  for (size_t i = 0; i < kNumBuckets; ++i) {
+    if (counts_[i] == 0) {
+      continue;
+    }
+    if (!first) {
+      result += ',';
+    }
+    first = false;
+    result += std::to_string(i);
+    result += ':';
+    result += std::to_string(counts_[i]);
+  }
+  return result;
+}
+
+Result<ExponentialHistogram> ExponentialHistogram::Parse(Slice serialized) {
+  if (!serialized.starts_with(kScaleTag)) {
+    return STATUS_FORMAT(
+        NotSupported, "Unsupported histogram scale tag in '$0'", serialized.ToDebugString());
+  }
+  serialized.remove_prefix(strlen(kScaleTag));
+  ExponentialHistogram result;
+  if (serialized.empty()) {
+    return result;
+  }
+  for (const auto& pair : StringSplit(serialized.ToBuffer(), ',')) {
+    const auto colon = pair.find(':');
+    if (colon == std::string::npos) {
+      return STATUS_FORMAT(Corruption, "Malformed histogram bucket '$0'", pair);
+    }
+    size_t index = 0;
+    uint64_t count = 0;
+    try {
+      index = std::stoull(pair.substr(0, colon));
+      count = std::stoull(pair.substr(colon + 1));
+    } catch (const std::exception& e) {
+      return STATUS_FORMAT(Corruption, "Malformed histogram bucket '$0': $1", pair, e.what());
+    }
+    if (index >= kNumBuckets) {
+      return STATUS_FORMAT(Corruption, "Histogram bucket index out of range: $0", index);
+    }
+    result.counts_[index] += count;
+  }
+  return result;
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/exponential_histogram.h
+++ b/src/yb/docdb/properties_collector/exponential_histogram.h
@@ -1,0 +1,78 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include "yb/util/result.h"
+#include "yb/util/slice.h"
+
+namespace yb::docdb {
+
+// A fixed-layout histogram of positive integers (chain lengths, stretch lengths, byte counts) for
+// SST properties. See properties_collector/README.md, "Histogram layout", for the design.
+//
+// Layout (scale 3 of the base-2 exponential family, base 2^(1/8) ~ 1.09):
+//   buckets 0..15    values 1..16, one bucket per value (exact);
+//   buckets 16..143  values 17..2^20-1, 8 equal-width sub-buckets per power-of-two range
+//                    (the HdrHistogram layout);
+//   bucket 144       values >= 2^20 (overflow).
+// Bucket edges are within 12.5% of each other, so a quantile read from bucket bounds is within
+// 12.5% of the true value. Merging two histograms is bucket-wise addition, exact at any rollup.
+//
+// Bucket index = one bit-scan plus a shift and a mask; no floating point. Plain counters, no
+// atomics: a histogram is owned by exactly one SST build.
+class ExponentialHistogram {
+ public:
+  static constexpr int kScale = 3;
+  static constexpr int kSubBucketsPerRange = 1 << kScale;
+  static constexpr uint64_t kExactMax = 16;
+  static constexpr int kMinRangeLog2 = 4;   // The first split power-of-two range is [16, 32).
+  static constexpr int kCeilingLog2 = 20;   // Values >= 2^20 share the overflow bucket.
+  static constexpr size_t kNumBuckets =
+      kExactMax + (kCeilingLog2 - kMinRangeLog2) * kSubBucketsPerRange + 1;  // 145
+
+  // Serialized form: the scale tag followed by sparse "index:count" pairs, e.g. "s3;0:12,17:3".
+  static constexpr char kScaleTag[] = "s3;";
+
+  // Bucket for a value. Values >= 1; 0 is folded into bucket 0.
+  static size_t BucketIndex(uint64_t value);
+  // Inclusive lower bound of a bucket's value range.
+  static uint64_t BucketLowerBound(size_t index);
+  // Exclusive upper bound of a bucket's value range; UINT64_MAX for the overflow bucket.
+  static uint64_t BucketUpperBound(size_t index);
+
+  void Add(uint64_t value, uint64_t weight = 1);
+  void Merge(const ExponentialHistogram& other);
+
+  uint64_t bucket(size_t index) const { return counts_[index]; }
+  uint64_t TotalWeight() const;
+  bool Empty() const;
+
+  // Lower bound of the bucket in which the cumulative weight first reaches quantile q in [0, 1].
+  // Returns 0 for an empty histogram.
+  uint64_t QuantileLowerBound(double q) const;
+
+  std::string Serialize() const;
+  static Result<ExponentialHistogram> Parse(Slice serialized);
+
+  bool operator==(const ExponentialHistogram& other) const { return counts_ == other.counts_; }
+
+ private:
+  std::array<uint64_t, kNumBuckets> counts_{};
+};
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/exponential_histogram.h
+++ b/src/yb/docdb/properties_collector/exponential_histogram.h
@@ -25,19 +25,22 @@ namespace yb::docdb {
 // A fixed-layout histogram of positive integers (chain lengths, stretch lengths, byte counts) for
 // SST properties. See properties_collector/README.md, "Histogram layout", for the design.
 //
-// Layout (scale 3 of the base-2 exponential family, base 2^(1/8) ~ 1.09):
+// The layout is HdrHistogram's LOG-LINEAR one -- the same bucket count as the base-2 exponential
+// family at scale 3, but with boundaries linear within each power-of-two range (NOT the geometric
+// 2^(k/8) edges of the OTel / Prometheus-native convention):
 //   buckets 0..15    values 1..16, one bucket per value (exact);
-//   buckets 16..143  values 17..2^20-1, 8 equal-width sub-buckets per power-of-two range
-//                    (the HdrHistogram layout);
+//   buckets 16..143  values 17..2^20-1, 8 equal-width sub-buckets per power-of-two range;
 //   bucket 144       values >= 2^20 (overflow).
-// Bucket edges are within 12.5% of each other, so a quantile read from bucket bounds is within
-// 12.5% of the true value. Merging two histograms is bucket-wise addition, exact at any rollup.
+// Below the overflow bucket, edges are within 12.5% of each other, so a quantile read from bucket
+// bounds is within 12.5% of the true value; a quantile landing in the overflow bucket reads as
+// 2^20 with unbounded error. Merging two histograms is bucket-wise addition, exact at any rollup;
+// coarsening within the linear family (halving the sub-bucket count) is exact too.
 //
 // Bucket index = one bit-scan plus a shift and a mask; no floating point. Plain counters, no
 // atomics: a histogram is owned by exactly one SST build.
 class ExponentialHistogram {
  public:
-  static constexpr int kScale = 3;
+  static constexpr int kScale = 3;  // 3 mantissa bits -> 8 linear sub-buckets per range.
   static constexpr int kSubBucketsPerRange = 1 << kScale;
   static constexpr uint64_t kExactMax = 16;
   static constexpr int kMinRangeLog2 = 4;   // The first split power-of-two range is [16, 32).
@@ -45,8 +48,10 @@ class ExponentialHistogram {
   static constexpr size_t kNumBuckets =
       kExactMax + (kCeilingLog2 - kMinRangeLog2) * kSubBucketsPerRange + 1;  // 145
 
-  // Serialized form: the scale tag followed by sparse "index:count" pairs, e.g. "s3;0:12,17:3".
-  static constexpr char kScaleTag[] = "s3;";
+  // Serialized form: the layout tag followed by sparse "index:count" pairs, e.g. "l3;0:12,17:3".
+  // "l3" = log-linear with 3 mantissa bits; deliberately not "s3", which would wrongly claim the
+  // geometric scale-3 boundary convention.
+  static constexpr char kLayoutTag[] = "l3;";
 
   // Bucket for a value. Values >= 1; 0 is folded into bucket 0.
   static size_t BucketIndex(uint64_t value);
@@ -63,7 +68,8 @@ class ExponentialHistogram {
   bool Empty() const;
 
   // Lower bound of the bucket in which the cumulative weight first reaches quantile q in [0, 1].
-  // Returns 0 for an empty histogram.
+  // Returns 0 for an empty histogram; a quantile in the overflow bucket returns 2^20 regardless of
+  // the true magnitude.
   uint64_t QuantileLowerBound(double q) const;
 
   std::string Serialize() const;


### PR DESCRIPTION

Summary:
A fixed-layout, single-threaded histogram of positive integers for SST
properties: 145 buckets at scale 3 of the base-2 exponential family (the
Prometheus-native-histogram / OpenTelemetry convention, base 2^(1/8)).
Values 1..16 get one bucket each; then 8 equal sub-buckets per power-of-two
range up to 2^20 (HdrHistogram's layout); then one overflow bucket. Bucket
edges are within 12.5% of each other, so quantiles read from bucket bounds
are within 12.5%.

The index is one bit-scan plus a shift and a mask, no floating point.
Merging is bucket-wise addition, exact at every rollup; coarsening to a
lower scale sums runs of adjacent buckets, also exact, which the serialized
scale tag ("s3;" + sparse index:count pairs) keeps possible across a mixed
fleet. Plain counters, no atomics: an instance is owned by one SST build.

Why not reuse an existing class: yb::HdrHistogram is built for concurrent
latency recording (five lock-prefixed RMWs plus two CAS loops per Add) and
lacks merge and bucket export; rocksdb::HistogramImpl merges, but its
bucket table is one process-global constant shared by every RocksDB latency
histogram, and each Add walks a std::map.

First consumer: the SST statistics collector stacked on top of this change
(chain-length and stretch distributions per SST file).

Test Plan:
./yb_build.sh release --cxx-test exponential_histogram-test

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
