### PR TITLE
[#33267] DocDB: one-pass chain tracker for SST garbage statistics

### DIFF
--- a/src/yb/docdb/properties_collector/CMakeLists.txt
+++ b/src/yb/docdb/properties_collector/CMakeLists.txt
@@ -18,6 +18,7 @@
 set(YB_PCH_PATH ../)
 
 set(DOCDB_PROPERTIES_COLLECTOR_SRCS
+    chain_tracker.cc
     exponential_histogram.cc
     )
 
@@ -34,4 +35,5 @@ ADD_YB_LIBRARY(yb_docdb_properties_collector
 
 set(YB_TEST_LINK_LIBS yb_docdb_properties_collector ${YB_MIN_TEST_LIBS})
 
+ADD_YB_TEST(chain_tracker-test)
 ADD_YB_TEST(exponential_histogram-test)

--- a/src/yb/docdb/properties_collector/README.md
+++ b/src/yb/docdb/properties_collector/README.md
@@ -67,11 +67,18 @@ Three counters over the chain-tracked entries of a file give the classification 
 
 Recognized at scan time:
 
-- A **dead row** is a row whose chain head is a row-level (or table-level) tombstone. Every entry of
-  it, marker included, is reclaimable by a full compaction.
-- **reclaimable** = shadowed entries of live rows + all entries of dead rows. All the garbage,
-  regardless of whether retention allows removing it yet. The two sets are disjoint, so counting
-  online never double counts.
+- A **covering write** is an entry at the row key itself: a packed row or a row-level (or
+  table-level) tombstone. It overwrites the whole row, so every entry of the row with an older
+  hybrid time is garbage even when it is the newest version of its own record. File order is key
+  order, not time order -- a covering write sits at the front of its row but may be newer or older
+  than any given entry behind it, so each record head is compared against the row's covering
+  writes by hybrid time.
+- A **dead row** is a row whose newest covering write is a tombstone with nothing newer in the
+  row. A row re-inserted after a delete is live again, tombstone notwithstanding.
+- **reclaimable** = shadowed versions + record heads older than a covering write + tombstone
+  markers themselves (a tombstone past the history cutoff drops at a full compaction whether or
+  not the row lives on). All the garbage, regardless of whether retention allows removing it yet,
+  counted once online.
 - **droppable** = the part of reclaimable already past the history cutoff a consumer applies. The
   compaction trigger uses droppable; the metric reports reclaimable.
 - A **stretch** is a maximal run of consecutive reclaimable entries in file order, ignoring key and
@@ -83,16 +90,18 @@ within each key, then dead row r2 with three:
 
 ```
 r1: [packed v3][packed v2][packed v1][col a v2][col a v1][col b v1]
-     live head   shadowed   shadowed   head      shadowed  head
-r2: [row tombstone][col a v1][col b v1]      <- head is a tombstone: the whole row is dead
+     live head   shadowed   shadowed   covered   shadowed  head
+                                       (older than packed v3)
+r2: [row tombstone][col a v1][col b v1]   <- both columns older than the tombstone: row is dead
 
 Ec = 9, K = 6, R = 2
-shadowed    = 3      repackable = 4 (r1.a, r1.b + r2.a, r2.b, the latter two
-                                     also reclaimable via the dead row)         collapsible = 7
+shadowed    = 3      repackable = 4 (r1.a, r1.b + r2.a, r2.b -- an identity over
+                                     heads; three of these four are also garbage)  collapsible = 7
 dead rows   = 1      dead-row entries = 3
-reclaimable = 3 (shadowed in r1) + 3 (all of r2) = 6
-stretches   = [packed v2, packed v1] = 2, [col a v1] = 1, [r2 x 3] = 3
+reclaimable = 3 (shadowed) + 1 (r1.a covered by packed v3) + 3 (all of r2) = 7
+stretches   = [packed v2 .. col a v1] = 4, [r2 x 3] = 3
 ```
+(`col b v1` shares packed v3's hybrid time, so no covering write is newer than it: live.)
 
 Why both distributions: a range of rows that were all deleted has short row chains but one very long
 stretch; every other row deleted has short stretches but half the file reclaimable.
@@ -129,10 +138,11 @@ this layout nor coarsened exactly, and each `Add` walks a `std::map`.
 
 ## Age bands and "droppable"
 
-A reclaimable entry can be removed by a compaction only once the entry that makes it garbage is at
-or below the history cutoff: for a shadowed version, the entry that shadows it (the compaction
-feed's overwrite-stack rule); for an entry of a dead row, the row tombstone. The collector buckets
-every reclaimable entry by the **age of that entry**, relative to a wall-clock anchor taken at
+A reclaimable entry can be removed by a compaction only once the write that makes it garbage is at
+or below the history cutoff (the compaction feed's overwrite-stack rule): the OLDEST such write --
+the entry's own successor version or a covering write, whichever is older -- and for a tombstone
+marker its own hybrid time. The collector buckets every reclaimable entry by the **age of that
+write**, relative to a wall-clock anchor taken at
 collector construction, into eight fixed bands whose edges fall on retention values in use (5 m,
 15 m, 1 h, 6 h, 24 h, 7 d, 30 d; the 15 m edge brackets the 900 s default). A consumer applying
 cutoff `C` sums the bands wholly older than `anchor - C`; the straddling band is excluded, so the
@@ -152,11 +162,12 @@ triggered compaction to `1 / threshold`.
 ## Cost
 
 The build path already walks doc-key components for every entry (the bloom-filter key transform).
-The tracker adds one word-wise shared-prefix compare against the previous key, a few counter
-increments, and, per shadowed or dead-row entry, one hybrid-time decode for the band. Per row: one
-`DocKey::EncodedSize` walk and two histogram increments. No allocation in steady state, no atomics,
-no floating point. The acceptance bar is end-to-end flush and compaction throughput with the flag on
-versus off.
+The tracker adds one word-wise shared-prefix compare against the previous key, one short
+encoded-hybrid-time compare against the row's covering writes (encoded order is time order, so no
+decode), a few counter increments, and, per garbage entry, one hybrid-time decode for the band.
+Per row: one `DocKey::EncodedSize` walk, up to a handful of covering-write decodes, and two
+histogram increments. No allocation in steady state, no atomics, no floating point. The acceptance
+bar is end-to-end flush and compaction throughput with the flag on versus off.
 
 ## Boundaries
 

--- a/src/yb/docdb/properties_collector/README.md
+++ b/src/yb/docdb/properties_collector/README.md
@@ -77,8 +77,10 @@ Recognized at scan time:
   row. A row re-inserted after a delete is live again, tombstone notwithstanding.
 - **reclaimable** = shadowed versions + record heads older than a covering write + tombstone
   markers themselves (a tombstone past the history cutoff drops at a full compaction whether or
-  not the row lives on). All the garbage, regardless of whether retention allows removing it yet,
-  counted once online.
+  not the row lives on) -- except a column tombstone over a packed row, which compactions may keep
+  unmerged (`docdb_keep_unmerged_column_tombstones_over_packed_row`; permanently, for columns that
+  never pack), so it is not counted and the statistic stays a lower bound. All the garbage,
+  regardless of whether retention allows removing it yet, counted once online.
 - **droppable** = the part of reclaimable already past the history cutoff a consumer applies. The
   compaction trigger uses droppable; the metric reports reclaimable.
 - A **stretch** is a maximal run of consecutive reclaimable entries in file order, ignoring key and

--- a/src/yb/docdb/properties_collector/chain_tracker-test.cc
+++ b/src/yb/docdb/properties_collector/chain_tracker-test.cc
@@ -1,0 +1,242 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/docdb/properties_collector/chain_tracker.h"
+
+#include "yb/docdb/properties_collector/chain_tracker_test_util.h"
+
+#include "yb/util/test_util.h"
+
+namespace yb::docdb {
+
+class ChainTrackerTest : public YBTest {};
+
+TEST_F(ChainTrackerTest, AnatomyStrip) {
+  const auto s = TrackerFixture().Add(AnatomyStrip()).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+
+  EXPECT_EQ(s.total_entries, 9);
+  EXPECT_EQ(s.chain_entries, 9);
+  EXPECT_EQ(s.meta_entries, 0);
+  EXPECT_EQ(s.tombstone_entries, 1);
+  EXPECT_EQ(s.packed_row_entries, 3);
+  // Subdoc keys: r1 packed, r1.a, r1.b, r2 tombstone, r2.a, r2.b.
+  EXPECT_EQ(s.num_subdoc_keys, 6);
+  EXPECT_EQ(s.num_rows, 2);
+  EXPECT_EQ(s.shadowed_entries(), 3);      // packed v2, packed v1, col a v1
+  EXPECT_EQ(s.repackable_entries(), 4);    // r1.a, r1.b, r2.a, r2.b (dead-row heads count too)
+  EXPECT_EQ(s.dead_rows, 1);
+  EXPECT_EQ(s.dead_row_entries, 3);
+  // Reclaimable = shadowed entries of live rows (3) + every entry of dead rows (3), no overlap.
+  EXPECT_EQ(s.reclaimable_entries, 6);
+  EXPECT_EQ(s.max_row_chain, 6);
+
+  // Row-chain histogram: one row of 6, one row of 3.
+  EXPECT_EQ(s.row_chain_hist.bucket(ExponentialHistogram::BucketIndex(6)), 1);
+  EXPECT_EQ(s.row_chain_hist.bucket(ExponentialHistogram::BucketIndex(3)), 1);
+  EXPECT_EQ(s.row_chain_hist.TotalWeight(), 2);
+
+  // Stretches of consecutive reclaimable entries in file order:
+  //   [packed v2, packed v1] = 2, [col a v1] = 1, [r2 tombstone, r2.a, r2.b] = 3.
+  EXPECT_EQ(s.stretch_hist.TotalWeight(), 3);
+  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(1)), 1);
+  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(2)), 1);
+  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(3)), 1);
+  EXPECT_EQ(s.max_stretch, 3);
+
+  // Age bands, by the age of what makes each entry droppable:
+  //   packed v2  -> its overwriter packed v3, 1 min old        -> band 0 (< 5 m)
+  //   packed v1  -> its overwriter packed v2, 20 min old       -> band 2 (15 m .. 1 h)
+  //   col a v1   -> its overwriter col a v2, 10 min old        -> band 1 (5 m .. 15 m)
+  //   r2 x 3     -> the row tombstone, 2 days old              -> band 5 (24 h .. 7 d)
+  const AgeBandCounts expected_bands = {1, 1, 1, 0, 0, 3, 0, 0};
+  EXPECT_EQ(s.droppable_age_entries, expected_bands);
+
+  // Write-time range spans the oldest (r2.b, 6 days) to the newest (1 minute) entry.
+  EXPECT_EQ(s.min_write_ht, AgeToHt(6 * kDay));
+  EXPECT_EQ(s.max_write_ht, AgeToHt(1 * kMinute));
+  EXPECT_EQ(s.anchor_micros, kAnchorMicros);
+}
+
+TEST_F(ChainTrackerTest, IdentitiesHoldOverChainEntriesWithMetaRecords) {
+  // Meta records are counted in total_entries but not in the chain population; the identities are
+  // stated over chain_entries and must survive meta records interleaved between rows.
+  auto entries = AnatomyStrip();
+  entries.insert(entries.begin() + 6, Entry{MetaKey(), "state"});
+  entries.push_back(Entry{MetaKey() + "2", "state"});
+  const auto s = TrackerFixture().Add(entries).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+  EXPECT_EQ(s.total_entries, 11);
+  EXPECT_EQ(s.meta_entries, 2);
+  EXPECT_EQ(s.chain_entries, 9);
+  EXPECT_EQ(s.num_rows, 2);
+  EXPECT_EQ(s.reclaimable_entries, 6);
+  // A meta record between two rows does not create a phantom row or join two stretches.
+  EXPECT_EQ(s.row_chain_hist.TotalWeight(), 2);
+  EXPECT_EQ(s.stretch_hist.TotalWeight(), 3);
+}
+
+TEST_F(ChainTrackerTest, EmptyFileAndFinishIdempotence) {
+  TrackerFixture empty;
+  const auto& s = empty.Finish();
+  EXPECT_EQ(s.total_entries, 0);
+  EXPECT_EQ(s.num_rows, 0);
+  EXPECT_TRUE(s.row_chain_hist.Empty());
+  EXPECT_TRUE(s.stretch_hist.Empty());
+  EXPECT_TRUE(s.chain_valid);
+  EXPECT_FALSE(s.min_write_ht.is_valid());
+
+  TrackerFixture fixture;
+  fixture.Add(AnatomyStrip());
+  const auto first = fixture.Finish();
+  const auto& second = fixture.Finish();
+  EXPECT_EQ(first.num_rows, second.num_rows);
+  EXPECT_EQ(first.row_chain_hist, second.row_chain_hist);
+  EXPECT_EQ(first.stretch_hist, second.stretch_hist);
+  EXPECT_EQ(first.dead_row_entries, second.dead_row_entries);
+}
+
+TEST_F(ChainTrackerTest, OnlyMetaRecords) {
+  const auto s = TrackerFixture()
+      .Add({{MetaKey(), "a"}, {MetaKey() + "1", "b"}, {MetaKey() + "2", "c"}}).Finish();
+  EXPECT_EQ(s.total_entries, 3);
+  EXPECT_EQ(s.meta_entries, 3);
+  EXPECT_EQ(s.chain_entries, 0);
+  EXPECT_EQ(s.num_rows, 0);
+  EXPECT_TRUE(s.row_chain_hist.Empty());
+  EXPECT_TRUE(s.chain_valid);
+}
+
+TEST_F(ChainTrackerTest, LongStretchOfDeadRows) {
+  // A drained queue: 100 deleted rows, each a tombstone plus two columns. Every row chain is short
+  // (3), but a cursor entering this range steps over 300 entries: one stretch of 300.
+  std::vector<Entry> entries;
+  for (int32_t id = 0; id < 100; ++id) {
+    const auto row = Row(id);
+    entries.push_back({RowKey(row, 1 * kDay), Tombstone()});
+    entries.push_back({ColumnKey(row, 1, 2 * kDay), Str("a")});
+    entries.push_back({ColumnKey(row, 2, 2 * kDay), Str("b")});
+  }
+  const auto s = TrackerFixture().Add(entries).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+  EXPECT_EQ(s.num_rows, 100);
+  EXPECT_EQ(s.dead_rows, 100);
+  EXPECT_EQ(s.dead_row_entries, 300);
+  EXPECT_EQ(s.reclaimable_entries, 300);
+  EXPECT_EQ(s.max_row_chain, 3);
+  EXPECT_EQ(s.max_stretch, 300);
+  EXPECT_EQ(s.stretch_hist.TotalWeight(), 1);
+  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(300)), 1);
+  // All droppable once the 1-day-old tombstones are; an age of exactly 24 h is the lower edge of
+  // band 5 (24 h .. 7 d).
+  EXPECT_EQ(s.droppable_age_entries[5], 300);
+}
+
+TEST_F(ChainTrackerTest, EveryOtherRowDeletedHasShortStretches) {
+  // Half the rows deleted, interleaved with live rows: high reclaimable total, short stretches.
+  std::vector<Entry> entries;
+  for (int32_t id = 0; id < 100; ++id) {
+    const auto row = Row(id);
+    if (id % 2 == 0) {
+      entries.push_back({RowKey(row, 1 * kDay), Tombstone()});
+      entries.push_back({ColumnKey(row, 1, 2 * kDay), Str("a")});
+    } else {
+      entries.push_back({RowKey(row, 1 * kDay), PackedRow("live")});
+    }
+  }
+  const auto s = TrackerFixture().Add(entries).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+  EXPECT_EQ(s.num_rows, 100);
+  EXPECT_EQ(s.dead_rows, 50);
+  EXPECT_EQ(s.reclaimable_entries, 100);
+  EXPECT_EQ(s.chain_entries, 150);
+  EXPECT_EQ(s.max_stretch, 2);
+  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(2)), 50);
+}
+
+TEST_F(ChainTrackerTest, TableTombstoneAndCoprefixSubtotals) {
+  const ColocationId dropped = 16385;
+  const ColocationId live = 16386;
+  // Colocated tablet: table `dropped` has a table-level tombstone (empty DocKey under the
+  // colocation id) followed by two of its rows; table `live` has one row with a shadowed version.
+  std::vector<Entry> entries = {
+      {dockv::SubDocKey(dockv::DocKey(dropped), AgeToHt(1 * kHour)).Encode().ToStringBuffer(),
+       Tombstone()},
+      {RowKey(ColocatedRow(dropped, 1), 2 * kHour), PackedRow("x")},
+      {RowKey(ColocatedRow(dropped, 2), 2 * kHour), PackedRow("y")},
+      {RowKey(ColocatedRow(live, 1), 1 * kMinute), PackedRow("new")},
+      {RowKey(ColocatedRow(live, 1), 1 * kHour), PackedRow("old")},
+  };
+  const auto s = TrackerFixture(/* subtotals = */ true).Add(entries).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+  // The table tombstone is the head of its own one-entry dead row. The dropped table's rows are
+  // separate rows here (the collector does not apply the tombstone to them; the compaction feed
+  // does), so they read as live single-entry rows.
+  EXPECT_EQ(s.num_rows, 4);
+  EXPECT_EQ(s.dead_rows, 1);
+  EXPECT_EQ(s.dead_row_entries, 1);
+  EXPECT_EQ(s.tombstone_entries, 1);
+  EXPECT_EQ(s.shadowed_entries(), 1);
+  EXPECT_EQ(s.reclaimable_entries, 2);
+
+  ASSERT_EQ(s.coprefix_subtotals.size(), 2);
+  const auto dropped_prefix = dockv::DocKey(dropped).Encode().ToStringBuffer();
+  const auto live_prefix = dockv::DocKey(live).Encode().ToStringBuffer();
+  // DocKey(colocation_id).Encode() ends with a kGroupEnd; the coprefix is the part before it.
+  const auto& dropped_sub =
+      s.coprefix_subtotals.at(dropped_prefix.substr(0, dropped_prefix.size() - 1));
+  EXPECT_EQ(dropped_sub.rows, 3);
+  EXPECT_EQ(dropped_sub.entries, 3);
+  EXPECT_EQ(dropped_sub.tombstone_entries, 1);
+  EXPECT_EQ(dropped_sub.reclaimable_entries, 1);
+  const auto& live_sub = s.coprefix_subtotals.at(live_prefix.substr(0, live_prefix.size() - 1));
+  EXPECT_EQ(live_sub.rows, 1);
+  EXPECT_EQ(live_sub.entries, 2);
+  EXPECT_EQ(live_sub.tombstone_entries, 0);
+  EXPECT_EQ(live_sub.reclaimable_entries, 1);
+}
+
+TEST_F(ChainTrackerTest, CorruptKeyInvalidatesChainStatsOnly) {
+  auto entries = AnatomyStrip();
+  // A key with no room for a hybrid time.
+  entries.insert(entries.begin() + 3, Entry{std::string(1, dockv::KeyEntryTypeAsChar::kString),
+                                            Tombstone()});
+  const auto s = TrackerFixture().Add(entries).Finish();
+  EXPECT_FALSE(s.chain_valid);
+  // The v1 counters keep counting every entry.
+  EXPECT_EQ(s.total_entries, 10);
+  EXPECT_EQ(s.tombstone_entries, 2);
+}
+
+TEST_F(ChainTrackerTest, MergeAcrossFilesIsExactForDisjointRows) {
+  // Two files holding disjoint rows: the merged histograms equal the histograms of one file
+  // holding all the entries.
+  const auto all = AnatomyStrip();
+  const std::vector<Entry> first(all.begin(), all.begin() + 6);   // r1
+  const std::vector<Entry> second(all.begin() + 6, all.end());    // r2
+  const auto a = TrackerFixture().Add(first).Finish();
+  const auto b = TrackerFixture().Add(second).Finish();
+  const auto both = TrackerFixture().Add(all).Finish();
+
+  auto merged_rows = a.row_chain_hist;
+  merged_rows.Merge(b.row_chain_hist);
+  EXPECT_EQ(merged_rows, both.row_chain_hist);
+  auto merged_stretch = a.stretch_hist;
+  merged_stretch.Merge(b.stretch_hist);
+  EXPECT_EQ(merged_stretch, both.stretch_hist);
+  EXPECT_EQ(a.reclaimable_entries + b.reclaimable_entries, both.reclaimable_entries);
+  EXPECT_EQ(a.chain_entries - a.num_rows + b.chain_entries - b.num_rows,
+            both.collapsible_entries());
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/chain_tracker-test.cc
+++ b/src/yb/docdb/properties_collector/chain_tracker-test.cc
@@ -206,6 +206,13 @@ TEST_F(ChainTrackerTest, TableTombstoneAndCoprefixSubtotals) {
   EXPECT_EQ(live_sub.reclaimable_entries, 1);
 }
 
+TEST_F(ChainTrackerTest, PlainTableRecordsNoCoprefixSubtotals) {
+  // Rows without a cotable / colocation prefix must not produce a subtotal under the empty
+  // coprefix, even with subtotal tracking enabled.
+  const auto s = TrackerFixture(/* subtotals = */ true).Add(AnatomyStrip()).Finish();
+  EXPECT_TRUE(s.coprefix_subtotals.empty());
+}
+
 TEST_F(ChainTrackerTest, CorruptKeyInvalidatesChainStatsOnly) {
   auto entries = AnatomyStrip();
   // A key with no room for a hybrid time.

--- a/src/yb/docdb/properties_collector/chain_tracker-test.cc
+++ b/src/yb/docdb/properties_collector/chain_tracker-test.cc
@@ -34,11 +34,13 @@ TEST_F(ChainTrackerTest, AnatomyStrip) {
   EXPECT_EQ(s.num_subdoc_keys, 6);
   EXPECT_EQ(s.num_rows, 2);
   EXPECT_EQ(s.shadowed_entries(), 3);      // packed v2, packed v1, col a v1
-  EXPECT_EQ(s.repackable_entries(), 4);    // r1.a, r1.b, r2.a, r2.b (dead-row heads count too)
+  EXPECT_EQ(s.repackable_entries(), 4);    // r1.a, r1.b, r2.a, r2.b (an identity over heads)
   EXPECT_EQ(s.dead_rows, 1);
   EXPECT_EQ(s.dead_row_entries, 3);
-  // Reclaimable = shadowed entries of live rows (3) + every entry of dead rows (3), no overlap.
-  EXPECT_EQ(s.reclaimable_entries, 6);
+  // Reclaimable = the 3 shadowed versions + col a v2 (10 min old, covered by the packed write at
+  // 1 min) + all 3 entries of the dead row r2. col b v1 shares packed v3's hybrid time, so no
+  // covering write is newer than it: live.
+  EXPECT_EQ(s.reclaimable_entries, 7);
   EXPECT_EQ(s.max_row_chain, 6);
 
   // Row-chain histogram: one row of 6, one row of 3.
@@ -47,19 +49,20 @@ TEST_F(ChainTrackerTest, AnatomyStrip) {
   EXPECT_EQ(s.row_chain_hist.TotalWeight(), 2);
 
   // Stretches of consecutive reclaimable entries in file order:
-  //   [packed v2, packed v1] = 2, [col a v1] = 1, [r2 tombstone, r2.a, r2.b] = 3.
-  EXPECT_EQ(s.stretch_hist.TotalWeight(), 3);
-  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(1)), 1);
-  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(2)), 1);
+  //   [packed v2, packed v1, col a v2, col a v1] = 4, [r2 tombstone, r2.a, r2.b] = 3.
+  EXPECT_EQ(s.stretch_hist.TotalWeight(), 2);
+  EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(4)), 1);
   EXPECT_EQ(s.stretch_hist.bucket(ExponentialHistogram::BucketIndex(3)), 1);
