### PR TITLE
[#33267] DocDB: SST statistics collector -- properties block and registration

### DIFF
--- a/src/yb/docdb/CMakeLists.txt
+++ b/src/yb/docdb/CMakeLists.txt
@@ -118,6 +118,7 @@ set(DOCDB_DEPS
         PUBLIC vector_index
         PUBLIC yb_ash
         PUBLIC yb_common
+        PUBLIC yb_docdb_properties_collector
         PUBLIC yb_docdb_shared
         PUBLIC yb_dockv
         PUBLIC yb_pggate

--- a/src/yb/docdb/properties_collector/CMakeLists.txt
+++ b/src/yb/docdb/properties_collector/CMakeLists.txt
@@ -18,7 +18,9 @@
 set(YB_PCH_PATH ../)
 
 set(DOCDB_PROPERTIES_COLLECTOR_SRCS
+    chain_tracker.cc
     exponential_histogram.cc
+    sst_stats_collector.cc
     )
 
 set(DOCDB_PROPERTIES_COLLECTOR_DEPS
@@ -35,3 +37,4 @@ ADD_YB_LIBRARY(yb_docdb_properties_collector
 set(YB_TEST_LINK_LIBS yb_docdb_properties_collector ${YB_MIN_TEST_LIBS})
 
 ADD_YB_TEST(exponential_histogram-test)
+ADD_YB_TEST(sst_stats_collector-test)

--- a/src/yb/docdb/properties_collector/chain_tracker.cc
+++ b/src/yb/docdb/properties_collector/chain_tracker.cc
@@ -1,0 +1,304 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/docdb/properties_collector/chain_tracker.h"
+
+#include <algorithm>
+
+#include "yb/dockv/doc_key.h"
+#include "yb/dockv/value.h"
+#include "yb/dockv/value_type.h"
+
+#include "yb/gutil/strings/fastmem.h"
+
+#include "yb/util/status_format.h"
+
+namespace yb::docdb {
+
+size_t AgeBands::BandIndex(int64_t age_micros) {
+  size_t band = 0;
+  while (band < kEdgesMicros.size() && age_micros >= kEdgesMicros[band]) {
+    ++band;
+  }
+  return band;
+}
+
+ChainTracker::ChainTracker(int64_t anchor_micros, bool track_coprefix_subtotals)
+    : track_coprefix_subtotals_(track_coprefix_subtotals) {
+  stats_.anchor_micros = anchor_micros;
+}
+
+// Per entry:
+//   1. Classify the value: skip the control-fields prefix, then one byte says tombstone / packed
+//      row / other. Values that do not follow the DocDB encoding count in total_entries only.
+//   2. Meta records are counted in meta_entries, close the open row and stretch, and are otherwise
+//      ignored; the identities are stated over chain_entries for this reason.
+//   3. Strip the hybrid time to get the subdoc key; track the encoded-HT extremes.
+//   4. Compare with the previous subdoc key by shared-prefix length:
+//        identical              -> a shadowed version; its overwriter is the previous entry.
+//        shares the row key     -> a new subdoc chain in the same row; reclaimable iff row is dead.
+//        otherwise              -> a new row: close the previous one, compute the row key length
+//                                  once, decide whether the row is dead (head is a tombstone whose
+//                                  subdoc key is exactly the row key).
+//   5. A reclaimable entry extends the current stretch and lands in the age band of what makes it
+//      droppable; a non-reclaimable entry closes the stretch.
+void ChainTracker::Add(Slice key, Slice value) {
+  ++stats_.total_entries;
+  const size_t entry_bytes = key.size() + value.size();
+
+  // Value kind. A DocDB delete is a Put whose payload is a kTombstone marker, optionally preceded
+  // by control fields (merge flags, intent doc hybrid time, TTL, user timestamp).
+  bool is_tombstone = false;
+  {
+    Slice value_slice = value;
+    Slice intent_doc_ht;
+    const auto control_fields =
+        dockv::ValueControlFields::DecodeWithIntentDocHt(&value_slice, &intent_doc_ht);
+    if (control_fields.ok()) {
+      const auto value_type = dockv::DecodeValueEntryType(value_slice);
+      if (value_type == dockv::ValueEntryType::kTombstone) {
+        is_tombstone = true;
+        ++stats_.tombstone_entries;
+      } else if (dockv::IsPackedRow(value_type)) {
+        ++stats_.packed_row_entries;
+      }
+    }
+    // Records that do not follow the DocDB value encoding are counted in total_entries only.
+  }
+
+  // Meta records (transaction apply state, vector index metadata) are not part of any chain.
+  if (key.empty() || dockv::IsRegularDBMetaKeyType(dockv::DecodeKeyEntryType(key)) ||
+      dockv::DecodeKeyEntryType(key) == dockv::KeyEntryType::kObsoleteIntentPrefix) {
+    OnMetaEntry();
+    return;
+  }
+  if (!stats_.chain_valid) {
+    return;
+  }
+
+  ++stats_.chain_entries;
+  stats_.chain_bytes += entry_bytes;
+
+  // Strip the hybrid time: its size is in the low bits of the last byte, and it is preceded by a
+  // kHybridTime marker byte.
+  const auto ht_size = DocHybridTime::GetEncodedSize(key);
+  if (!ht_size.ok() || key.size() < *ht_size + 2) {
+    Invalidate();
+    return;
+  }
+  const size_t subdoc_key_end = key.size() - *ht_size - 1;
+  const Slice subdoc_key(key.data(), subdoc_key_end);
+  EncodedDocHybridTime encoded_ht(key.Suffix(*ht_size));
+  UpdateWriteHtRange(encoded_ht);
+
+  // Chain boundary detection: the length of the prefix shared with the previous subdoc key.
+  const size_t compare_len = std::min(subdoc_key_end, prev_key_.size());
+  const size_t shared_prefix =
+      has_prev_ ? strings::MemoryDifferencePos(key.data(), prev_key_.data(), compare_len) : 0;
+
+  bool reclaimable = false;
+  int64_t droppable_by_micros = 0;
+  if (has_prev_ && subdoc_key_end == prev_key_.size() && shared_prefix >= subdoc_key_end) {
+    // Same subdoc key as the previous (newer) entry: this version is shadowed. It becomes droppable
+    // once the entry that shadows it is past the history cutoff.
+    ++row_entries_;
+    row_bytes_ += entry_bytes;
+    reclaimable = true;
+    const auto overwriter_micros = PhysicalMicros(prev_entry_ht_);
+    if (!overwriter_micros.ok()) {
+      Invalidate();
+      return;
+    }
+    droppable_by_micros = *overwriter_micros;
+  } else if (has_prev_ && shared_prefix >= row_end_) {
+    // Same row, new subdoc key: a live head (of a column or record) in this row.
+    ++stats_.num_subdoc_keys;
+    ++row_entries_;
+    row_bytes_ += entry_bytes;
+    if (row_dead_) {
+      // Under a row tombstone every entry goes when the tombstone does.
+      reclaimable = true;
+      droppable_by_micros = row_tombstone_micros_;
+    }
+  } else {
+    // New row.
+    CloseRow();
+    const auto ends = ComputeRowKeyEnds(subdoc_key);
+    if (!ends.ok()) {
+      Invalidate();
+      return;
+    }
+    row_end_ = ends->row_end;
+    ++stats_.num_rows;
+    ++stats_.num_subdoc_keys;
+    row_entries_ = 1;
+    row_bytes_ = entry_bytes;
+    // A dead row: its chain head is a row-level (or table-level) tombstone.
+    row_dead_ = subdoc_key_end == row_end_ && is_tombstone;
+    if (row_dead_) {
+      const auto tombstone_micros = PhysicalMicros(encoded_ht);
+      if (!tombstone_micros.ok()) {
+        Invalidate();
+        return;
+      }
+      row_tombstone_micros_ = *tombstone_micros;
+      reclaimable = true;
+      droppable_by_micros = row_tombstone_micros_;
+    }
+    if (track_coprefix_subtotals_) {
+      row_subtotal_ =
+          &stats_.coprefix_subtotals[std::string(subdoc_key.cdata(), ends->coprefix_end)];
+      ++row_subtotal_->rows;
+    }
+  }
+
+  if (reclaimable) {
+    AddReclaimable(entry_bytes, droppable_by_micros);
+  } else {
+    CloseStretch();
+  }
+  if (row_subtotal_ != nullptr) {
+    ++row_subtotal_->entries;
+    row_subtotal_->tombstone_entries += is_tombstone ? 1 : 0;
+    row_subtotal_->reclaimable_entries += reclaimable ? 1 : 0;
+  }
+
+  AssignPrevKey(subdoc_key, shared_prefix);
+  prev_entry_ht_ = encoded_ht;
+  has_prev_ = true;
+}
+
+const SstStats& ChainTracker::Finish() {
+  if (!finished_) {
+    CloseRow();
+    CloseStretch();
+    if (!min_encoded_ht_.empty()) {
+      auto min_ht = min_encoded_ht_.Decode();
+      auto max_ht = max_encoded_ht_.Decode();
+      if (min_ht.ok() && max_ht.ok()) {
+        stats_.min_write_ht = min_ht->hybrid_time();
+        stats_.max_write_ht = max_ht->hybrid_time();
+      } else {
+        Invalidate();
+      }
+    }
+    finished_ = true;
+  }
+  return stats_;
+}
+
+void ChainTracker::OnMetaEntry() {
+  ++stats_.meta_entries;
+  // A meta record separates chains and stretches but belongs to neither.
+  CloseRow();
+  CloseStretch();
+  has_prev_ = false;
+  row_subtotal_ = nullptr;
+}
+
+void ChainTracker::CloseRow() {
+  // Explicit no-op when no row is open (first entry, consecutive meta records, empty file), so the
+  // histograms never acquire phantom rows.
+  if (row_entries_ == 0) {
+    return;
+  }
+  stats_.row_chain_hist.Add(row_entries_);
+  stats_.row_chain_bytes_hist.Add(row_bytes_);
+  stats_.max_row_chain = std::max(stats_.max_row_chain, row_entries_);
+  if (row_dead_) {
+    ++stats_.dead_rows;
+    stats_.dead_row_entries += row_entries_;
+  }
+  row_entries_ = 0;
+  row_bytes_ = 0;
+  row_dead_ = false;
+}
+
+void ChainTracker::CloseStretch() {
+  if (stretch_entries_ == 0) {
+    return;
+  }
+  stats_.stretch_hist.Add(stretch_entries_);
+  stats_.stretch_entries_hist.Add(stretch_entries_, stretch_entries_);
+  stats_.stretch_bytes_hist.Add(stretch_entries_, stretch_bytes_);
+  stats_.max_stretch = std::max(stats_.max_stretch, stretch_entries_);
+  stretch_entries_ = 0;
+  stretch_bytes_ = 0;
+}
+
+void ChainTracker::Invalidate() {
+  stats_.chain_valid = false;
+  has_prev_ = false;
+  row_entries_ = 0;
+  row_bytes_ = 0;
+  row_dead_ = false;
+  stretch_entries_ = 0;
+  stretch_bytes_ = 0;
+  row_subtotal_ = nullptr;
+}
+
+void ChainTracker::AssignPrevKey(Slice subdoc_key, size_t shared_prefix) {
+  // Only the suffix past the shared prefix changed; copy just that.
+  const size_t keep = std::min(shared_prefix, prev_key_.size());
+  prev_key_.resize(subdoc_key.size());
+  if (subdoc_key.size() > keep) {
+    memcpy(prev_key_.data() + keep, subdoc_key.data() + keep, subdoc_key.size() - keep);
+  }
+}
+
+void ChainTracker::AddReclaimable(size_t entry_bytes, int64_t droppable_by_micros) {
+  ++stats_.reclaimable_entries;
+  stats_.reclaimable_bytes += entry_bytes;
+  const size_t band = AgeBands::BandIndex(stats_.anchor_micros - droppable_by_micros);
+  ++stats_.droppable_age_entries[band];
+  stats_.droppable_age_bytes[band] += entry_bytes;
+  ++stretch_entries_;
+  stretch_bytes_ += entry_bytes;
+}
+
+void ChainTracker::UpdateWriteHtRange(const EncodedDocHybridTime& encoded_ht) {
+  // EncodedDocHybridTime orders by the time it encodes (the byte order is reversed internally).
+  if (min_encoded_ht_.empty() || encoded_ht < min_encoded_ht_) {
+    min_encoded_ht_ = encoded_ht;
+  }
+  if (max_encoded_ht_.empty() || encoded_ht > max_encoded_ht_) {
+    max_encoded_ht_ = encoded_ht;
+  }
+}
+
+Result<int64_t> ChainTracker::PhysicalMicros(const EncodedDocHybridTime& encoded_ht) {
+  const auto doc_ht = VERIFY_RESULT(encoded_ht.Decode());
+  return static_cast<int64_t>(doc_ht.hybrid_time().GetPhysicalValueMicros());
+}
+
+Result<ChainTracker::RowKeyEnds> ChainTracker::ComputeRowKeyEnds(Slice subdoc_key) {
+  // Mirrors the first call of SubDocKey::DecodeDocKeyAndSubKeyEnds, including the table-tombstone
+  // form (cotable/colocation id followed directly by kGroupEnd: an empty DocKey).
+  const auto id_size =
+      VERIFY_RESULT(dockv::DocKey::EncodedSize(subdoc_key, dockv::DocKeyPart::kUpToId));
+  SCHECK_GT(subdoc_key.size(), id_size, Corruption,
+            Format("Cannot have exclusively ID in key $0", subdoc_key.ToDebugHexString()));
+  const char first = subdoc_key[0];
+  if ((first == dockv::KeyEntryTypeAsChar::kColocationId ||
+       first == dockv::KeyEntryTypeAsChar::kTableId) &&
+      subdoc_key[id_size] == dockv::KeyEntryTypeAsChar::kGroupEnd) {
+    // Table tombstone: the row key is the coprefix plus the group end, so that the tombstone entry
+    // itself is the head of its own (dead) row.
+    return RowKeyEnds{.coprefix_end = id_size, .row_end = id_size + 1};
+  }
+  const auto doc_key_size = VERIFY_RESULT(dockv::DocKey::EncodedSize(
+      subdoc_key.WithoutPrefix(id_size), dockv::DocKeyPart::kWholeDocKey));
+  return RowKeyEnds{.coprefix_end = id_size, .row_end = id_size + doc_key_size};
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/chain_tracker.h
+++ b/src/yb/docdb/properties_collector/chain_tracker.h
@@ -1,0 +1,183 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "yb/common/doc_hybrid_time.h"
+#include "yb/common/hybrid_time.h"
+
+#include "yb/docdb/properties_collector/exponential_histogram.h"
+
+#include "yb/util/slice.h"
+
+namespace yb::docdb {
+
+// Fixed age bands for "how old is the entry that made this garbage droppable". A consumer sums the
+// bands that are wholly older than the history cutoff it is applying. The 15 m edge brackets the
+// default history retention (timestamp_history_retention_interval_sec = 900).
+struct AgeBands {
+  static constexpr size_t kNumBands = 8;
+  // Upper edges of bands 0..6, in microseconds: 5 m, 15 m, 1 h, 6 h, 24 h, 7 d, 30 d.
+  // Band 7 is everything older.
+  static constexpr std::array<int64_t, kNumBands - 1> kEdgesMicros = {
+      5LL * 60 * 1000000,
+      15LL * 60 * 1000000,
+      60LL * 60 * 1000000,
+      6LL * 60 * 60 * 1000000,
+      24LL * 60 * 60 * 1000000,
+      7LL * 24 * 60 * 60 * 1000000,
+      30LL * 24 * 60 * 60 * 1000000,
+  };
+
+  // Band for an age; negative ages (clock skew) land in band 0.
+  static size_t BandIndex(int64_t age_micros);
+};
+
+using AgeBandCounts = std::array<uint64_t, AgeBands::kNumBands>;
+
+// Per-coprefix (cotable / colocation id) subtotals for colocated tablets.
+struct CoprefixSubtotal {
+  uint64_t entries = 0;
+  uint64_t tombstone_entries = 0;
+  uint64_t reclaimable_entries = 0;
+  uint64_t rows = 0;
+};
+
+// Everything the collector records for one SST file. Definitions in
+// properties_collector/README.md, "Vocabulary".
+struct SstStats {
+  // Every entry handed to the collector, including meta records and entries that failed to parse.
+  uint64_t total_entries = 0;
+  uint64_t tombstone_entries = 0;
+  uint64_t packed_row_entries = 0;
+  // Regular-DB meta records (transaction apply state, vector index metadata). Not chain-tracked.
+  uint64_t meta_entries = 0;
+
+  // The chain-tracked population. The identities below hold over these, not over total_entries.
+  uint64_t chain_entries = 0;     // Ec
+  uint64_t chain_bytes = 0;       // raw key + value bytes of chain-tracked entries
+  uint64_t num_subdoc_keys = 0;   // K: distinct subdocument keys = number of subdoc chains
+  uint64_t num_rows = 0;          // R: distinct rows = number of row chains
+
+  // Rows whose chain head is a row-level (or table-level) tombstone, and all their entries.
+  uint64_t dead_rows = 0;
+  uint64_t dead_row_entries = 0;
+
+  // All the garbage: shadowed entries of live rows + every entry of dead rows, counted once at scan
+  // time (the two sets are disjoint by construction, so there is no double counting).
+  uint64_t reclaimable_entries = 0;
+  uint64_t reclaimable_bytes = 0;
+
+  uint64_t max_row_chain = 0;
+  uint64_t max_stretch = 0;
+
+  // False once a key failed to parse; the chain statistics are then partial and must not be used
+  // for the identities. The v1 counters (total/tombstone) stay valid.
+  bool chain_valid = true;
+
+  // Exact write-time range of chain-tracked entries (invalid when there are none).
+  HybridTime min_write_ht = HybridTime::kInvalid;
+  HybridTime max_write_ht = HybridTime::kInvalid;
+  // Wall-clock reference the age bands are measured against (taken at collector construction).
+  int64_t anchor_micros = 0;
+
+  // Row-chain length distribution, by row count and by bytes.
+  ExponentialHistogram row_chain_hist;
+  ExponentialHistogram row_chain_bytes_hist;
+  // Stretch distribution: maximal runs of consecutive reclaimable entries in file order, ignoring
+  // key boundaries. By stretch count, by entries contained, by bytes contained.
+  ExponentialHistogram stretch_hist;
+  ExponentialHistogram stretch_entries_hist;
+  ExponentialHistogram stretch_bytes_hist;
+
+  // Reclaimable entries and bytes by the age of what makes them droppable: for a shadowed entry the
+  // entry that shadows it, for a dead-row entry the row tombstone.
+  AgeBandCounts droppable_age_entries{};
+  AgeBandCounts droppable_age_bytes{};
+
+  // Only populated when subtotals are enabled; key = raw coprefix bytes ("" for a plain table).
+  std::map<std::string, CoprefixSubtotal> coprefix_subtotals;
+
+  // Derived identities (meaningful only while chain_valid).
+  uint64_t shadowed_entries() const { return chain_entries - num_subdoc_keys; }
+  uint64_t repackable_entries() const { return num_subdoc_keys - num_rows; }
+  uint64_t collapsible_entries() const { return chain_entries - num_rows; }
+};
+
+// Walks the entries of one SST in build order and derives SstStats in a single pass. Because the
+// file is sorted and versions of a key are adjacent (newest first), the tracker never looks
+// anything up: it compares each key with the previous one. No allocation in steady state.
+//
+// Usage: Add() once per entry, then Finish(). Add() never fails; a key that cannot be parsed
+// invalidates the chain statistics (chain_valid = false) and the tracker keeps counting the v1
+// scalars.
+class ChainTracker {
+ public:
+  ChainTracker(int64_t anchor_micros, bool track_coprefix_subtotals);
+
+  void Add(Slice key, Slice value);
+
+  // Closes the open row and stretch and returns the statistics. Idempotent.
+  const SstStats& Finish();
+
+  const SstStats& stats() const { return stats_; }
+
+ private:
+  void OnMetaEntry();
+  void CloseRow();
+  void CloseStretch();
+  void Invalidate();
+  void AssignPrevKey(Slice subdoc_key, size_t shared_prefix);
+  void AddReclaimable(size_t entry_bytes, int64_t droppable_by_micros);
+  void UpdateWriteHtRange(const EncodedDocHybridTime& encoded_ht);
+  Result<int64_t> PhysicalMicros(const EncodedDocHybridTime& encoded_ht);
+
+  // Length of the row key prefix of a subdocument key (hybrid time already stripped), and of its
+  // coprefix (cotable / colocation id, possibly empty).
+  struct RowKeyEnds {
+    size_t coprefix_end;
+    size_t row_end;
+  };
+  static Result<RowKeyEnds> ComputeRowKeyEnds(Slice subdoc_key);
+
+  SstStats stats_;
+  const bool track_coprefix_subtotals_;
+  bool finished_ = false;
+
+  // Previous chain-tracked entry.
+  bool has_prev_ = false;
+  std::vector<char> prev_key_;              // subdoc key without hybrid time
+  EncodedDocHybridTime prev_entry_ht_;
+  EncodedDocHybridTime min_encoded_ht_;     // lexicographic extremes of the encoded form
+  EncodedDocHybridTime max_encoded_ht_;
+
+  // Current row.
+  size_t row_end_ = 0;
+  uint64_t row_entries_ = 0;
+  uint64_t row_bytes_ = 0;
+  bool row_dead_ = false;
+  int64_t row_tombstone_micros_ = 0;        // valid when row_dead_
+  CoprefixSubtotal* row_subtotal_ = nullptr;
+
+  // Current stretch of consecutive reclaimable entries.
+  uint64_t stretch_entries_ = 0;
+  uint64_t stretch_bytes_ = 0;
+};
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/sst_stats_collector-test.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_collector-test.cc
@@ -1,0 +1,445 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/docdb/properties_collector/sst_stats_collector.h"
+
+#include "yb/common/column_id.h"
+
+#include "yb/dockv/doc_key.h"
+#include "yb/dockv/value_type.h"
+
+#include "yb/util/flags.h"
+#include "yb/util/test_util.h"
+
+DECLARE_bool(docdb_sst_stats_coprefix_subtotals);
+DECLARE_uint32(sst_tombstone_mark_ratio_percent);
+DECLARE_uint64(sst_tombstone_mark_min_count);
+
+namespace yb::docdb {
+
+namespace {
+
+// A fixed wall-clock reference for the age bands: 2023-11-14T22:13:20Z.
+constexpr int64_t kAnchorMicros = 1700000000LL * 1000000;
+constexpr int64_t kMinute = 60LL * 1000000;
+constexpr int64_t kHour = 60 * kMinute;
+constexpr int64_t kDay = 24 * kHour;
+
+// An entry as the collector sees it: the RocksDB user key (subdoc key + hybrid time) and value.
+struct Entry {
+  std::string key;
+  std::string value;
+};
+
+HybridTime AgeToHt(int64_t age_micros) {
+  return HybridTime::FromMicros(kAnchorMicros - age_micros);
+}
+
+dockv::DocKey Row(int32_t id) {
+  return dockv::DocKey(
+      /* hash = */ 1000 + id, dockv::MakeKeyEntryValues("h"),
+      dockv::MakeKeyEntryValues(id));
+}
+
+dockv::DocKey ColocatedRow(ColocationId colocation_id, int32_t id) {
+  return dockv::DocKey(
+      colocation_id, /* hash = */ 1000 + id, dockv::MakeKeyEntryValues("h"),
+      dockv::MakeKeyEntryValues(id));
+}
+
+// Row-level key (packed row or row tombstone): the DocKey itself, no subkeys.
+std::string RowKey(const dockv::DocKey& row, int64_t age_micros) {
+  return dockv::SubDocKey(row, AgeToHt(age_micros)).Encode().ToStringBuffer();
+}
+
+std::string ColumnKey(const dockv::DocKey& row, int column, int64_t age_micros) {
+  return dockv::SubDocKey(
+      row, AgeToHt(age_micros),
+      dockv::KeyEntryValues{dockv::KeyEntryValue::MakeColumnId(ColumnId(column))})
+      .Encode().ToStringBuffer();
+}
+
+std::string Tombstone() {
+  return std::string(1, dockv::ValueEntryTypeAsChar::kTombstone);
+}
+
+std::string PackedRow(const std::string& payload) {
+  return std::string(1, dockv::ValueEntryTypeAsChar::kPackedRowV2) + payload;
+}
+
+std::string Str(const std::string& s) {
+  return std::string(1, dockv::ValueEntryTypeAsChar::kString) + s;
+}
+
+std::string MetaKey() {
+  return std::string(1, dockv::KeyEntryTypeAsChar::kTransactionApplyState) + "txn-id-bytes";
+}
+
+class TrackerFixture {
+ public:
+  explicit TrackerFixture(bool subtotals = false) : tracker_(kAnchorMicros, subtotals) {}
+
+  TrackerFixture& Add(const Entry& e) {
+    tracker_.Add(e.key, e.value);
+    return *this;
+  }
+
+  TrackerFixture& Add(const std::vector<Entry>& entries) {
+    for (const auto& e : entries) {
+      Add(e);
+    }
+    return *this;
+  }
+
+  const SstStats& Finish() { return tracker_.Finish(); }
+
+ private:
+  ChainTracker tracker_;
+};
+
+// The anatomy strip from the design (README "Vocabulary" example).
+//
+// Live row r1, 6 entries, newest first within each key:
+//   [packed v3][packed v2][packed v1][col a v2][col a v1][col b v1]
+// Dead row r2, 3 entries:
+//   [row tombstone][col a v1][col b v1]
+std::vector<Entry> AnatomyStrip() {
+  const auto r1 = Row(1);
+  const auto r2 = Row(2);
+  return {
+      {RowKey(r1, 1 * kMinute), PackedRow("v3")},
+      {RowKey(r1, 20 * kMinute), PackedRow("v2")},
+      {RowKey(r1, 2 * kHour), PackedRow("v1")},
+      {ColumnKey(r1, 1, 10 * kMinute), Str("a2")},
+      {ColumnKey(r1, 1, 3 * kDay), Str("a1")},
+      {ColumnKey(r1, 2, 1 * kMinute), Str("b1")},
+      {RowKey(r2, 2 * kDay), Tombstone()},
+      {ColumnKey(r2, 1, 5 * kDay), Str("a1")},
+      {ColumnKey(r2, 2, 6 * kDay), Str("b1")},
+  };
+}
+
+void ExpectIdentities(const SstStats& s) {
+  ASSERT_TRUE(s.chain_valid);
+  ASSERT_EQ(s.chain_entries, s.shadowed_entries() + s.num_subdoc_keys);
+  ASSERT_EQ(s.num_subdoc_keys, s.repackable_entries() + s.num_rows);
+  ASSERT_EQ(s.collapsible_entries(), s.shadowed_entries() + s.repackable_entries());
+  ASSERT_EQ(s.total_entries, s.chain_entries + s.meta_entries);
+  ASSERT_EQ(s.row_chain_hist.TotalWeight(), s.num_rows);
+  ASSERT_EQ(s.stretch_entries_hist.TotalWeight(), s.reclaimable_entries);
+  ASSERT_EQ(s.stretch_bytes_hist.TotalWeight(), s.reclaimable_bytes);
+  uint64_t banded_entries = 0, banded_bytes = 0;
+  for (size_t i = 0; i < AgeBands::kNumBands; ++i) {
+    banded_entries += s.droppable_age_entries[i];
+    banded_bytes += s.droppable_age_bytes[i];
+  }
+  ASSERT_EQ(banded_entries, s.reclaimable_entries);
+  ASSERT_EQ(banded_bytes, s.reclaimable_bytes);
+}
+
+}  // namespace
+
+class SstStatsCollectorTest : public YBTest {};
+
+TEST_F(SstStatsCollectorTest, AnatomyStrip) {
+  const auto s = TrackerFixture().Add(AnatomyStrip()).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+
+  EXPECT_EQ(s.total_entries, 9);
+  EXPECT_EQ(s.chain_entries, 9);
+  EXPECT_EQ(s.meta_entries, 0);
+  EXPECT_EQ(s.tombstone_entries, 1);
+  EXPECT_EQ(s.packed_row_entries, 3);
+  // Subdoc keys: r1 packed, r1.a, r1.b, r2 tombstone, r2.a, r2.b.
+  EXPECT_EQ(s.num_subdoc_keys, 6);
+  EXPECT_EQ(s.num_rows, 2);
+  EXPECT_EQ(s.shadowed_entries(), 3);      // packed v2, packed v1, col a v1
+  EXPECT_EQ(s.repackable_entries(), 4);    // r1.a, r1.b, r2.a, r2.b (dead-row heads count too)
+  EXPECT_EQ(s.dead_rows, 1);
+  EXPECT_EQ(s.dead_row_entries, 3);
+  // Reclaimable = shadowed entries of live rows (3) + every entry of dead rows (3), no overlap.
+  EXPECT_EQ(s.reclaimable_entries, 6);
+  EXPECT_EQ(s.max_row_chain, 6);
+
+  // Row-chain histogram: one row of 6, one row of 3.
+  EXPECT_EQ(s.row_chain_hist.bucket(ExponentialHistogram::BucketIndex(6)), 1);
+  EXPECT_EQ(s.row_chain_hist.bucket(ExponentialHistogram::BucketIndex(3)), 1);
+  EXPECT_EQ(s.row_chain_hist.TotalWeight(), 2);
+
+  // Stretches of consecutive reclaimable entries in file order:
+  //   [packed v2, packed v1] = 2, [col a v1] = 1, [r2 tombstone, r2.a, r2.b] = 3.
+  EXPECT_EQ(s.stretch_hist.TotalWeight(), 3);
+  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(1)), 1);
+  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(2)), 1);
+  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(3)), 1);
+  EXPECT_EQ(s.max_stretch, 3);
+
+  // Age bands, by the age of what makes each entry droppable:
+  //   packed v2  -> its overwriter packed v3, 1 min old        -> band 0 (< 5 m)
+  //   packed v1  -> its overwriter packed v2, 20 min old       -> band 2 (15 m .. 1 h)
+  //   col a v1   -> its overwriter col a v2, 10 min old        -> band 1 (5 m .. 15 m)
+  //   r2 x 3     -> the row tombstone, 2 days old              -> band 5 (24 h .. 7 d)
+  const AgeBandCounts expected_bands = {1, 1, 1, 0, 0, 3, 0, 0};
+  EXPECT_EQ(s.droppable_age_entries, expected_bands);
+
+  // Write-time range spans the oldest (r2.b, 6 days) to the newest (1 minute) entry.
+  EXPECT_EQ(s.min_write_ht, AgeToHt(6 * kDay));
+  EXPECT_EQ(s.max_write_ht, AgeToHt(1 * kMinute));
+  EXPECT_EQ(s.anchor_micros, kAnchorMicros);
+}
+
+TEST_F(SstStatsCollectorTest, IdentitiesHoldOverChainEntriesWithMetaRecords) {
+  // Meta records are counted in total_entries but not in the chain population; the identities are
+  // stated over chain_entries and must survive meta records interleaved between rows.
+  auto entries = AnatomyStrip();
+  entries.insert(entries.begin() + 6, Entry{MetaKey(), "state"});
+  entries.push_back(Entry{MetaKey() + "2", "state"});
+  const auto s = TrackerFixture().Add(entries).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+  EXPECT_EQ(s.total_entries, 11);
+  EXPECT_EQ(s.meta_entries, 2);
+  EXPECT_EQ(s.chain_entries, 9);
+  EXPECT_EQ(s.num_rows, 2);
+  EXPECT_EQ(s.reclaimable_entries, 6);
+  // A meta record between two rows does not create a phantom row or join two stretches.
+  EXPECT_EQ(s.row_chain_hist.TotalWeight(), 2);
+  EXPECT_EQ(s.stretch_hist.TotalWeight(), 3);
+}
+
+TEST_F(SstStatsCollectorTest, EmptyFileAndFinishIdempotence) {
+  TrackerFixture empty;
+  const auto& s = empty.Finish();
+  EXPECT_EQ(s.total_entries, 0);
+  EXPECT_EQ(s.num_rows, 0);
+  EXPECT_TRUE(s.row_chain_hist.Empty());
+  EXPECT_TRUE(s.stretch_hist.Empty());
+  EXPECT_TRUE(s.chain_valid);
+  EXPECT_FALSE(s.min_write_ht.is_valid());
+
+  TrackerFixture fixture;
+  fixture.Add(AnatomyStrip());
+  const auto first = fixture.Finish();
+  const auto& second = fixture.Finish();
+  EXPECT_EQ(first.num_rows, second.num_rows);
+  EXPECT_EQ(first.row_chain_hist, second.row_chain_hist);
+  EXPECT_EQ(first.stretch_hist, second.stretch_hist);
+  EXPECT_EQ(first.dead_row_entries, second.dead_row_entries);
+}
+
+TEST_F(SstStatsCollectorTest, OnlyMetaRecords) {
+  const auto s = TrackerFixture()
+      .Add({{MetaKey(), "a"}, {MetaKey() + "1", "b"}, {MetaKey() + "2", "c"}}).Finish();
+  EXPECT_EQ(s.total_entries, 3);
+  EXPECT_EQ(s.meta_entries, 3);
+  EXPECT_EQ(s.chain_entries, 0);
+  EXPECT_EQ(s.num_rows, 0);
+  EXPECT_TRUE(s.row_chain_hist.Empty());
+  EXPECT_TRUE(s.chain_valid);
+}
+
+TEST_F(SstStatsCollectorTest, LongStretchOfDeadRows) {
+  // A drained queue: 100 deleted rows, each a tombstone plus two columns. Every row chain is short
+  // (3), but a cursor entering this range steps over 300 entries: one stretch of 300.
+  std::vector<Entry> entries;
+  for (int32_t id = 0; id < 100; ++id) {
+    const auto row = Row(id);
+    entries.push_back({RowKey(row, 1 * kDay), Tombstone()});
+    entries.push_back({ColumnKey(row, 1, 2 * kDay), Str("a")});
+    entries.push_back({ColumnKey(row, 2, 2 * kDay), Str("b")});
+  }
+  const auto s = TrackerFixture().Add(entries).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+  EXPECT_EQ(s.num_rows, 100);
+  EXPECT_EQ(s.dead_rows, 100);
+  EXPECT_EQ(s.dead_row_entries, 300);
+  EXPECT_EQ(s.reclaimable_entries, 300);
+  EXPECT_EQ(s.max_row_chain, 3);
+  EXPECT_EQ(s.max_stretch, 300);
+  EXPECT_EQ(s.stretch_hist.TotalWeight(), 1);
+  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(300)), 1);
+  // All droppable once the 1-day-old tombstones are; an age of exactly 24 h is the lower edge of
+  // band 5 (24 h .. 7 d).
+  EXPECT_EQ(s.droppable_age_entries[5], 300);
+}
+
+TEST_F(SstStatsCollectorTest, EveryOtherRowDeletedHasShortStretches) {
+  // Half the rows deleted, interleaved with live rows: high reclaimable total, short stretches.
+  std::vector<Entry> entries;
+  for (int32_t id = 0; id < 100; ++id) {
+    const auto row = Row(id);
+    if (id % 2 == 0) {
+      entries.push_back({RowKey(row, 1 * kDay), Tombstone()});
+      entries.push_back({ColumnKey(row, 1, 2 * kDay), Str("a")});
+    } else {
+      entries.push_back({RowKey(row, 1 * kDay), PackedRow("live")});
+    }
+  }
+  const auto s = TrackerFixture().Add(entries).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+  EXPECT_EQ(s.num_rows, 100);
+  EXPECT_EQ(s.dead_rows, 50);
+  EXPECT_EQ(s.reclaimable_entries, 100);
+  EXPECT_EQ(s.chain_entries, 150);
+  EXPECT_EQ(s.max_stretch, 2);
+  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(2)), 50);
+}
+
+TEST_F(SstStatsCollectorTest, TableTombstoneAndCoprefixSubtotals) {
+  const ColocationId dropped = 16385;
+  const ColocationId live = 16386;
+  // Colocated tablet: table `dropped` has a table-level tombstone (empty DocKey under the
+  // colocation id) followed by two of its rows; table `live` has one row with a shadowed version.
+  std::vector<Entry> entries = {
+      {dockv::SubDocKey(dockv::DocKey(dropped), AgeToHt(1 * kHour)).Encode().ToStringBuffer(),
+       Tombstone()},
+      {RowKey(ColocatedRow(dropped, 1), 2 * kHour), PackedRow("x")},
+      {RowKey(ColocatedRow(dropped, 2), 2 * kHour), PackedRow("y")},
+      {RowKey(ColocatedRow(live, 1), 1 * kMinute), PackedRow("new")},
+      {RowKey(ColocatedRow(live, 1), 1 * kHour), PackedRow("old")},
+  };
+  const auto s = TrackerFixture(/* subtotals = */ true).Add(entries).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+  // The table tombstone is the head of its own one-entry dead row. The dropped table's rows are
+  // separate rows here (the collector does not apply the tombstone to them; the compaction feed
+  // does), so they read as live single-entry rows.
+  EXPECT_EQ(s.num_rows, 4);
+  EXPECT_EQ(s.dead_rows, 1);
+  EXPECT_EQ(s.dead_row_entries, 1);
+  EXPECT_EQ(s.tombstone_entries, 1);
+  EXPECT_EQ(s.shadowed_entries(), 1);
+  EXPECT_EQ(s.reclaimable_entries, 2);
+
+  ASSERT_EQ(s.coprefix_subtotals.size(), 2);
+  const auto dropped_prefix = dockv::DocKey(dropped).Encode().ToStringBuffer();
+  const auto live_prefix = dockv::DocKey(live).Encode().ToStringBuffer();
+  // DocKey(colocation_id).Encode() ends with a kGroupEnd; the coprefix is the part before it.
+  const auto& dropped_sub =
+      s.coprefix_subtotals.at(dropped_prefix.substr(0, dropped_prefix.size() - 1));
+  EXPECT_EQ(dropped_sub.rows, 3);
+  EXPECT_EQ(dropped_sub.entries, 3);
+  EXPECT_EQ(dropped_sub.tombstone_entries, 1);
+  EXPECT_EQ(dropped_sub.reclaimable_entries, 1);
+  const auto& live_sub = s.coprefix_subtotals.at(live_prefix.substr(0, live_prefix.size() - 1));
+  EXPECT_EQ(live_sub.rows, 1);
+  EXPECT_EQ(live_sub.entries, 2);
+  EXPECT_EQ(live_sub.tombstone_entries, 0);
+  EXPECT_EQ(live_sub.reclaimable_entries, 1);
+}
+
+TEST_F(SstStatsCollectorTest, CorruptKeyInvalidatesChainStatsOnly) {
+  auto entries = AnatomyStrip();
+  // A key with no room for a hybrid time.
+  entries.insert(entries.begin() + 3, Entry{std::string(1, dockv::KeyEntryTypeAsChar::kString),
+                                            Tombstone()});
+  const auto s = TrackerFixture().Add(entries).Finish();
+  EXPECT_FALSE(s.chain_valid);
+  // The v1 counters keep counting every entry.
+  EXPECT_EQ(s.total_entries, 10);
+  EXPECT_EQ(s.tombstone_entries, 2);
+}
+
+TEST_F(SstStatsCollectorTest, MergeAcrossFilesIsExactForDisjointRows) {
+  // Two files holding disjoint rows: the merged histograms equal the histograms of one file
+  // holding all the entries.
+  const auto all = AnatomyStrip();
+  const std::vector<Entry> first(all.begin(), all.begin() + 6);   // r1
+  const std::vector<Entry> second(all.begin() + 6, all.end());    // r2
+  const auto a = TrackerFixture().Add(first).Finish();
+  const auto b = TrackerFixture().Add(second).Finish();
+  const auto both = TrackerFixture().Add(all).Finish();
+
+  auto merged_rows = a.row_chain_hist;
+  merged_rows.Merge(b.row_chain_hist);
+  EXPECT_EQ(merged_rows, both.row_chain_hist);
+  auto merged_stretch = a.stretch_hist;
+  merged_stretch.Merge(b.stretch_hist);
+  EXPECT_EQ(merged_stretch, both.stretch_hist);
+  EXPECT_EQ(a.reclaimable_entries + b.reclaimable_entries, both.reclaimable_entries);
+  EXPECT_EQ(a.chain_entries - a.num_rows + b.chain_entries - b.num_rows,
+            both.collapsible_entries());
+}
+
+TEST_F(SstStatsCollectorTest, PropertiesRoundTrip) {
+  const auto s = TrackerFixture(/* subtotals = */ true).Add(AnatomyStrip()).Finish();
+  rocksdb::UserCollectedProperties properties;
+  SstStatsToProperties(s, &properties);
+  EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kCollectorVersion)),
+            kSstStatsCollectorVersion);
+  EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kReclaimableEntries)), "6");
+  EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kDroppableAgeEntries)),
+            "1,1,1,0,0,3,0,0");
+
+  const auto parsed = ASSERT_RESULT(SstStatsFromProperties(properties));
+  EXPECT_EQ(parsed.total_entries, s.total_entries);
+  EXPECT_EQ(parsed.tombstone_entries, s.tombstone_entries);
+  EXPECT_EQ(parsed.chain_entries, s.chain_entries);
+  EXPECT_EQ(parsed.chain_bytes, s.chain_bytes);
+  EXPECT_EQ(parsed.num_subdoc_keys, s.num_subdoc_keys);
+  EXPECT_EQ(parsed.num_rows, s.num_rows);
+  EXPECT_EQ(parsed.dead_rows, s.dead_rows);
+  EXPECT_EQ(parsed.dead_row_entries, s.dead_row_entries);
+  EXPECT_EQ(parsed.reclaimable_entries, s.reclaimable_entries);
+  EXPECT_EQ(parsed.reclaimable_bytes, s.reclaimable_bytes);
+  EXPECT_EQ(parsed.max_row_chain, s.max_row_chain);
+  EXPECT_EQ(parsed.max_stretch, s.max_stretch);
+  EXPECT_EQ(parsed.chain_valid, s.chain_valid);
+  EXPECT_EQ(parsed.min_write_ht, s.min_write_ht);
+  EXPECT_EQ(parsed.max_write_ht, s.max_write_ht);
+  EXPECT_EQ(parsed.anchor_micros, s.anchor_micros);
+  EXPECT_EQ(parsed.row_chain_hist, s.row_chain_hist);
+  EXPECT_EQ(parsed.row_chain_bytes_hist, s.row_chain_bytes_hist);
+  EXPECT_EQ(parsed.stretch_hist, s.stretch_hist);
+  EXPECT_EQ(parsed.stretch_entries_hist, s.stretch_entries_hist);
+  EXPECT_EQ(parsed.stretch_bytes_hist, s.stretch_bytes_hist);
+  EXPECT_EQ(parsed.droppable_age_entries, s.droppable_age_entries);
+  EXPECT_EQ(parsed.droppable_age_bytes, s.droppable_age_bytes);
+  ASSERT_EQ(parsed.coprefix_subtotals.size(), 1);
+  EXPECT_EQ(parsed.coprefix_subtotals.begin()->second.rows, 2);
+
+  EXPECT_NOK(SstStatsFromProperties(rocksdb::UserCollectedProperties()));
+}
+
+TEST_F(SstStatsCollectorTest, CollectorEndToEnd) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_sst_tombstone_mark_min_count) = 1;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_sst_tombstone_mark_ratio_percent) = 50;
+
+  auto factory = MakeSstStatsCollectorFactory();
+  std::unique_ptr<rocksdb::TablePropertiesCollector> collector(
+      factory->CreateTablePropertiesCollector(rocksdb::TablePropertiesCollectorFactory::Context()));
+  for (const auto& e : AnatomyStrip()) {
+    ASSERT_OK(collector->AddUserKey(e.key, e.value, rocksdb::kEntryPut, 0, 0));
+  }
+  // 1 tombstone out of 9 entries: below the 50% marking threshold.
+  EXPECT_FALSE(collector->NeedCompact());
+
+  rocksdb::UserCollectedProperties properties;
+  ASSERT_OK(collector->Finish(&properties));
+  const auto s = ASSERT_RESULT(SstStatsFromProperties(properties));
+  EXPECT_EQ(s.total_entries, 9);
+  EXPECT_EQ(s.reclaimable_entries, 6);
+  EXPECT_EQ(s.num_rows, 2);
+  // The anchor is taken from the wall clock at construction; the test entries are dated relative
+  // to a fixed 2023 anchor, so every band lands in the oldest bucket here.
+  EXPECT_GT(s.anchor_micros, kAnchorMicros);
+  EXPECT_EQ(s.droppable_age_entries[AgeBands::kNumBands - 1], 6);
+
+  // A tombstone-heavy file trips the MANIFEST mark.
+  std::unique_ptr<rocksdb::TablePropertiesCollector> heavy(
+      factory->CreateTablePropertiesCollector(rocksdb::TablePropertiesCollectorFactory::Context()));
+  for (int32_t id = 0; id < 10; ++id) {
+    ASSERT_OK(heavy->AddUserKey(RowKey(Row(id), kHour), Tombstone(), rocksdb::kEntryPut, 0, 0));
+  }
+  EXPECT_TRUE(heavy->NeedCompact());
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/sst_stats_collector.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_collector.cc
@@ -1,0 +1,286 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/docdb/properties_collector/sst_stats_collector.h"
+
+#include "yb/gutil/strings/escaping.h"
+#include "yb/gutil/walltime.h"
+
+#include "yb/util/flags.h"
+#include "yb/util/status_format.h"
+#include "yb/util/string_util.h"
+
+DEFINE_NON_RUNTIME_bool(docdb_enable_sst_stats_collector, false,
+    "Whether to register the DocDB SST statistics collector on the regular RocksDB of each tablet. "
+    "The collector stores garbage and chain statistics in each SST file's properties block. Takes "
+    "effect on tablet (re)open.");
+
+DEFINE_RUNTIME_bool(docdb_sst_stats_coprefix_subtotals, false,
+    "Whether the DocDB SST statistics collector also records per-table (cotable / colocation id) "
+    "subtotals in colocated tablets. Applies to files built from then on.");
+
+DEFINE_RUNTIME_uint32(sst_tombstone_mark_ratio_percent, 30,
+    "Mark an SST file for compaction when at least this percentage of its entries are DocDB "
+    "tombstones (in combination with sst_tombstone_mark_min_count). The mark is persisted in the "
+    "MANIFEST; nothing consumes it under DocDB's universal compaction until a picker or trigger "
+    "explicitly opts in.");
+
+DEFINE_RUNTIME_uint64(sst_tombstone_mark_min_count, 10000,
+    "Mark an SST file for compaction only when it contains at least this many DocDB tombstones "
+    "(in combination with sst_tombstone_mark_ratio_percent).");
+
+namespace yb::docdb {
+
+namespace {
+
+constexpr size_t kCoprefixSubtotalsMaxBytes = 4096;
+
+// UserCollectedProperties is a std::map<std::string, std::string> without a transparent
+// comparator, so lookups need an owning key.
+rocksdb::UserCollectedProperties::const_iterator Find(
+    const rocksdb::UserCollectedProperties& properties, std::string_view key) {
+  return properties.find(std::string(key));
+}
+
+void Set(rocksdb::UserCollectedProperties* properties, std::string_view key, std::string value) {
+  (*properties)[std::string(key)] = std::move(value);
+}
+
+std::string JoinCounts(const AgeBandCounts& counts) {
+  std::string result;
+  for (size_t i = 0; i < counts.size(); ++i) {
+    if (i != 0) {
+      result += ',';
+    }
+    result += std::to_string(counts[i]);
+  }
+  return result;
+}
+
+Result<AgeBandCounts> SplitCounts(const std::string& text) {
+  AgeBandCounts result{};
+  const auto parts = StringSplit(text, ',');
+  SCHECK_EQ(parts.size(), result.size(), Corruption, Format("Expected 8 age bands in '$0'", text));
+  for (size_t i = 0; i < parts.size(); ++i) {
+    try {
+      result[i] = std::stoull(parts[i]);
+    } catch (const std::exception& e) {
+      return STATUS_FORMAT(Corruption, "Malformed age band '$0': $1", parts[i], e.what());
+    }
+  }
+  return result;
+}
+
+std::string SerializeCoprefixSubtotals(const std::map<std::string, CoprefixSubtotal>& subtotals) {
+  std::string result;
+  for (const auto& [coprefix, subtotal] : subtotals) {
+    std::string item = Format(
+        "$0:$1:$2:$3:$4", strings::b2a_hex(coprefix), subtotal.entries, subtotal.tombstone_entries,
+        subtotal.reclaimable_entries, subtotal.rows);
+    if (result.size() + item.size() + 1 > kCoprefixSubtotalsMaxBytes) {
+      result += ";...";
+      break;
+    }
+    if (!result.empty()) {
+      result += ';';
+    }
+    result += item;
+  }
+  return result;
+}
+
+Result<std::map<std::string, CoprefixSubtotal>> ParseCoprefixSubtotals(const std::string& text) {
+  std::map<std::string, CoprefixSubtotal> result;
+  if (text.empty()) {
+    return result;
+  }
+  for (const auto& item : StringSplit(text, ';')) {
+    if (item == "...") {
+      continue;
+    }
+    const auto fields = StringSplit(item, ':');
+    SCHECK_EQ(fields.size(), 5, Corruption, Format("Malformed coprefix subtotal '$0'", item));
+    try {
+      auto& subtotal = result[strings::a2b_hex(fields[0])];
+      subtotal.entries = std::stoull(fields[1]);
+      subtotal.tombstone_entries = std::stoull(fields[2]);
+      subtotal.reclaimable_entries = std::stoull(fields[3]);
+      subtotal.rows = std::stoull(fields[4]);
+    } catch (const std::exception& e) {
+      return STATUS_FORMAT(Corruption, "Malformed coprefix subtotal '$0': $1", item, e.what());
+    }
+  }
+  return result;
+}
+
+Result<const std::string&> Get(
+    const rocksdb::UserCollectedProperties& properties, std::string_view key) {
+  const auto it = Find(properties, key);
+  SCHECK(it != properties.end(), NotFound, Format("Missing SST property $0", key));
+  return it->second;
+}
+
+Result<uint64_t> GetUint64(
+    const rocksdb::UserCollectedProperties& properties, std::string_view key) {
+  const auto& text = VERIFY_RESULT_REF(Get(properties, key));
+  try {
+    return std::stoull(text);
+  } catch (const std::exception& e) {
+    return STATUS_FORMAT(
+        Corruption, "Malformed SST property $0 = '$1': $2", key, text, e.what());
+  }
+}
+
+Result<ExponentialHistogram> GetHistogram(
+    const rocksdb::UserCollectedProperties& properties, std::string_view key) {
+  return ExponentialHistogram::Parse(VERIFY_RESULT_REF(Get(properties, key)));
+}
+
+Result<AgeBandCounts> GetAgeBands(
+    const rocksdb::UserCollectedProperties& properties, std::string_view key) {
+  return SplitCounts(VERIFY_RESULT_REF(Get(properties, key)));
+}
+
+class SstStatsCollector : public rocksdb::TablePropertiesCollector {
+ public:
+  SstStatsCollector()
+      : tracker_(GetCurrentTimeMicros(), FLAGS_docdb_sst_stats_coprefix_subtotals) {}
+
+  Status AddUserKey(
+      const Slice& key, const Slice& value, rocksdb::EntryType type, rocksdb::SequenceNumber seq,
+      uint64_t file_size) override {
+    // A properties collector must never fail the table build; the tracker records parse failures
+    // in chain_valid instead of returning them.
+    tracker_.Add(key, value);
+    return Status::OK();
+  }
+
+  Status Finish(rocksdb::UserCollectedProperties* properties) override {
+    SstStatsToProperties(tracker_.Finish(), properties);
+    return Status::OK();
+  }
+
+  rocksdb::UserCollectedProperties GetReadableProperties() const override {
+    rocksdb::UserCollectedProperties properties;
+    // GetReadableProperties may be called before Finish; report what has been seen so far without
+    // closing the open row.
+    SstStatsToProperties(tracker_.stats(), &properties);
+    return properties;
+  }
+
+  const char* Name() const override { return "DocDbSstStatsCollector"; }
+
+  // Sets FileMetaData::marked_for_compaction on the just-built file, which the MANIFEST persists.
+  // Nothing consumes the mark under DocDB's universal compaction; the raw counts are stored
+  // regardless, so thresholds can be revisited without losing information.
+  bool NeedCompact() const override {
+    const auto& stats = tracker_.stats();
+    return stats.tombstone_entries >= FLAGS_sst_tombstone_mark_min_count &&
+           stats.tombstone_entries * 100 >=
+               stats.total_entries * FLAGS_sst_tombstone_mark_ratio_percent;
+  }
+
+ private:
+  ChainTracker tracker_;
+};
+
+class SstStatsCollectorFactory : public rocksdb::TablePropertiesCollectorFactory {
+ public:
+  rocksdb::TablePropertiesCollector* CreateTablePropertiesCollector(
+      rocksdb::TablePropertiesCollectorFactory::Context context) override {
+    return new SstStatsCollector();
+  }
+
+  const char* Name() const override { return "DocDbSstStatsCollectorFactory"; }
+};
+
+}  // namespace
+
+void SstStatsToProperties(const SstStats& stats, rocksdb::UserCollectedProperties* properties) {
+  using K = SstStatsPropertyKeys;
+  Set(properties, K::kCollectorVersion, std::string(kSstStatsCollectorVersion));
+  Set(properties, K::kTotalEntries, std::to_string(stats.total_entries));
+  Set(properties, K::kTombstoneEntries, std::to_string(stats.tombstone_entries));
+  Set(properties, K::kPackedRowEntries, std::to_string(stats.packed_row_entries));
+  Set(properties, K::kMetaEntries, std::to_string(stats.meta_entries));
+  Set(properties, K::kChainEntries, std::to_string(stats.chain_entries));
+  Set(properties, K::kChainBytes, std::to_string(stats.chain_bytes));
+  Set(properties, K::kNumSubdocKeys, std::to_string(stats.num_subdoc_keys));
+  Set(properties, K::kNumRows, std::to_string(stats.num_rows));
+  Set(properties, K::kDeadRows, std::to_string(stats.dead_rows));
+  Set(properties, K::kDeadRowEntries, std::to_string(stats.dead_row_entries));
+  Set(properties, K::kReclaimableEntries, std::to_string(stats.reclaimable_entries));
+  Set(properties, K::kReclaimableBytes, std::to_string(stats.reclaimable_bytes));
+  Set(properties, K::kMaxRowChain, std::to_string(stats.max_row_chain));
+  Set(properties, K::kMaxStretch, std::to_string(stats.max_stretch));
+  Set(properties, K::kChainValid, stats.chain_valid ? "1" : "0");
+  Set(properties, K::kMinWriteHt, std::to_string(stats.min_write_ht.ToUint64()));
+  Set(properties, K::kMaxWriteHt, std::to_string(stats.max_write_ht.ToUint64()));
+  Set(properties, K::kAnchorMicros, std::to_string(stats.anchor_micros));
+  Set(properties, K::kRowChainHist, stats.row_chain_hist.Serialize());
+  Set(properties, K::kRowChainBytesHist, stats.row_chain_bytes_hist.Serialize());
+  Set(properties, K::kStretchHist, stats.stretch_hist.Serialize());
+  Set(properties, K::kStretchEntriesHist, stats.stretch_entries_hist.Serialize());
+  Set(properties, K::kStretchBytesHist, stats.stretch_bytes_hist.Serialize());
+  Set(properties, K::kDroppableAgeEntries, JoinCounts(stats.droppable_age_entries));
+  Set(properties, K::kDroppableAgeBytes, JoinCounts(stats.droppable_age_bytes));
+  if (!stats.coprefix_subtotals.empty()) {
+    Set(properties, K::kCoprefixSubtotals, SerializeCoprefixSubtotals(stats.coprefix_subtotals));
+  }
+}
+
+Result<SstStats> SstStatsFromProperties(const rocksdb::UserCollectedProperties& properties) {
+  using K = SstStatsPropertyKeys;
+  const auto version = Find(properties, K::kCollectorVersion);
+  SCHECK(version != properties.end(), NotFound, "No DocDB SST statistics in properties");
+  SCHECK_EQ(version->second, kSstStatsCollectorVersion, NotSupported,
+            Format("Unsupported DocDB SST statistics version $0", version->second));
+  SstStats stats;
+  stats.total_entries = VERIFY_RESULT(GetUint64(properties, K::kTotalEntries));
+  stats.tombstone_entries = VERIFY_RESULT(GetUint64(properties, K::kTombstoneEntries));
+  stats.packed_row_entries = VERIFY_RESULT(GetUint64(properties, K::kPackedRowEntries));
+  stats.meta_entries = VERIFY_RESULT(GetUint64(properties, K::kMetaEntries));
+  stats.chain_entries = VERIFY_RESULT(GetUint64(properties, K::kChainEntries));
+  stats.chain_bytes = VERIFY_RESULT(GetUint64(properties, K::kChainBytes));
+  stats.num_subdoc_keys = VERIFY_RESULT(GetUint64(properties, K::kNumSubdocKeys));
+  stats.num_rows = VERIFY_RESULT(GetUint64(properties, K::kNumRows));
+  stats.dead_rows = VERIFY_RESULT(GetUint64(properties, K::kDeadRows));
+  stats.dead_row_entries = VERIFY_RESULT(GetUint64(properties, K::kDeadRowEntries));
+  stats.reclaimable_entries = VERIFY_RESULT(GetUint64(properties, K::kReclaimableEntries));
+  stats.reclaimable_bytes = VERIFY_RESULT(GetUint64(properties, K::kReclaimableBytes));
+  stats.max_row_chain = VERIFY_RESULT(GetUint64(properties, K::kMaxRowChain));
+  stats.max_stretch = VERIFY_RESULT(GetUint64(properties, K::kMaxStretch));
+  stats.chain_valid = VERIFY_RESULT(GetUint64(properties, K::kChainValid)) != 0;
+  stats.min_write_ht = HybridTime(VERIFY_RESULT(GetUint64(properties, K::kMinWriteHt)));
+  stats.max_write_ht = HybridTime(VERIFY_RESULT(GetUint64(properties, K::kMaxWriteHt)));
+  stats.anchor_micros =
+      static_cast<int64_t>(VERIFY_RESULT(GetUint64(properties, K::kAnchorMicros)));
+  stats.row_chain_hist = VERIFY_RESULT(GetHistogram(properties, K::kRowChainHist));
+  stats.row_chain_bytes_hist = VERIFY_RESULT(GetHistogram(properties, K::kRowChainBytesHist));
+  stats.stretch_hist = VERIFY_RESULT(GetHistogram(properties, K::kStretchHist));
+  stats.stretch_entries_hist = VERIFY_RESULT(GetHistogram(properties, K::kStretchEntriesHist));
+  stats.stretch_bytes_hist = VERIFY_RESULT(GetHistogram(properties, K::kStretchBytesHist));
+  stats.droppable_age_entries = VERIFY_RESULT(GetAgeBands(properties, K::kDroppableAgeEntries));
+  stats.droppable_age_bytes = VERIFY_RESULT(GetAgeBands(properties, K::kDroppableAgeBytes));
+  const auto subtotals = Find(properties, K::kCoprefixSubtotals);
+  if (subtotals != properties.end()) {
+    stats.coprefix_subtotals = VERIFY_RESULT(ParseCoprefixSubtotals(subtotals->second));
+  }
+  return stats;
+}
+
+std::shared_ptr<rocksdb::TablePropertiesCollectorFactory> MakeSstStatsCollectorFactory() {
+  return std::make_shared<SstStatsCollectorFactory>();
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/sst_stats_collector.h
+++ b/src/yb/docdb/properties_collector/sst_stats_collector.h
@@ -1,0 +1,88 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <memory>
+#include <string_view>
+
+#include "yb/docdb/properties_collector/chain_tracker.h"
+
+#include "yb/rocksdb/table_properties.h"
+
+namespace yb::docdb {
+
+// DocDB-aware SST properties collector: measures garbage (tombstones, shadowed versions, dead rows)
+// and chain / stretch distributions while an SST file is built, and stores them in the file's
+// user_collected_properties block. Design and vocabulary: properties_collector/README.md.
+
+// Keys of the properties this collector stores, all under "yb.docdb.". Values are decimal strings
+// unless noted. Groups:
+//   counts       total/tombstone/packed-row/meta entries; chain entries (Ec) and bytes; subdoc keys
+//                (K); rows (R); dead rows and their entries; reclaimable entries and bytes; max row
+//                chain; max stretch. Shadowed (Ec-K), repackable (K-R), collapsible (Ec-R) are
+//                identities, not stored.
+//   validity     collector_version, chain_valid.
+//   write range  exact min/max write hybrid time of chain-tracked entries; the age-band anchor.
+//   histograms   row-chain length (by rows, by bytes); stretch length (by stretches, by entries,
+//                by bytes). ExponentialHistogram::Serialize() form.
+//   age bands    reclaimable entries and bytes by age of what makes them droppable (8 bands).
+//   colocation   per-coprefix subtotals, only when enabled by flag.
+// A typical file adds well under 1 KB (histograms are sparse); the fully dense worst case is about
+// 1.7 KB per histogram.
+struct SstStatsPropertyKeys {
+  static constexpr std::string_view kCollectorVersion = "yb.docdb.collector_version";
+  static constexpr std::string_view kTotalEntries = "yb.docdb.total_entries";
+  static constexpr std::string_view kTombstoneEntries = "yb.docdb.tombstone_entries";
+  static constexpr std::string_view kPackedRowEntries = "yb.docdb.packed_row_entries";
+  static constexpr std::string_view kMetaEntries = "yb.docdb.meta_entries";
+  static constexpr std::string_view kChainEntries = "yb.docdb.chain_entries";
+  static constexpr std::string_view kChainBytes = "yb.docdb.chain_bytes";
+  static constexpr std::string_view kNumSubdocKeys = "yb.docdb.num_subdoc_keys";
+  static constexpr std::string_view kNumRows = "yb.docdb.num_rows";
+  static constexpr std::string_view kDeadRows = "yb.docdb.dead_rows";
+  static constexpr std::string_view kDeadRowEntries = "yb.docdb.dead_row_entries";
+  static constexpr std::string_view kReclaimableEntries = "yb.docdb.reclaimable_entries";
+  static constexpr std::string_view kReclaimableBytes = "yb.docdb.reclaimable_bytes";
+  static constexpr std::string_view kMaxRowChain = "yb.docdb.max_row_chain";
+  static constexpr std::string_view kMaxStretch = "yb.docdb.max_stretch";
+  static constexpr std::string_view kChainValid = "yb.docdb.chain_valid";  // "1" or "0"
+  // HybridTime::ToUint64().
+  static constexpr std::string_view kMinWriteHt = "yb.docdb.min_write_ht";
+  static constexpr std::string_view kMaxWriteHt = "yb.docdb.max_write_ht";
+  static constexpr std::string_view kAnchorMicros = "yb.docdb.stats_anchor_micros";
+  // ExponentialHistogram::Serialize().
+  static constexpr std::string_view kRowChainHist = "yb.docdb.row_chain_hist";
+  static constexpr std::string_view kRowChainBytesHist = "yb.docdb.row_chain_bytes_hist";
+  static constexpr std::string_view kStretchHist = "yb.docdb.stretch_hist";
+  static constexpr std::string_view kStretchEntriesHist = "yb.docdb.stretch_entries_hist";
+  static constexpr std::string_view kStretchBytesHist = "yb.docdb.stretch_bytes_hist";
+  // 8 comma-separated counts.
+  static constexpr std::string_view kDroppableAgeEntries = "yb.docdb.droppable_age_entries";
+  static constexpr std::string_view kDroppableAgeBytes = "yb.docdb.droppable_age_bytes";
+  // "<hex coprefix>:<entries>:<tombstones>:<reclaimable>:<rows>" items joined by ';'.
+  static constexpr std::string_view kCoprefixSubtotals = "yb.docdb.coprefix_subtotals";
+};
+
+// Value of kCollectorVersion written by this code.
+inline constexpr std::string_view kSstStatsCollectorVersion = "2";
+
+// Serializes statistics into a properties map (what Finish() writes) and reads them back.
+void SstStatsToProperties(const SstStats& stats, rocksdb::UserCollectedProperties* properties);
+Result<SstStats> SstStatsFromProperties(const rocksdb::UserCollectedProperties& properties);
+
+// Creates the collector factory. Registered on each tablet's regular RocksDB when
+// --docdb_enable_sst_stats_collector is set.
+std::shared_ptr<rocksdb::TablePropertiesCollectorFactory> MakeSstStatsCollectorFactory();
+
+}  // namespace yb::docdb

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -68,6 +68,7 @@
 #include "yb/docdb/docdb_rocksdb_util.h"
 #include "yb/docdb/docdb_statistics.h"
 #include "yb/docdb/docdb_util.h"
+#include "yb/docdb/properties_collector/sst_stats_collector.h"
 #include "yb/docdb/pgsql_operation.h"
 #include "yb/docdb/ql_rocksdb_storage.h"
 #include "yb/docdb/redis_operation.h"
@@ -366,6 +367,7 @@ DEFINE_RUNTIME_AUTO_bool(enable_transaction_metadata_update, kLocalPersisted, fa
 DECLARE_bool(cdc_immediate_transaction_cleanup);
 DECLARE_bool(cdc_enable_time_based_intent_retention);
 DECLARE_bool(consistent_restore);
+DECLARE_bool(docdb_enable_sst_stats_collector);
 DECLARE_bool(flush_rocksdb_on_shutdown);
 DECLARE_bool(TEST_invalidate_last_change_metadata_op);
 DECLARE_int32(client_read_write_timeout_ms);
@@ -1243,6 +1245,11 @@ Status Tablet::OpenRegularDB(const rocksdb::Options& common_options) {
     table_options.use_delta_encoding = UseDeltaEncoding(table_type_);
     docdb::InitRocksDBOptionsTableFactory(
         &regular_rocksdb_options, tablet_options_, std::move(table_options));
+  }
+
+  if (FLAGS_docdb_enable_sst_stats_collector) {
+    regular_rocksdb_options.table_properties_collector_factories.push_back(
+        docdb::MakeSstStatsCollectorFactory());
   }
 
   // Install the history cleanup handler. Note that TabletRetentionPolicy is going to hold a raw ptr


### PR DESCRIPTION

Summary:
The RocksDB-facing half of the SST statistics collector, on top of the
chain tracker from the previous change in this stack: property keys (all
under yb.docdb.*), SstStats <-> user_collected_properties serialization
(sparse histograms with a scale tag; 8 comma-separated age-band counts;
capped per-coprefix subtotals), the rocksdb::TablePropertiesCollector
wrapper, and per-tablet registration on the regular RocksDB.

The collector runs while an SST is built (flush or compaction, on every
replica) and stores what the tracker saw in the file's own properties
block. This is the storage-side signal the read-driven full-compaction
trigger lacks: followers and point-get workloads never populate the read
statistics (#33267), so garbage debt goes unmeasured until reads suffer.

NeedCompact() keeps the v1 semantics: tombstone-heavy files get
FileMetaData::marked_for_compaction (MANIFEST breadcrumb only; nothing
consumes it under universal compaction).

Registration is behind docdb_enable_sst_stats_collector, DEFAULT OFF.
Flipping the default is a separate change gated on performance results.

Not in this change: the per-tablet aggregate, the Prometheus gauges and
the full-compaction trigger clause that consume these properties. They
follow separately.

Replaces the Phorge draft D56928.

Test Plan:
./yb_build.sh release --cxx-test sst_stats_collector-test
(properties round trip; the collector end to end through the RocksDB
interface including NeedCompact)