-  EXPECT_EQ(s.max_stretch, 3);
+  EXPECT_EQ(s.max_stretch, 4);
 
-  // Age bands, by the age of what makes each entry droppable:
-  //   packed v2  -> its overwriter packed v3, 1 min old        -> band 0 (< 5 m)
-  //   packed v1  -> its overwriter packed v2, 20 min old       -> band 2 (15 m .. 1 h)
-  //   col a v1   -> its overwriter col a v2, 10 min old        -> band 1 (5 m .. 15 m)
-  //   r2 x 3     -> the row tombstone, 2 days old              -> band 5 (24 h .. 7 d)
-  const AgeBandCounts expected_bands = {1, 1, 1, 0, 0, 3, 0, 0};
+  // Age bands, by the age of the OLDEST write whose passing of the cutoff makes the entry
+  // droppable:
+  //   packed v2  -> packed v3, 1 min old                          -> band 0 (< 5 m)
+  //   packed v1  -> packed v2, 20 min old                         -> band 2 (15 m .. 1 h)
+  //   col a v2   -> the covering packed v3, 1 min old             -> band 0
+  //   col a v1   -> min(col a v2 @ 10 min, covering packed v1 @ 2 h): the older wins -> band 3
+  //   r2 x 3     -> the row tombstone, 2 days old                 -> band 5 (24 h .. 7 d)
+  const AgeBandCounts expected_bands = {2, 0, 1, 1, 0, 3, 0, 0};
   EXPECT_EQ(s.droppable_age_entries, expected_bands);
 
   // Write-time range spans the oldest (r2.b, 6 days) to the newest (1 minute) entry.
@@ -80,10 +83,10 @@ TEST_F(ChainTrackerTest, IdentitiesHoldOverChainEntriesWithMetaRecords) {
   EXPECT_EQ(s.meta_entries, 2);
   EXPECT_EQ(s.chain_entries, 9);
   EXPECT_EQ(s.num_rows, 2);
-  EXPECT_EQ(s.reclaimable_entries, 6);
+  EXPECT_EQ(s.reclaimable_entries, 7);
   // A meta record between two rows does not create a phantom row or join two stretches.
   EXPECT_EQ(s.row_chain_hist.TotalWeight(), 2);
-  EXPECT_EQ(s.stretch_hist.TotalWeight(), 3);
+  EXPECT_EQ(s.stretch_hist.TotalWeight(), 2);
 }
 
 TEST_F(ChainTrackerTest, EmptyFileAndFinishIdempotence) {
@@ -204,6 +207,62 @@ TEST_F(ChainTrackerTest, TableTombstoneAndCoprefixSubtotals) {
   EXPECT_EQ(live_sub.entries, 2);
   EXPECT_EQ(live_sub.tombstone_entries, 0);
   EXPECT_EQ(live_sub.reclaimable_entries, 1);
+}
+
+TEST_F(ChainTrackerTest, PackedRowCoversOlderColumns) {
+  // A packed (whole-row) write covers every older entry of the row, including record heads the
+  // key comparison alone would call live: col2, written before the packed row, is garbage; col1,
+  // written after it, is live.
+  const auto row = Row(1);
+  const auto s = TrackerFixture().Add({
+      {RowKey(row, 10 * kMinute), PackedRow("v")},
+      {ColumnKey(row, 1, 5 * kMinute), Str("newer than packed: live")},
+      {ColumnKey(row, 2, 20 * kMinute), Str("older than packed: covered")},
+  }).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+  EXPECT_EQ(s.chain_entries, 3);
+  EXPECT_EQ(s.num_subdoc_keys, 3);
+  EXPECT_EQ(s.num_rows, 1);
+  EXPECT_EQ(s.shadowed_entries(), 0);
+  EXPECT_EQ(s.dead_rows, 0);
+  EXPECT_EQ(s.reclaimable_entries, 1);
+  // col2 becomes droppable when the packed write (10 min old) passes the cutoff: band 1.
+  EXPECT_EQ(s.droppable_age_entries[1], 1);
+  EXPECT_EQ(s.max_stretch, 1);
+}
+
+TEST_F(ChainTrackerTest, RowResurrectedAfterDelete) {
+  // A column written after a row tombstone brings the row back to life: the column is live data,
+  // the row is not dead. The tombstone marker itself stays reclaimable (it drops at a full
+  // compaction once its own hybrid time passes the cutoff, resurrection or not).
+  const auto row = Row(1);
+  const auto s = TrackerFixture().Add({
+      {RowKey(row, 2 * kHour), Tombstone()},
+      {ColumnKey(row, 1, 10 * kMinute), Str("written after the delete: live")},
+  }).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+  EXPECT_EQ(s.chain_entries, 2);
+  EXPECT_EQ(s.tombstone_entries, 1);
+  EXPECT_EQ(s.dead_rows, 0);
+  EXPECT_EQ(s.dead_row_entries, 0);
+  EXPECT_EQ(s.reclaimable_entries, 1);       // the marker only, by its own age (2 h: band 3)
+  EXPECT_EQ(s.droppable_age_entries[3], 1);
+  EXPECT_EQ(s.max_stretch, 1);
+}
+
+TEST_F(ChainTrackerTest, ColumnTombstoneHeadIsReclaimable) {
+  // A column-level delete marker that nothing covers still drops at a full compaction once past
+  // the cutoff; it does not make the row dead.
+  const auto row = Row(1);
+  const auto s = TrackerFixture().Add({
+      {RowKey(row, 10 * kMinute), PackedRow("v")},
+      {ColumnKey(row, 1, 2 * kMinute), Tombstone()},
+  }).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+  EXPECT_EQ(s.tombstone_entries, 1);
+  EXPECT_EQ(s.dead_rows, 0);
+  EXPECT_EQ(s.reclaimable_entries, 1);       // the column marker, by its own age (2 min: band 0)
+  EXPECT_EQ(s.droppable_age_entries[0], 1);
 }
 
 TEST_F(ChainTrackerTest, PlainTableRecordsNoCoprefixSubtotals) {

--- a/src/yb/docdb/properties_collector/chain_tracker-test.cc
+++ b/src/yb/docdb/properties_collector/chain_tracker-test.cc
@@ -250,13 +250,28 @@ TEST_F(ChainTrackerTest, RowResurrectedAfterDelete) {
   EXPECT_EQ(s.max_stretch, 1);
 }
 
-TEST_F(ChainTrackerTest, ColumnTombstoneHeadIsReclaimable) {
-  // A column-level delete marker that nothing covers still drops at a full compaction once past
-  // the cutoff; it does not make the row dead.
+TEST_F(ChainTrackerTest, ColumnTombstoneOverPackedRowIsNotCounted) {
+  // A column tombstone over a packed row may be kept unmerged by compactions
+  // (docdb_keep_unmerged_column_tombstones_over_packed_row; permanently for columns that never
+  // pack), so it is not counted reclaimable: the statistic stays a lower bound.
   const auto row = Row(1);
   const auto s = TrackerFixture().Add({
       {RowKey(row, 10 * kMinute), PackedRow("v")},
       {ColumnKey(row, 1, 2 * kMinute), Tombstone()},
+  }).Finish();
+  ASSERT_NO_FATALS(ExpectIdentities(s));
+  EXPECT_EQ(s.tombstone_entries, 1);
+  EXPECT_EQ(s.dead_rows, 0);
+  EXPECT_EQ(s.reclaimable_entries, 0);
+}
+
+TEST_F(ChainTrackerTest, ColumnTombstoneWithoutPackedRowIsReclaimable) {
+  // With no packed row under it, a column marker past the cutoff drops at a full compaction; it
+  // does not make the row dead.
+  const auto row = Row(1);
+  const auto s = TrackerFixture().Add({
+      {ColumnKey(row, 1, 2 * kMinute), Tombstone()},
+      {ColumnKey(row, 2, 1 * kMinute), Str("live")},
   }).Finish();
   ASSERT_NO_FATALS(ExpectIdentities(s));
   EXPECT_EQ(s.tombstone_entries, 1);

--- a/src/yb/docdb/properties_collector/chain_tracker-test.cc
+++ b/src/yb/docdb/properties_collector/chain_tracker-test.cc
@@ -48,6 +48,16 @@ TEST_F(ChainTrackerTest, AnatomyStrip) {
   EXPECT_EQ(s.row_chain_hist.bucket(ExponentialHistogram::BucketIndex(3)), 1);
   EXPECT_EQ(s.row_chain_hist.TotalWeight(), 2);
 
+  // The byte-weighted twin buckets by the same LENGTH, weighted by the row's bytes -- it is not a
+  // distribution of row sizes. Pin both the bucket index and the weight.
+  const auto strip = AnatomyStrip();
+  uint64_t r1_bytes = 0, r2_bytes = 0;
+  for (size_t i = 0; i < strip.size(); ++i) {
+    (i < 6 ? r1_bytes : r2_bytes) += strip[i].key.size() + strip[i].value.size();
+  }
+  EXPECT_EQ(s.row_chain_bytes_hist.bucket(ExponentialHistogram::BucketIndex(6)), r1_bytes);
+  EXPECT_EQ(s.row_chain_bytes_hist.bucket(ExponentialHistogram::BucketIndex(3)), r2_bytes);
+
   // Stretches of consecutive reclaimable entries in file order:
   //   [packed v2, packed v1, col a v2, col a v1] = 4, [r2 tombstone, r2.a, r2.b] = 3.
   EXPECT_EQ(s.stretch_hist.TotalWeight(), 2);

--- a/src/yb/docdb/properties_collector/chain_tracker.cc
+++ b/src/yb/docdb/properties_collector/chain_tracker.cc
@@ -155,10 +155,14 @@ void ChainTracker::Add(Slice key, Slice value) {
       reclaimable = true;
       droppable_by_micros = row_tombstone_micros_;
     }
-    if (track_coprefix_subtotals_) {
+    if (track_coprefix_subtotals_ && ends->coprefix_end > 0) {
+      // Subtotals are per cotable / colocation prefix; a plain (non-colocated) table has no
+      // coprefix and records none, so single-table tablets never carry a redundant subtotal.
       row_subtotal_ =
           &stats_.coprefix_subtotals[std::string(subdoc_key.cdata(), ends->coprefix_end)];
       ++row_subtotal_->rows;
+    } else {
+      row_subtotal_ = nullptr;
     }
   }
 

--- a/src/yb/docdb/properties_collector/chain_tracker.cc
+++ b/src/yb/docdb/properties_collector/chain_tracker.cc
@@ -1,0 +1,304 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/docdb/properties_collector/chain_tracker.h"
+
+#include <algorithm>
+
+#include "yb/dockv/doc_key.h"
+#include "yb/dockv/value.h"
+#include "yb/dockv/value_type.h"
+
+#include "yb/gutil/strings/fastmem.h"
+
+#include "yb/util/status_format.h"
+
+namespace yb::docdb {
+
+size_t AgeBands::BandIndex(int64_t age_micros) {
+  size_t band = 0;
+  while (band < kEdgesMicros.size() && age_micros >= kEdgesMicros[band]) {
+    ++band;
+  }
+  return band;
+}
+
+ChainTracker::ChainTracker(int64_t anchor_micros, bool track_coprefix_subtotals)
+    : track_coprefix_subtotals_(track_coprefix_subtotals) {
+  stats_.anchor_micros = anchor_micros;
+}
+
+// Per entry:
+//   1. Classify the value: skip the control-fields prefix, then one byte says tombstone / packed
+//      row / other. Values that do not follow the DocDB encoding count in total_entries only.
+//   2. Meta records are counted in meta_entries, close the open row and stretch, and are otherwise
+//      ignored; the identities are stated over chain_entries for this reason.
+//   3. Strip the hybrid time to get the subdoc key; track the encoded-HT extremes.
+//   4. Compare with the previous subdoc key by shared-prefix length:
+//        identical              -> a shadowed version; its overwriter is the previous entry.
+//        shares the row key     -> a new subdoc chain in the same row; reclaimable iff row is dead.
+//        otherwise              -> a new row: close the previous one, compute the row key length
+//                                  once, decide whether the row is dead (head is a tombstone whose
+//                                  subdoc key is exactly the row key).
+//   5. A reclaimable entry extends the current stretch and lands in the age band of what makes it
+//      droppable; a non-reclaimable entry closes the stretch.
+void ChainTracker::Add(Slice key, Slice value) {
+  ++stats_.total_entries;
+  const size_t entry_bytes = key.size() + value.size();
+
+  // Value kind. A DocDB delete is a Put whose payload is a kTombstone marker, optionally preceded
+  // by control fields (merge flags, intent doc hybrid time, TTL, user timestamp).
+  bool is_tombstone = false;
+  {
+    Slice value_slice = value;
+    Slice intent_doc_ht;
+    const auto control_fields =
+        dockv::ValueControlFields::DecodeWithIntentDocHt(&value_slice, &intent_doc_ht);
+    if (control_fields.ok()) {
+      const auto value_type = dockv::DecodeValueEntryType(value_slice);
+      if (value_type == dockv::ValueEntryType::kTombstone) {
+        is_tombstone = true;
+        ++stats_.tombstone_entries;
+      } else if (dockv::IsPackedRow(value_type)) {
+        ++stats_.packed_row_entries;
+      }
+    }
+    // Records that do not follow the DocDB value encoding are counted in total_entries only.
+  }
+
+  // Meta records (transaction apply state, vector index metadata) are not part of any chain.
+  if (key.empty() || dockv::IsRegularDBMetaKeyType(dockv::DecodeKeyEntryType(key)) ||
+      dockv::DecodeKeyEntryType(key) == dockv::KeyEntryType::kObsoleteIntentPrefix) {
+    OnMetaEntry();
+    return;
+  }
+  if (!stats_.chain_valid) {
+    return;
+  }
+
+  ++stats_.chain_entries;
+  stats_.chain_bytes += entry_bytes;
+
+  // Strip the hybrid time: its size is in the low bits of the last byte, and it is preceded by a
+  // kHybridTime marker byte.
+  const auto ht_size = DocHybridTime::GetEncodedSize(key);
+  if (!ht_size.ok() || key.size() < *ht_size + 2) {
+    Invalidate();
+    return;
+  }
+  const size_t subdoc_key_end = key.size() - *ht_size - 1;
+  const Slice subdoc_key(key.data(), subdoc_key_end);
+  EncodedDocHybridTime encoded_ht(key.Suffix(*ht_size));
+  UpdateWriteHtRange(encoded_ht);
+
+  // Chain boundary detection: the length of the prefix shared with the previous subdoc key.
+  const size_t compare_len = std::min(subdoc_key_end, prev_key_.size());
+  const size_t shared_prefix =
+      has_prev_ ? strings::MemoryDifferencePos(key.data(), prev_key_.data(), compare_len) : 0;
+
+  bool reclaimable = false;
+  int64_t droppable_by_micros = 0;
+  if (has_prev_ && subdoc_key_end == prev_key_.size() && shared_prefix >= subdoc_key_end) {
+    // Same subdoc key as the previous (newer) entry: this version is shadowed. It becomes droppable
+    // once the entry that shadows it is past the history cutoff.
+    ++row_entries_;
+    row_bytes_ += entry_bytes;
+    reclaimable = true;
+    const auto overwriter_micros = PhysicalMicros(prev_entry_ht_);
+    if (!overwriter_micros.ok()) {
+      Invalidate();
+      return;
+    }
+    droppable_by_micros = *overwriter_micros;
+  } else if (has_prev_ && shared_prefix >= row_end_) {
+    // Same row, new subdoc key: a live head (of a column or record) in this row.
+    ++stats_.num_subdoc_keys;
+    ++row_entries_;
+    row_bytes_ += entry_bytes;
+    if (row_dead_) {
+      // Under a row tombstone every entry goes when the tombstone does.
+      reclaimable = true;
+      droppable_by_micros = row_tombstone_micros_;
+    }
+  } else {
+    // New row.
+    CloseRow();
+    const auto ends = ComputeRowKeyEnds(subdoc_key);
+    if (!ends.ok()) {
+      Invalidate();
+      return;
+    }
+    row_end_ = ends->row_end;
+    ++stats_.num_rows;
+    ++stats_.num_subdoc_keys;
+    row_entries_ = 1;
+    row_bytes_ = entry_bytes;
+    // A dead row: its chain head is a row-level (or table-level) tombstone.
+    row_dead_ = subdoc_key_end == row_end_ && is_tombstone;
+    if (row_dead_) {
+      const auto tombstone_micros = PhysicalMicros(encoded_ht);
+      if (!tombstone_micros.ok()) {
+        Invalidate();
+        return;
+      }
+      row_tombstone_micros_ = *tombstone_micros;
+      reclaimable = true;
+      droppable_by_micros = row_tombstone_micros_;
+    }
+    if (track_coprefix_subtotals_) {
+      row_subtotal_ =
+          &stats_.coprefix_subtotals[std::string(subdoc_key.cdata(), ends->coprefix_end)];
+      ++row_subtotal_->rows;
+    }
+  }
+
+  if (reclaimable) {
+    AddReclaimable(entry_bytes, droppable_by_micros);
+  } else {
+    CloseStretch();
+  }
+  if (row_subtotal_ != nullptr) {
+    ++row_subtotal_->entries;
+    row_subtotal_->tombstone_entries += is_tombstone ? 1 : 0;
+    row_subtotal_->reclaimable_entries += reclaimable ? 1 : 0;
+  }
+
+  AssignPrevKey(subdoc_key, shared_prefix);
+  prev_entry_ht_ = encoded_ht;
+  has_prev_ = true;
+}
+
+const SstStats& ChainTracker::Finish() {
+  if (!finished_) {
+    CloseRow();
+    CloseStretch();
+    if (!min_encoded_ht_.empty()) {
+      auto min_ht = min_encoded_ht_.Decode();
+      auto max_ht = max_encoded_ht_.Decode();
+      if (min_ht.ok() && max_ht.ok()) {
+        stats_.min_write_ht = min_ht->hybrid_time();
+        stats_.max_write_ht = max_ht->hybrid_time();
+      } else {
+        Invalidate();
+      }
+    }
+    finished_ = true;
+  }
+  return stats_;
+}
+
+void ChainTracker::OnMetaEntry() {
+  ++stats_.meta_entries;
+  // A meta record separates chains and stretches but belongs to neither.
+  CloseRow();
+  CloseStretch();
+  has_prev_ = false;
+  row_subtotal_ = nullptr;
+}
+
+void ChainTracker::CloseRow() {
+  // Explicit no-op when no row is open (first entry, consecutive meta records, empty file), so the
+  // histograms never acquire phantom rows.
+  if (row_entries_ == 0) {
+    return;
+  }
+  stats_.row_chain_hist.Add(row_entries_);
+  stats_.row_chain_bytes_hist.Add(row_bytes_);
+  stats_.max_row_chain = std::max(stats_.max_row_chain, row_entries_);
+  if (row_dead_) {
+    ++stats_.dead_rows;
+    stats_.dead_row_entries += row_entries_;
+  }
+  row_entries_ = 0;
+  row_bytes_ = 0;
+  row_dead_ = false;
+}
+
+void ChainTracker::CloseStretch() {
+  if (stretch_entries_ == 0) {
+    return;
+  }
+  stats_.stretch_hist.Add(stretch_entries_);
+  stats_.stretch_entries_hist.Add(stretch_entries_, stretch_entries_);
+  stats_.stretch_bytes_hist.Add(stretch_entries_, stretch_bytes_);
+  stats_.max_stretch = std::max(stats_.max_stretch, stretch_entries_);
+  stretch_entries_ = 0;
+  stretch_bytes_ = 0;
+}
+
+void ChainTracker::Invalidate() {
+  stats_.chain_valid = false;
+  has_prev_ = false;
+  row_entries_ = 0;
+  row_bytes_ = 0;
+  row_dead_ = false;
+  stretch_entries_ = 0;
+  stretch_bytes_ = 0;
+  row_subtotal_ = nullptr;
+}
+
+void ChainTracker::AssignPrevKey(Slice subdoc_key, size_t shared_prefix) {
+  // Only the suffix past the shared prefix changed; copy just that.
+  const size_t keep = std::min(shared_prefix, prev_key_.size());
+  prev_key_.resize(subdoc_key.size());
+  if (subdoc_key.size() > keep) {
+    memcpy(prev_key_.data() + keep, subdoc_key.data() + keep, subdoc_key.size() - keep);
+  }
+}
+
+void ChainTracker::AddReclaimable(size_t entry_bytes, int64_t droppable_by_micros) {
+  ++stats_.reclaimable_entries;
+  stats_.reclaimable_bytes += entry_bytes;
+  const size_t band = AgeBands::BandIndex(stats_.anchor_micros - droppable_by_micros);
+  ++stats_.droppable_age_entries[band];
+  stats_.droppable_age_bytes[band] += entry_bytes;
+  ++stretch_entries_;
+  stretch_bytes_ += entry_bytes;
+}
+
+void ChainTracker::UpdateWriteHtRange(const EncodedDocHybridTime& encoded_ht) {
+  // EncodedDocHybridTime orders by the time it encodes (the byte order is reversed internally).
+  if (min_encoded_ht_.empty() || encoded_ht < min_encoded_ht_) {
+    min_encoded_ht_ = encoded_ht;
+  }
+  if (max_encoded_ht_.empty() || encoded_ht > max_encoded_ht_) {
+    max_encoded_ht_ = encoded_ht;
+  }
+}
+
+Result<int64_t> ChainTracker::PhysicalMicros(const EncodedDocHybridTime& encoded_ht) {
+  const auto doc_ht = VERIFY_RESULT(encoded_ht.Decode());
+  return static_cast<int64_t>(doc_ht.hybrid_time().GetPhysicalValueMicros());
+}
+
+Result<ChainTracker::RowKeyEnds> ChainTracker::ComputeRowKeyEnds(Slice subdoc_key) {
+  // Mirrors the first call of SubDocKey::DecodeDocKeyAndSubKeyEnds, including the table-tombstone
+  // form (cotable/colocation id followed directly by kGroupEnd: an empty DocKey).
+  const auto id_size =
+      VERIFY_RESULT(dockv::DocKey::EncodedSize(subdoc_key, dockv::DocKeyPart::kUpToId));
+  SCHECK_GT(subdoc_key.size(), id_size, Corruption,
+            Format("Cannot have exclusively ID in key $0", subdoc_key.ToDebugHexString()));
+  const char first = subdoc_key[0];
+  if ((first == dockv::KeyEntryTypeAsChar::kColocationId ||
+       first == dockv::KeyEntryTypeAsChar::kTableId) &&
+      subdoc_key[id_size] == dockv::KeyEntryTypeAsChar::kGroupEnd) {
+    // Table tombstone: the row key is the coprefix plus the group end, so that the tombstone entry
+    // itself is the head of its own (dead) row.
+    return RowKeyEnds{.coprefix_end = id_size, .row_end = id_size + 1};
+  }
+  const auto doc_key_size = VERIFY_RESULT(dockv::DocKey::EncodedSize(
+      subdoc_key.WithoutPrefix(id_size), dockv::DocKeyPart::kWholeDocKey));
+  return RowKeyEnds{.coprefix_end = id_size, .row_end = id_size + doc_key_size};
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/chain_tracker.cc
+++ b/src/yb/docdb/properties_collector/chain_tracker.cc
@@ -45,13 +45,21 @@ ChainTracker::ChainTracker(int64_t anchor_micros, bool track_coprefix_subtotals)
 //      ignored; the identities are stated over chain_entries for this reason.
 //   3. Strip the hybrid time to get the subdoc key; track the encoded-HT extremes.
 //   4. Compare with the previous subdoc key by shared-prefix length:
-//        identical              -> a shadowed version; its overwriter is the previous entry.
-//        shares the row key     -> a new subdoc chain in the same row; reclaimable iff row is dead.
+//        identical              -> a shadowed version; garbage.
+//        shares the row key     -> a new record (subdoc chain) in the same row.
 //        otherwise              -> a new row: close the previous one, compute the row key length
-//                                  once, decide whether the row is dead (head is a tombstone whose
-//                                  subdoc key is exactly the row key).
-//   5. A reclaimable entry extends the current stretch and lands in the age band of what makes it
-//      droppable; a non-reclaimable entry closes the stretch.
+//                                  once.
+//   5. Entries at the row key itself (packed rows, row tombstones) are covering writes: they
+//      overwrite the whole row, so any entry of the row with an older hybrid time is garbage even
+//      if it is the newest version of its own record. Note file order is key order, not time
+//      order: a covering write is newer than some entries after it and older than others, so each
+//      record head is compared (encoded hybrid times, a short memcmp) against the covering writes
+//      seen so far -- which is all of them, because the row key sorts first in the row.
+//   6. Garbage is therefore: shadowed versions, record heads older than a covering write, and
+//      tombstone markers themselves (a tombstone past the history cutoff drops at a full
+//      compaction regardless). Each lands in the age band of the OLDEST write whose passing of
+//      the cutoff makes it droppable (its own hybrid time, for a marker), and extends the current
+//      stretch; a non-garbage entry closes the stretch.
 void ChainTracker::Add(Slice key, Slice value) {
   ++stats_.total_entries;
   const size_t entry_bytes = key.size() + value.size();
@@ -106,30 +114,17 @@ void ChainTracker::Add(Slice key, Slice value) {
   const size_t shared_prefix =
       has_prev_ ? strings::MemoryDifferencePos(key.data(), prev_key_.data(), compare_len) : 0;
 
-  bool reclaimable = false;
-  int64_t droppable_by_micros = 0;
+  bool is_head = true;
   if (has_prev_ && subdoc_key_end == prev_key_.size() && shared_prefix >= subdoc_key_end) {
-    // Same subdoc key as the previous (newer) entry: this version is shadowed. It becomes droppable
-    // once the entry that shadows it is past the history cutoff.
+    // Same subdoc key as the previous (newer) entry: this version is shadowed.
+    is_head = false;
     ++row_entries_;
     row_bytes_ += entry_bytes;
-    reclaimable = true;
-    const auto overwriter_micros = PhysicalMicros(prev_entry_ht_);
-    if (!overwriter_micros.ok()) {
-      Invalidate();
-      return;
-    }
-    droppable_by_micros = *overwriter_micros;
   } else if (has_prev_ && shared_prefix >= row_end_) {
-    // Same row, new subdoc key: a live head (of a column or record) in this row.
+    // Same row, new record (subdoc chain).
     ++stats_.num_subdoc_keys;
     ++row_entries_;
     row_bytes_ += entry_bytes;
-    if (row_dead_) {
-      // Under a row tombstone every entry goes when the tombstone does.
-      reclaimable = true;
-      droppable_by_micros = row_tombstone_micros_;
-    }
   } else {
     // New row.
     CloseRow();
@@ -143,18 +138,6 @@ void ChainTracker::Add(Slice key, Slice value) {
     ++stats_.num_subdoc_keys;
     row_entries_ = 1;
     row_bytes_ = entry_bytes;
-    // A dead row: its chain head is a row-level (or table-level) tombstone.
-    row_dead_ = subdoc_key_end == row_end_ && is_tombstone;
-    if (row_dead_) {
-      const auto tombstone_micros = PhysicalMicros(encoded_ht);
-      if (!tombstone_micros.ok()) {
-        Invalidate();
-        return;
-      }
-      row_tombstone_micros_ = *tombstone_micros;
-      reclaimable = true;
-      droppable_by_micros = row_tombstone_micros_;
-    }
     if (track_coprefix_subtotals_ && ends->coprefix_end > 0) {
       // Subtotals are per cotable / colocation prefix; a plain (non-colocated) table has no
       // coprefix and records none, so single-table tablets never carry a redundant subtotal.
@@ -164,6 +147,51 @@ void ChainTracker::Add(Slice key, Slice value) {
     } else {
       row_subtotal_ = nullptr;
     }
+  }
+
+  // Classify against the row's covering writes. Only writes seen so far are in the list, which is
+  // all of them: the row-key chain sorts first within the row.
+  const auto* oldest_covering = OldestCoveringAfter(encoded_ht);
+  bool reclaimable = false;
+  int64_t droppable_by_micros = 0;
+  if (!is_head) {
+    // Droppable once the oldest write that overwrites it passes the cutoff: its own successor
+    // version, or an even older covering write.
+    const auto overwriter_micros = PhysicalMicros(prev_entry_ht_);
+    if (!overwriter_micros.ok()) {
+      Invalidate();
+      return;
+    }
+    reclaimable = true;
+    droppable_by_micros = oldest_covering != nullptr
+        ? std::min(*overwriter_micros, oldest_covering->micros)
+        : *overwriter_micros;
+  } else if (oldest_covering != nullptr) {
+    // A record head older than a covering write: the whole-row write shadows it.
+    reclaimable = true;
+    droppable_by_micros = oldest_covering->micros;
+  } else if (is_tombstone) {
+    // An uncovered tombstone marker (row- or column-level): droppable at a full compaction once
+    // its own hybrid time passes the cutoff, whether or not the row lives on.
+    const auto own_micros = PhysicalMicros(encoded_ht);
+    if (!own_micros.ok()) {
+      Invalidate();
+      return;
+    }
+    reclaimable = true;
+    droppable_by_micros = *own_micros;
+  }
+
+  // Maintain the covering-write list and the row's live-content count.
+  if (subdoc_key_end == row_end_) {
+    const auto micros = PhysicalMicros(encoded_ht);
+    if (!micros.ok()) {
+      Invalidate();
+      return;
+    }
+    AddCoveringWrite(encoded_ht, *micros, is_tombstone);
+  } else if (is_head && !reclaimable && !is_tombstone) {
+    ++uncovered_record_heads_;
   }
 
   if (reclaimable) {
@@ -219,13 +247,17 @@ void ChainTracker::CloseRow() {
   stats_.row_chain_hist.Add(row_entries_);
   stats_.row_chain_bytes_hist.Add(row_bytes_);
   stats_.max_row_chain = std::max(stats_.max_row_chain, row_entries_);
-  if (row_dead_) {
+  // Dead row: the newest covering write is a tombstone and nothing newer was written -- a row
+  // re-inserted after a delete has an uncovered record head and stays live.
+  if (num_covering_writes_ > 0 && covering_writes_[0].is_tombstone &&
+      uncovered_record_heads_ == 0) {
     ++stats_.dead_rows;
     stats_.dead_row_entries += row_entries_;
   }
   row_entries_ = 0;
   row_bytes_ = 0;
-  row_dead_ = false;
+  num_covering_writes_ = 0;
+  uncovered_record_heads_ = 0;
 }
 
 void ChainTracker::CloseStretch() {
@@ -245,7 +277,8 @@ void ChainTracker::Invalidate() {
   has_prev_ = false;
   row_entries_ = 0;
   row_bytes_ = 0;
-  row_dead_ = false;
+  num_covering_writes_ = 0;
+  uncovered_record_heads_ = 0;
   stretch_entries_ = 0;
   stretch_bytes_ = 0;
   row_subtotal_ = nullptr;
@@ -278,6 +311,28 @@ void ChainTracker::UpdateWriteHtRange(const EncodedDocHybridTime& encoded_ht) {
   if (max_encoded_ht_.empty() || encoded_ht > max_encoded_ht_) {
     max_encoded_ht_ = encoded_ht;
   }
+}
+
+void ChainTracker::AddCoveringWrite(
+    const EncodedDocHybridTime& encoded_ht, int64_t micros, bool is_tombstone) {
+  if (num_covering_writes_ == kMaxCoveringWrites) {
+    // New arrivals are older (scan order is newest first); dropping them only makes banding
+    // conservative.
+    return;
+  }
+  covering_writes_[num_covering_writes_++] = {encoded_ht, micros, is_tombstone};
+}
+
+const ChainTracker::CoveringWrite* ChainTracker::OldestCoveringAfter(
+    const EncodedDocHybridTime& encoded_ht) const {
+  // The list is newest first, so scan from the oldest end for the first write newer than the
+  // entry.
+  for (size_t i = num_covering_writes_; i > 0; --i) {
+    if (covering_writes_[i - 1].encoded_ht > encoded_ht) {
+      return &covering_writes_[i - 1];
+    }
+  }
+  return nullptr;
 }
 
 Result<int64_t> ChainTracker::PhysicalMicros(const EncodedDocHybridTime& encoded_ht) {

--- a/src/yb/docdb/properties_collector/chain_tracker.cc
+++ b/src/yb/docdb/properties_collector/chain_tracker.cc
@@ -57,9 +57,10 @@ ChainTracker::ChainTracker(int64_t anchor_micros, bool track_coprefix_subtotals)
 //      seen so far -- which is all of them, because the row key sorts first in the row.
 //   6. Garbage is therefore: shadowed versions, record heads older than a covering write, and
 //      tombstone markers themselves (a tombstone past the history cutoff drops at a full
-//      compaction regardless). Each lands in the age band of the OLDEST write whose passing of
-//      the cutoff makes it droppable (its own hybrid time, for a marker), and extends the current
-//      stretch; a non-garbage entry closes the stretch.
+//      compaction) -- except a column tombstone over a packed row, which compactions may keep
+//      unmerged, so it is never counted. Each garbage entry lands in the age band of the OLDEST
+//      write whose passing of the cutoff makes it droppable (its own hybrid time, for a marker),
+//      and extends the current stretch; a non-garbage entry closes the stretch.
 void ChainTracker::Add(Slice key, Slice value) {
   ++stats_.total_entries;
   const size_t entry_bytes = key.size() + value.size();
@@ -170,9 +171,13 @@ void ChainTracker::Add(Slice key, Slice value) {
     // A record head older than a covering write: the whole-row write shadows it.
     reclaimable = true;
     droppable_by_micros = oldest_covering->micros;
-  } else if (is_tombstone) {
-    // An uncovered tombstone marker (row- or column-level): droppable at a full compaction once
-    // its own hybrid time passes the cutoff, whether or not the row lives on.
+  } else if (is_tombstone && (subdoc_key_end == row_end_ || !row_has_packed_covering_)) {
+    // An uncovered tombstone marker: droppable at a full compaction once its own hybrid time
+    // passes the cutoff, whether or not the row lives on. EXCEPT a column tombstone over a packed
+    // row: the feed keeps it when it was not merged into the packed row
+    // (docdb_keep_unmerged_column_tombstones_over_packed_row, and permanently for columns that
+    // never pack, e.g. YCQL collections) -- counting it would break the lower-bound property, so
+    // those markers are excluded above.
     const auto own_micros = PhysicalMicros(encoded_ht);
     if (!own_micros.ok()) {
       Invalidate();
@@ -260,6 +265,7 @@ void ChainTracker::CloseRow() {
   row_bytes_ = 0;
   num_covering_writes_ = 0;
   uncovered_record_heads_ = 0;
+  row_has_packed_covering_ = false;
 }
 
 void ChainTracker::CloseStretch() {
@@ -281,6 +287,7 @@ void ChainTracker::Invalidate() {
   row_bytes_ = 0;
   num_covering_writes_ = 0;
   uncovered_record_heads_ = 0;
+  row_has_packed_covering_ = false;
   stretch_entries_ = 0;
   stretch_bytes_ = 0;
   row_subtotal_ = nullptr;
@@ -323,6 +330,7 @@ void ChainTracker::AddCoveringWrite(
     return;
   }
   covering_writes_[num_covering_writes_++] = {encoded_ht, micros, is_tombstone};
+  row_has_packed_covering_ |= !is_tombstone;
 }
 
 const ChainTracker::CoveringWrite* ChainTracker::OldestCoveringAfter(

--- a/src/yb/docdb/properties_collector/chain_tracker.cc
+++ b/src/yb/docdb/properties_collector/chain_tracker.cc
@@ -244,8 +244,10 @@ void ChainTracker::CloseRow() {
   if (row_entries_ == 0) {
     return;
   }
+  // Both histograms bucket by CHAIN LENGTH; they differ in weight (rows vs the row's bytes), so
+  // together they answer "how many rows / how many bytes sit in chains of length >= L".
   stats_.row_chain_hist.Add(row_entries_);
-  stats_.row_chain_bytes_hist.Add(row_bytes_);
+  stats_.row_chain_bytes_hist.Add(row_entries_, row_bytes_);
   stats_.max_row_chain = std::max(stats_.max_row_chain, row_entries_);
   // Dead row: the newest covering write is a tombstone and nothing newer was written -- a row
   // re-inserted after a delete has an uncovered record head and stays live.

--- a/src/yb/docdb/properties_collector/chain_tracker.h
+++ b/src/yb/docdb/properties_collector/chain_tracker.h
@@ -116,6 +116,9 @@ struct SstStats {
 
   // Derived identities (meaningful only while chain_valid).
   uint64_t shadowed_entries() const { return chain_entries - num_subdoc_keys; }
+  // Heads beyond one per row: a repack-opportunity measure, not a garbage class. In a dead row
+  // these heads are also garbage and counted by reclaimable, so the two overlap there. Never a
+  // trigger input either way.
   uint64_t repackable_entries() const { return num_subdoc_keys - num_rows; }
   uint64_t collapsible_entries() const { return chain_entries - num_rows; }
 };

--- a/src/yb/docdb/properties_collector/chain_tracker.h
+++ b/src/yb/docdb/properties_collector/chain_tracker.h
@@ -1,0 +1,183 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "yb/common/doc_hybrid_time.h"
+#include "yb/common/hybrid_time.h"
+
+#include "yb/docdb/properties_collector/exponential_histogram.h"
+
+#include "yb/util/slice.h"
+
+namespace yb::docdb {
+
+// Fixed age bands for "how old is the entry that made this garbage droppable". A consumer sums the
+// bands that are wholly older than the history cutoff it is applying. The 15 m edge brackets the
+// default history retention (timestamp_history_retention_interval_sec = 900).
+struct AgeBands {
+  static constexpr size_t kNumBands = 8;
+  // Upper edges of bands 0..6, in microseconds: 5 m, 15 m, 1 h, 6 h, 24 h, 7 d, 30 d.
+  // Band 7 is everything older.
+  static constexpr std::array<int64_t, kNumBands - 1> kEdgesMicros = {
+      5LL * 60 * 1000000,
+      15LL * 60 * 1000000,
+      60LL * 60 * 1000000,
+      6LL * 60 * 60 * 1000000,
+      24LL * 60 * 60 * 1000000,
+      7LL * 24 * 60 * 60 * 1000000,
+      30LL * 24 * 60 * 60 * 1000000,
+  };
+
+  // Band for an age; negative ages (clock skew) land in band 0.
+  static size_t BandIndex(int64_t age_micros);
+};
+
+using AgeBandCounts = std::array<uint64_t, AgeBands::kNumBands>;
+
+// Per-coprefix (cotable / colocation id) subtotals for colocated tablets.
+struct CoprefixSubtotal {
+  uint64_t entries = 0;
+  uint64_t tombstone_entries = 0;
+  uint64_t reclaimable_entries = 0;
+  uint64_t rows = 0;
+};
+
+// Everything the collector records for one SST file. Definitions in
+// properties_collector/README.md, "Vocabulary".
+struct SstStats {
+  // Every entry handed to the collector, including meta records and entries that failed to parse.
+  uint64_t total_entries = 0;
+  uint64_t tombstone_entries = 0;
+  uint64_t packed_row_entries = 0;
+  // Regular-DB meta records (transaction apply state, vector index metadata). Not chain-tracked.
+  uint64_t meta_entries = 0;
+
+  // The chain-tracked population. The identities below hold over these, not over total_entries.
+  uint64_t chain_entries = 0;     // Ec
+  uint64_t chain_bytes = 0;       // raw key + value bytes of chain-tracked entries
+  uint64_t num_subdoc_keys = 0;   // K: distinct subdocument keys = number of subdoc chains
+  uint64_t num_rows = 0;          // R: distinct rows = number of row chains
+
+  // Rows whose chain head is a row-level (or table-level) tombstone, and all their entries.
+  uint64_t dead_rows = 0;
+  uint64_t dead_row_entries = 0;
+
+  // All the garbage: shadowed entries of live rows + every entry of dead rows, counted once at scan
+  // time (the two sets are disjoint by construction, so there is no double counting).
+  uint64_t reclaimable_entries = 0;
+  uint64_t reclaimable_bytes = 0;
+
+  uint64_t max_row_chain = 0;
+  uint64_t max_stretch = 0;
+
+  // False once a key failed to parse; the chain statistics are then partial and must not be used
+  // for the identities. The v1 counters (total/tombstone) stay valid.
+  bool chain_valid = true;
+
+  // Exact write-time range of chain-tracked entries (invalid when there are none).
+  HybridTime min_write_ht = HybridTime::kInvalid;
+  HybridTime max_write_ht = HybridTime::kInvalid;
+  // Wall-clock reference the age bands are measured against (taken at collector construction).
+  int64_t anchor_micros = 0;
+
+  // Row-chain length distribution, by row count and by bytes.
+  ExponentialHistogram row_chain_hist;
+  ExponentialHistogram row_chain_bytes_hist;
+  // Stretch distribution: maximal runs of consecutive reclaimable entries in file order, ignoring
+  // key boundaries. By stretch count, by entries contained, by bytes contained.
+  ExponentialHistogram stretch_hist;
+  ExponentialHistogram stretch_entries_hist;
+  ExponentialHistogram stretch_bytes_hist;
+
+  // Reclaimable entries and bytes by the age of what makes them droppable: for a shadowed entry the
+  // entry that shadows it, for a dead-row entry the row tombstone.
+  AgeBandCounts droppable_age_entries{};
+  AgeBandCounts droppable_age_bytes{};
+
+  // Only populated when subtotals are enabled; key = raw coprefix bytes ("" for a plain table).
+  std::map<std::string, CoprefixSubtotal> coprefix_subtotals;
+
+  // Derived identities (meaningful only while chain_valid).
+  uint64_t shadowed_entries() const { return chain_entries - num_subdoc_keys; }
+  uint64_t repackable_entries() const { return num_subdoc_keys - num_rows; }
+  uint64_t collapsible_entries() const { return chain_entries - num_rows; }
+};
+
+// Walks the entries of one SST in build order and derives SstStats in a single pass. Because the
+// file is sorted and versions of a key are adjacent (newest first), the tracker never looks
+// anything up: it compares each key with the previous one. No allocation in steady state.
+//
+// Usage: Add() once per entry, then Finish(). Add() never fails; a key that cannot be parsed
+// invalidates the chain statistics (chain_valid = false) and the tracker keeps counting the v1
+// scalars.
+class ChainTracker {
+ public:
+  ChainTracker(int64_t anchor_micros, bool track_coprefix_subtotals);
+
+  void Add(Slice key, Slice value);
+
+  // Closes the open row and stretch and returns the statistics. Idempotent.
+  const SstStats& Finish();
+
+  const SstStats& stats() const { return stats_; }
+
+ private:
+  void OnMetaEntry();
+  void CloseRow();
+  void CloseStretch();
+  void Invalidate();
+  void AssignPrevKey(Slice subdoc_key, size_t shared_prefix);
+  void AddReclaimable(size_t entry_bytes, int64_t droppable_by_micros);
+  void UpdateWriteHtRange(const EncodedDocHybridTime& encoded_ht);
+  Result<int64_t> PhysicalMicros(const EncodedDocHybridTime& encoded_ht);
+
+  // Length of the row key prefix of a subdocument key (hybrid time already stripped), and of its
+  // coprefix (cotable / colocation id, possibly empty).
+  struct RowKeyEnds {
+    size_t coprefix_end;
+    size_t row_end;
+  };
+  static Result<RowKeyEnds> ComputeRowKeyEnds(Slice subdoc_key);
+
+  SstStats stats_;
+  const bool track_coprefix_subtotals_;
+  bool finished_ = false;
+
+  // Previous chain-tracked entry.
+  bool has_prev_ = false;
+  std::vector<char> prev_key_;              // subdoc key without hybrid time
+  EncodedDocHybridTime prev_entry_ht_;
+  EncodedDocHybridTime min_encoded_ht_;     // lexicographic extremes of the encoded form
+  EncodedDocHybridTime max_encoded_ht_;
+
+  // Current row.
+  size_t row_end_ = 0;
+  uint64_t row_entries_ = 0;
+  uint64_t row_bytes_ = 0;
+  bool row_dead_ = false;
+  int64_t row_tombstone_micros_ = 0;        // valid when row_dead_
+  CoprefixSubtotal* row_subtotal_ = nullptr;
+
+  // Current stretch of consecutive reclaimable entries.
+  uint64_t stretch_entries_ = 0;
+  uint64_t stretch_bytes_ = 0;
+};
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/chain_tracker.h
+++ b/src/yb/docdb/properties_collector/chain_tracker.h
@@ -111,7 +111,8 @@ struct SstStats {
   AgeBandCounts droppable_age_entries{};
   AgeBandCounts droppable_age_bytes{};
 
-  // Only populated when subtotals are enabled; key = raw coprefix bytes ("" for a plain table).
+  // Only populated when subtotals are enabled AND the tablet is colocated; key = the raw
+  // cotable / colocation prefix bytes. Rows without a coprefix (plain tables) record none.
   std::map<std::string, CoprefixSubtotal> coprefix_subtotals;
 
   // Derived identities (meaningful only while chain_valid).

--- a/src/yb/docdb/properties_collector/chain_tracker.h
+++ b/src/yb/docdb/properties_collector/chain_tracker.h
@@ -75,12 +75,15 @@ struct SstStats {
   uint64_t num_subdoc_keys = 0;   // K: distinct subdocument keys = number of subdoc chains
   uint64_t num_rows = 0;          // R: distinct rows = number of row chains
 
-  // Rows whose chain head is a row-level (or table-level) tombstone, and all their entries.
+  // Rows whose newest covering write (see ChainTracker) is a tombstone with nothing newer in the
+  // row, and all their entries. A row re-inserted after a delete is NOT dead.
   uint64_t dead_rows = 0;
   uint64_t dead_row_entries = 0;
 
-  // All the garbage: shadowed entries of live rows + every entry of dead rows, counted once at scan
-  // time (the two sets are disjoint by construction, so there is no double counting).
+  // All the garbage, counted once at scan time: entries shadowed by a newer version of their own
+  // record, record heads older than a covering write (a packed row or row tombstone overwrites the
+  // whole row), and tombstone markers themselves (a tombstone past the history cutoff drops at a
+  // full compaction regardless of covering).
   uint64_t reclaimable_entries = 0;
   uint64_t reclaimable_bytes = 0;
 
@@ -143,6 +146,15 @@ class ChainTracker {
   const SstStats& stats() const { return stats_; }
 
  private:
+  // A covering write is an entry at the row key itself -- a packed row or a row tombstone. It
+  // overwrites the whole row, so every entry of the row with an older hybrid time is garbage
+  // (the compaction feed's overwrite stack applies parent writes to all deeper components).
+  struct CoveringWrite {
+    EncodedDocHybridTime encoded_ht;
+    int64_t micros;
+    bool is_tombstone;
+  };
+
   void OnMetaEntry();
   void CloseRow();
   void CloseStretch();
@@ -151,6 +163,10 @@ class ChainTracker {
   void AddReclaimable(size_t entry_bytes, int64_t droppable_by_micros);
   void UpdateWriteHtRange(const EncodedDocHybridTime& encoded_ht);
   Result<int64_t> PhysicalMicros(const EncodedDocHybridTime& encoded_ht);
+  void AddCoveringWrite(const EncodedDocHybridTime& encoded_ht, int64_t micros, bool is_tombstone);
+  // The oldest covering write newer than encoded_ht, i.e. the first write whose passing of the
+  // history cutoff makes an entry at encoded_ht droppable; nullptr if none.
+  const CoveringWrite* OldestCoveringAfter(const EncodedDocHybridTime& encoded_ht) const;
 
   // Length of the row key prefix of a subdocument key (hybrid time already stripped), and of its
   // coprefix (cotable / colocation id, possibly empty).
@@ -175,9 +191,16 @@ class ChainTracker {
   size_t row_end_ = 0;
   uint64_t row_entries_ = 0;
   uint64_t row_bytes_ = 0;
-  bool row_dead_ = false;
-  int64_t row_tombstone_micros_ = 0;        // valid when row_dead_
   CoprefixSubtotal* row_subtotal_ = nullptr;
+  // Covering writes of the current row, newest first (scan order); typically 0..2. On overflow the
+  // oldest are dropped, which only makes banding conservative (a newer overwriter means "droppable
+  // later"), never wrong.
+  static constexpr size_t kMaxCoveringWrites = 8;
+  std::array<CoveringWrite, kMaxCoveringWrites> covering_writes_;
+  size_t num_covering_writes_ = 0;
+  // Record heads of the current row that are neither covered nor tombstones: the row's live
+  // content. A row is dead iff its newest covering write is a tombstone and this stays zero.
+  uint64_t uncovered_record_heads_ = 0;
 
   // Current stretch of consecutive reclaimable entries.
   uint64_t stretch_entries_ = 0;

--- a/src/yb/docdb/properties_collector/chain_tracker.h
+++ b/src/yb/docdb/properties_collector/chain_tracker.h
@@ -100,7 +100,8 @@ struct SstStats {
   // Wall-clock reference the age bands are measured against (taken at collector construction).
   int64_t anchor_micros = 0;
 
-  // Row-chain length distribution, by row count and by bytes.
+  // Row-chain LENGTH distributions: both bucket by the row's entry count; the first weights each
+  // row as 1, the second by the row's raw bytes ("how many bytes sit in chains of length >= L").
   ExponentialHistogram row_chain_hist;
   ExponentialHistogram row_chain_bytes_hist;
   // Stretch distribution: maximal runs of consecutive reclaimable entries in file order, ignoring

--- a/src/yb/docdb/properties_collector/chain_tracker.h
+++ b/src/yb/docdb/properties_collector/chain_tracker.h
@@ -83,7 +83,8 @@ struct SstStats {
   // All the garbage, counted once at scan time: entries shadowed by a newer version of their own
   // record, record heads older than a covering write (a packed row or row tombstone overwrites the
   // whole row), and tombstone markers themselves (a tombstone past the history cutoff drops at a
-  // full compaction regardless of covering).
+  // full compaction) -- excluding column tombstones over a packed row, which compactions may keep
+  // unmerged, so the count stays a lower bound.
   uint64_t reclaimable_entries = 0;
   uint64_t reclaimable_bytes = 0;
 
@@ -189,7 +190,9 @@ class ChainTracker {
   bool has_prev_ = false;
   std::vector<char> prev_key_;              // subdoc key without hybrid time
   EncodedDocHybridTime prev_entry_ht_;
-  EncodedDocHybridTime min_encoded_ht_;     // lexicographic extremes of the encoded form
+  // Time-order extremes: EncodedDocHybridTime's comparator inverts the reversed byte encoding,
+  // so min_encoded_ht_ is the OLDEST write time and max_encoded_ht_ the newest.
+  EncodedDocHybridTime min_encoded_ht_;
   EncodedDocHybridTime max_encoded_ht_;
 
   // Current row.
@@ -206,6 +209,10 @@ class ChainTracker {
   // Record heads of the current row that are neither covered nor tombstones: the row's live
   // content. A row is dead iff its newest covering write is a tombstone and this stays zero.
   uint64_t uncovered_record_heads_ = 0;
+  // Whether any covering write of the current row is a packed row (not a tombstone). A column
+  // tombstone over a packed row may be kept un-dropped by compactions (see Add()), so such
+  // markers are not counted reclaimable.
+  bool row_has_packed_covering_ = false;
 
   // Current stretch of consecutive reclaimable entries.
   uint64_t stretch_entries_ = 0;

--- a/src/yb/docdb/properties_collector/chain_tracker.h
+++ b/src/yb/docdb/properties_collector/chain_tracker.h
@@ -118,6 +118,10 @@ struct SstStats {
   // Only populated when subtotals are enabled AND the tablet is colocated; key = the raw
   // cotable / colocation prefix bytes. Rows without a coprefix (plain tables) record none.
   std::map<std::string, CoprefixSubtotal> coprefix_subtotals;
+  // Set only by SstStatsFromProperties, when the serialized subtotals were truncated at the size
+  // cap (so coprefix_subtotals is a prefix of the tablet's tables, not all of them). The collector
+  // itself never truncates its in-memory map, so it leaves this false.
+  bool coprefix_subtotals_truncated = false;
 
   // Derived identities (meaningful only while chain_valid).
   uint64_t shadowed_entries() const { return chain_entries - num_subdoc_keys; }

--- a/src/yb/docdb/properties_collector/chain_tracker_test_util.h
+++ b/src/yb/docdb/properties_collector/chain_tracker_test_util.h
@@ -1,0 +1,150 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+// Shared helpers for the properties_collector tests: encoded-entry builders and the worked
+// "anatomy strip" example from README.md.
+
+#include <string>
+#include <vector>
+
+#include "yb/common/column_id.h"
+
+#include "yb/docdb/properties_collector/chain_tracker.h"
+
+#include "yb/dockv/doc_key.h"
+#include "yb/dockv/value_type.h"
+
+#include "yb/util/test_macros.h"
+
+namespace yb::docdb {
+
+// A fixed wall-clock reference for the age bands: 2023-11-14T22:13:20Z.
+inline constexpr int64_t kAnchorMicros = 1700000000LL * 1000000;
+inline constexpr int64_t kMinute = 60LL * 1000000;
+inline constexpr int64_t kHour = 60 * kMinute;
+inline constexpr int64_t kDay = 24 * kHour;
+
+// An entry as the collector sees it: the RocksDB user key (subdoc key + hybrid time) and value.
+struct Entry {
+  std::string key;
+  std::string value;
+};
+
+inline HybridTime AgeToHt(int64_t age_micros) {
+  return HybridTime::FromMicros(kAnchorMicros - age_micros);
+}
+
+inline dockv::DocKey Row(int32_t id) {
+  return dockv::DocKey(
+      /* hash = */ 1000 + id, dockv::MakeKeyEntryValues("h"), dockv::MakeKeyEntryValues(id));
+}
+
+inline dockv::DocKey ColocatedRow(ColocationId colocation_id, int32_t id) {
+  return dockv::DocKey(
+      colocation_id, /* hash = */ 1000 + id, dockv::MakeKeyEntryValues("h"),
+      dockv::MakeKeyEntryValues(id));
+}
+
+// Row-level key (packed row or row tombstone): the DocKey itself, no subkeys.
+inline std::string RowKey(const dockv::DocKey& row, int64_t age_micros) {
+  return dockv::SubDocKey(row, AgeToHt(age_micros)).Encode().ToStringBuffer();
+}
+
+inline std::string ColumnKey(const dockv::DocKey& row, int column, int64_t age_micros) {
+  return dockv::SubDocKey(
+      row, AgeToHt(age_micros),
+      dockv::KeyEntryValues{dockv::KeyEntryValue::MakeColumnId(ColumnId(column))})
+      .Encode().ToStringBuffer();
+}
+
+inline std::string Tombstone() {
+  return std::string(1, dockv::ValueEntryTypeAsChar::kTombstone);
+}
+
+inline std::string PackedRow(const std::string& payload) {
+  return std::string(1, dockv::ValueEntryTypeAsChar::kPackedRowV2) + payload;
+}
+
+inline std::string Str(const std::string& s) {
+  return std::string(1, dockv::ValueEntryTypeAsChar::kString) + s;
+}
+
+inline std::string MetaKey() {
+  return std::string(1, dockv::KeyEntryTypeAsChar::kTransactionApplyState) + "txn-id-bytes";
+}
+
+class TrackerFixture {
+ public:
+  explicit TrackerFixture(bool subtotals = false) : tracker_(kAnchorMicros, subtotals) {}
+
+  TrackerFixture& Add(const Entry& e) {
+    tracker_.Add(e.key, e.value);
+    return *this;
+  }
+
+  TrackerFixture& Add(const std::vector<Entry>& entries) {
+    for (const auto& e : entries) {
+      Add(e);
+    }
+    return *this;
+  }
+
+  const SstStats& Finish() { return tracker_.Finish(); }
+
+ private:
+  ChainTracker tracker_;
+};
+
+// The anatomy strip from the design (README "Vocabulary" example).
+//
+// Live row r1, 6 entries, newest first within each key:
+//   [packed v3][packed v2][packed v1][col a v2][col a v1][col b v1]
+// Dead row r2, 3 entries:
+//   [row tombstone][col a v1][col b v1]
+inline std::vector<Entry> AnatomyStrip() {
+  const auto r1 = Row(1);
+  const auto r2 = Row(2);
+  return {
+      {RowKey(r1, 1 * kMinute), PackedRow("v3")},
+      {RowKey(r1, 20 * kMinute), PackedRow("v2")},
+      {RowKey(r1, 2 * kHour), PackedRow("v1")},
+      {ColumnKey(r1, 1, 10 * kMinute), Str("a2")},
+      {ColumnKey(r1, 1, 3 * kDay), Str("a1")},
+      {ColumnKey(r1, 2, 1 * kMinute), Str("b1")},
+      {RowKey(r2, 2 * kDay), Tombstone()},
+      {ColumnKey(r2, 1, 5 * kDay), Str("a1")},
+      {ColumnKey(r2, 2, 6 * kDay), Str("b1")},
+  };
+}
+
+inline void ExpectIdentities(const SstStats& s) {
+  ASSERT_TRUE(s.chain_valid);
+  ASSERT_EQ(s.chain_entries, s.shadowed_entries() + s.num_subdoc_keys);
+  ASSERT_EQ(s.num_subdoc_keys, s.repackable_entries() + s.num_rows);
+  ASSERT_EQ(s.collapsible_entries(), s.shadowed_entries() + s.repackable_entries());
+  ASSERT_EQ(s.total_entries, s.chain_entries + s.meta_entries);
+  ASSERT_EQ(s.row_chain_hist.TotalWeight(), s.num_rows);
+  ASSERT_EQ(s.stretch_entries_hist.TotalWeight(), s.reclaimable_entries);
+  ASSERT_EQ(s.stretch_bytes_hist.TotalWeight(), s.reclaimable_bytes);
+  uint64_t banded_entries = 0, banded_bytes = 0;
+  for (size_t i = 0; i < AgeBands::kNumBands; ++i) {
+    banded_entries += s.droppable_age_entries[i];
+    banded_bytes += s.droppable_age_bytes[i];
+  }
+  ASSERT_EQ(banded_entries, s.reclaimable_entries);
+  ASSERT_EQ(banded_bytes, s.reclaimable_bytes);
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/chain_tracker_test_util.h
+++ b/src/yb/docdb/properties_collector/chain_tracker_test_util.h
@@ -136,6 +136,7 @@ inline void ExpectIdentities(const SstStats& s) {
   ASSERT_EQ(s.collapsible_entries(), s.shadowed_entries() + s.repackable_entries());
   ASSERT_EQ(s.total_entries, s.chain_entries + s.meta_entries);
   ASSERT_EQ(s.row_chain_hist.TotalWeight(), s.num_rows);
+  ASSERT_EQ(s.row_chain_bytes_hist.TotalWeight(), s.chain_bytes);
   ASSERT_EQ(s.stretch_entries_hist.TotalWeight(), s.reclaimable_entries);
   ASSERT_EQ(s.stretch_bytes_hist.TotalWeight(), s.reclaimable_bytes);
   uint64_t banded_entries = 0, banded_bytes = 0;


### PR DESCRIPTION
Summary:
The semantic core of the SST statistics collector: ChainTracker derives,
in a single pass over an SST's entries in build order, everything the
collector will store per file (SstStats). The RocksDB-facing collector
that serializes SstStats into the file's properties block and registers
on the tablet is the next change in this stack; this one is pure logic
over (key, value) slices and reviewable without RocksDB context.

What it computes, and the definitions that carry the design:
- Ec (chain-tracked entries), K (distinct subdoc keys), R (distinct
  rows). Shadowed = Ec - K (garbage), repackable = K - R (a
  repack-opportunity measure, not a garbage class), collapsible = Ec - R.
- Covering writes: an entry at the row key itself (a packed row or a
  row-level tombstone) overwrites the whole row, so every entry of the
  row with an older hybrid time is garbage even when it is the newest
  version of its own record. File order is key order, not time order,
  so each record head is compared against the row's covering writes by
  hybrid time.
- Dead rows: the newest covering write is a tombstone and nothing in the
  row is newer. A row re-inserted after a delete is alive.
- reclaimable = shadowed versions + record heads older than a covering
  write + tombstone markers, except column tombstones over a packed row,
  which compactions may keep unmerged
  (docdb_keep_unmerged_column_tombstones_over_packed_row); excluding them
  keeps the count a lower bound. Entries and bytes, counted once online.
- Distributions (exponential histograms from the previous change):
  row-chain length, by rows and by bytes, and stretch length (maximal
  runs of consecutive reclaimable entries in file order, what a cursor
  read steps over), by stretches, entries and bytes. Each is blind to a
  shape the other sees: a fully drained queue range has short chains but
  one huge stretch; alternating deleted/live rows has short stretches but
  half the file reclaimable.
- Age bands: reclaimable entries and bytes by the age of the OLDEST write
  whose passing of the history cutoff makes them droppable (the entry's
  own successor version or a covering write, whichever is older; a
  marker's own hybrid time), so a consumer can count only garbage already
  past its cutoff without rescanning.
- Exact min/max write hybrid time; per-coprefix subtotals (optional,
  colocated tablets only).

One pass, no lookups: the file is sorted with versions adjacent, so the
tracker compares each key with the previous one. No allocation in steady
state, no atomics, no floating point. A key that fails to parse marks the
chain statistics invalid for the file (chain_valid); counting never fails.

Test Plan:
./yb_build.sh release --cxx-test chain_tracker-test

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
