### PR TITLE
[#33267] DocDB: SST statistics collector -- properties block and registration

### DIFF
--- a/src/yb/docdb/CMakeLists.txt
+++ b/src/yb/docdb/CMakeLists.txt
@@ -120,6 +120,7 @@ set(DOCDB_DEPS
         PUBLIC vector_index
         PUBLIC yb_ash
         PUBLIC yb_common
+        PUBLIC yb_docdb_properties_collector
         PUBLIC yb_docdb_shared
         PUBLIC yb_dockv
         PUBLIC yb_pggate

--- a/src/yb/docdb/properties_collector/CMakeLists.txt
+++ b/src/yb/docdb/properties_collector/CMakeLists.txt
@@ -20,6 +20,7 @@ set(YB_PCH_PATH ../)
 set(DOCDB_PROPERTIES_COLLECTOR_SRCS
     chain_tracker.cc
     exponential_histogram.cc
+    sst_stats_collector.cc
     )
 
 set(DOCDB_PROPERTIES_COLLECTOR_DEPS
@@ -37,3 +38,4 @@ set(YB_TEST_LINK_LIBS yb_docdb_properties_collector ${YB_MIN_TEST_LIBS})
 
 ADD_YB_TEST(chain_tracker-test)
 ADD_YB_TEST(exponential_histogram-test)
+ADD_YB_TEST(sst_stats_collector-test)

--- a/src/yb/docdb/properties_collector/sst_stats_collector-test.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_collector-test.cc
@@ -1,0 +1,103 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/docdb/properties_collector/sst_stats_collector.h"
+
+#include "yb/docdb/properties_collector/chain_tracker_test_util.h"
+
+#include "yb/util/flags.h"
+#include "yb/util/test_util.h"
+
+DECLARE_uint32(sst_tombstone_mark_ratio_percent);
+DECLARE_uint64(sst_tombstone_mark_min_count);
+
+namespace yb::docdb {
+
+// ChainTracker semantics are covered by chain_tracker-test; this file covers the properties
+// (de)serialization and the rocksdb::TablePropertiesCollector wrapper.
+class SstStatsCollectorTest : public YBTest {};
+
+TEST_F(SstStatsCollectorTest, PropertiesRoundTrip) {
+  const auto s = TrackerFixture(/* subtotals = */ true).Add(AnatomyStrip()).Finish();
+  rocksdb::UserCollectedProperties properties;
+  SstStatsToProperties(s, &properties);
+  EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kCollectorVersion)),
+            kSstStatsCollectorVersion);
+  EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kReclaimableEntries)), "6");
+  EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kDroppableAgeEntries)),
+            "1,1,1,0,0,3,0,0");
+
+  const auto parsed = ASSERT_RESULT(SstStatsFromProperties(properties));
+  EXPECT_EQ(parsed.total_entries, s.total_entries);
+  EXPECT_EQ(parsed.tombstone_entries, s.tombstone_entries);
+  EXPECT_EQ(parsed.chain_entries, s.chain_entries);
+  EXPECT_EQ(parsed.chain_bytes, s.chain_bytes);
+  EXPECT_EQ(parsed.num_subdoc_keys, s.num_subdoc_keys);
+  EXPECT_EQ(parsed.num_rows, s.num_rows);
+  EXPECT_EQ(parsed.dead_rows, s.dead_rows);
+  EXPECT_EQ(parsed.dead_row_entries, s.dead_row_entries);
+  EXPECT_EQ(parsed.reclaimable_entries, s.reclaimable_entries);
+  EXPECT_EQ(parsed.reclaimable_bytes, s.reclaimable_bytes);
+  EXPECT_EQ(parsed.max_row_chain, s.max_row_chain);
+  EXPECT_EQ(parsed.max_stretch, s.max_stretch);
+  EXPECT_EQ(parsed.chain_valid, s.chain_valid);
+  EXPECT_EQ(parsed.min_write_ht, s.min_write_ht);
+  EXPECT_EQ(parsed.max_write_ht, s.max_write_ht);
+  EXPECT_EQ(parsed.anchor_micros, s.anchor_micros);
+  EXPECT_EQ(parsed.row_chain_hist, s.row_chain_hist);
+  EXPECT_EQ(parsed.row_chain_bytes_hist, s.row_chain_bytes_hist);
+  EXPECT_EQ(parsed.stretch_hist, s.stretch_hist);
+  EXPECT_EQ(parsed.stretch_entries_hist, s.stretch_entries_hist);
+  EXPECT_EQ(parsed.stretch_bytes_hist, s.stretch_bytes_hist);
+  EXPECT_EQ(parsed.droppable_age_entries, s.droppable_age_entries);
+  EXPECT_EQ(parsed.droppable_age_bytes, s.droppable_age_bytes);
+  ASSERT_EQ(parsed.coprefix_subtotals.size(), 1);
+  EXPECT_EQ(parsed.coprefix_subtotals.begin()->second.rows, 2);
+
+  EXPECT_NOK(SstStatsFromProperties(rocksdb::UserCollectedProperties()));
+}
+
+TEST_F(SstStatsCollectorTest, CollectorEndToEnd) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_sst_tombstone_mark_min_count) = 1;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_sst_tombstone_mark_ratio_percent) = 50;
+
+  auto factory = MakeSstStatsCollectorFactory();
+  std::unique_ptr<rocksdb::TablePropertiesCollector> collector(
+      factory->CreateTablePropertiesCollector(rocksdb::TablePropertiesCollectorFactory::Context()));
+  for (const auto& e : AnatomyStrip()) {
+    ASSERT_OK(collector->AddUserKey(e.key, e.value, rocksdb::kEntryPut, 0, 0));
+  }
+  // 1 tombstone out of 9 entries: below the 50% marking threshold.
+  EXPECT_FALSE(collector->NeedCompact());
+
+  rocksdb::UserCollectedProperties properties;
+  ASSERT_OK(collector->Finish(&properties));
+  const auto s = ASSERT_RESULT(SstStatsFromProperties(properties));
+  EXPECT_EQ(s.total_entries, 9);
+  EXPECT_EQ(s.reclaimable_entries, 6);
+  EXPECT_EQ(s.num_rows, 2);
+  // The anchor is taken from the wall clock at construction; the test entries are dated relative
+  // to a fixed 2023 anchor, so every band lands in the oldest bucket here.
+  EXPECT_GT(s.anchor_micros, kAnchorMicros);
+  EXPECT_EQ(s.droppable_age_entries[AgeBands::kNumBands - 1], 6);
+
+  // A tombstone-heavy file trips the MANIFEST mark.
+  std::unique_ptr<rocksdb::TablePropertiesCollector> heavy(
+      factory->CreateTablePropertiesCollector(rocksdb::TablePropertiesCollectorFactory::Context()));
+  for (int32_t id = 0; id < 10; ++id) {
+    ASSERT_OK(heavy->AddUserKey(RowKey(Row(id), kHour), Tombstone(), rocksdb::kEntryPut, 0, 0));
+  }
+  EXPECT_TRUE(heavy->NeedCompact());
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/sst_stats_collector-test.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_collector-test.cc
@@ -28,14 +28,24 @@ namespace yb::docdb {
 class SstStatsCollectorTest : public YBTest {};
 
 TEST_F(SstStatsCollectorTest, PropertiesRoundTrip) {
-  const auto s = TrackerFixture(/* subtotals = */ true).Add(AnatomyStrip()).Finish();
+  auto fixture = TrackerFixture(/* subtotals = */ true);
+  // One colocated row (two versions) so the coprefix-subtotal property is exercised too: plain
+  // rows record no subtotals. The colocation-id prefix byte sorts before hash-partitioned keys,
+  // so these entries come first in file order.
+  const ColocationId colocation_id = 16385;
+  fixture.Add({RowKey(ColocatedRow(colocation_id, 1), 1 * kHour), PackedRow("new")});
+  fixture.Add({RowKey(ColocatedRow(colocation_id, 1), 2 * kHour), PackedRow("old")});
+  fixture.Add(AnatomyStrip());
+  const auto s = fixture.Finish();
   rocksdb::UserCollectedProperties properties;
   SstStatsToProperties(s, &properties);
   EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kCollectorVersion)),
             kSstStatsCollectorVersion);
-  EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kReclaimableEntries)), "6");
+  // The anatomy strip's 6 plus the shadowed colocated version.
+  EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kReclaimableEntries)), "7");
+  // The shadowed colocated version's overwriter is 1 h old: the lower edge of band 3 (1-6 h).
   EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kDroppableAgeEntries)),
-            "1,1,1,0,0,3,0,0");
+            "1,1,1,1,0,3,0,0");
 
   const auto parsed = ASSERT_RESULT(SstStatsFromProperties(properties));
   EXPECT_EQ(parsed.total_entries, s.total_entries);
@@ -62,7 +72,9 @@ TEST_F(SstStatsCollectorTest, PropertiesRoundTrip) {
   EXPECT_EQ(parsed.droppable_age_entries, s.droppable_age_entries);
   EXPECT_EQ(parsed.droppable_age_bytes, s.droppable_age_bytes);
   ASSERT_EQ(parsed.coprefix_subtotals.size(), 1);
-  EXPECT_EQ(parsed.coprefix_subtotals.begin()->second.rows, 2);
+  EXPECT_EQ(parsed.coprefix_subtotals.begin()->second.rows, 1);
+  EXPECT_EQ(parsed.coprefix_subtotals.begin()->second.entries, 2);
+  EXPECT_EQ(parsed.coprefix_subtotals.begin()->second.reclaimable_entries, 1);
 
   EXPECT_NOK(SstStatsFromProperties(rocksdb::UserCollectedProperties()));
 }

--- a/src/yb/docdb/properties_collector/sst_stats_collector-test.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_collector-test.cc
@@ -41,11 +41,11 @@ TEST_F(SstStatsCollectorTest, PropertiesRoundTrip) {
   SstStatsToProperties(s, &properties);
   EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kCollectorVersion)),
             kSstStatsCollectorVersion);
-  // The anatomy strip's 6 plus the shadowed colocated version.
-  EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kReclaimableEntries)), "7");
+  // The anatomy strip's 7 plus the shadowed colocated version.
+  EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kReclaimableEntries)), "8");
   // The shadowed colocated version's overwriter is 1 h old: the lower edge of band 3 (1-6 h).
   EXPECT_EQ(properties.at(std::string(SstStatsPropertyKeys::kDroppableAgeEntries)),
-            "1,1,1,1,0,3,0,0");
+            "2,0,1,2,0,3,0,0");
 
   const auto parsed = ASSERT_RESULT(SstStatsFromProperties(properties));
   EXPECT_EQ(parsed.total_entries, s.total_entries);
@@ -96,12 +96,12 @@ TEST_F(SstStatsCollectorTest, CollectorEndToEnd) {
   ASSERT_OK(collector->Finish(&properties));
   const auto s = ASSERT_RESULT(SstStatsFromProperties(properties));
   EXPECT_EQ(s.total_entries, 9);
-  EXPECT_EQ(s.reclaimable_entries, 6);
+  EXPECT_EQ(s.reclaimable_entries, 7);
   EXPECT_EQ(s.num_rows, 2);
   // The anchor is taken from the wall clock at construction; the test entries are dated relative
   // to a fixed 2023 anchor, so every band lands in the oldest bucket here.
   EXPECT_GT(s.anchor_micros, kAnchorMicros);
-  EXPECT_EQ(s.droppable_age_entries[AgeBands::kNumBands - 1], 6);
+  EXPECT_EQ(s.droppable_age_entries[AgeBands::kNumBands - 1], 7);
 
   // A tombstone-heavy file trips the MANIFEST mark.
   std::unique_ptr<rocksdb::TablePropertiesCollector> heavy(

--- a/src/yb/docdb/properties_collector/sst_stats_collector-test.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_collector-test.cc
@@ -80,6 +80,26 @@ TEST_F(SstStatsCollectorTest, PropertiesRoundTrip) {
   EXPECT_NOK(SstStatsFromProperties(rocksdb::UserCollectedProperties()));
 }
 
+TEST_F(SstStatsCollectorTest, MalformedCoprefixSubtotalsAreRejected) {
+  // The coprefix field is hex from on-disk data; strings::a2b_hex only DCHECKs its input, so the
+  // parser must validate it. Build a valid property set, then corrupt just that property.
+  SstStats s;
+  s.coprefix_subtotals["\x01\x02"] = {.entries = 1, .rows = 1};
+  rocksdb::UserCollectedProperties valid;
+  SstStatsToProperties(s, &valid);
+  const std::string key(SstStatsPropertyKeys::kCoprefixSubtotals);
+  ASSERT_OK(SstStatsFromProperties(valid));
+
+  for (const auto& bad : {"zz:1:0:0:1",        // non-hex coprefix
+                          "abc:1:0:0:1",       // odd-length hex
+                          "0102:1:0:0",        // too few fields
+                          "0102:1:0:0:1:2"}) { // too many fields
+    auto properties = valid;
+    properties[key] = bad;
+    EXPECT_NOK(SstStatsFromProperties(properties)) << "accepted malformed input: " << bad;
+  }
+}
+
 TEST_F(SstStatsCollectorTest, CoprefixSubtotalsTruncationIsVisible) {
   // A colocated tablet with more tables than fit under the size cap: the parsed map is a prefix
   // and coprefix_subtotals_truncated says so, distinguishing it from "no subtotals".
@@ -91,6 +111,12 @@ TEST_F(SstStatsCollectorTest, CoprefixSubtotalsTruncationIsVisible) {
   }
   rocksdb::UserCollectedProperties properties;
   SstStatsToProperties(s, &properties);
+  // The marker never lands where it would parse as an empty item, and the cap is respected.
+  const auto& serialized = properties[std::string(SstStatsPropertyKeys::kCoprefixSubtotals)];
+  EXPECT_LE(serialized.size(), 4096);
+  EXPECT_NE(serialized.front(), ';');
+  EXPECT_TRUE(serialized.ends_with(";..."));
+
   const auto parsed = ASSERT_RESULT(SstStatsFromProperties(properties));
   EXPECT_TRUE(parsed.coprefix_subtotals_truncated);
   EXPECT_LT(parsed.coprefix_subtotals.size(), s.coprefix_subtotals.size());

--- a/src/yb/docdb/properties_collector/sst_stats_collector-test.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_collector-test.cc
@@ -75,8 +75,26 @@ TEST_F(SstStatsCollectorTest, PropertiesRoundTrip) {
   EXPECT_EQ(parsed.coprefix_subtotals.begin()->second.rows, 1);
   EXPECT_EQ(parsed.coprefix_subtotals.begin()->second.entries, 2);
   EXPECT_EQ(parsed.coprefix_subtotals.begin()->second.reclaimable_entries, 1);
+  EXPECT_FALSE(parsed.coprefix_subtotals_truncated);
 
   EXPECT_NOK(SstStatsFromProperties(rocksdb::UserCollectedProperties()));
+}
+
+TEST_F(SstStatsCollectorTest, CoprefixSubtotalsTruncationIsVisible) {
+  // A colocated tablet with more tables than fit under the size cap: the parsed map is a prefix
+  // and coprefix_subtotals_truncated says so, distinguishing it from "no subtotals".
+  SstStats s;
+  for (int i = 0; i < 400; ++i) {
+    // Distinct 8-byte coprefixes; 400 x ~40 chars each overruns the 4 KiB cap.
+    std::string coprefix = "coprefix" + std::to_string(i);
+    s.coprefix_subtotals[coprefix] = {.entries = 1, .rows = 1};
+  }
+  rocksdb::UserCollectedProperties properties;
+  SstStatsToProperties(s, &properties);
+  const auto parsed = ASSERT_RESULT(SstStatsFromProperties(properties));
+  EXPECT_TRUE(parsed.coprefix_subtotals_truncated);
+  EXPECT_LT(parsed.coprefix_subtotals.size(), s.coprefix_subtotals.size());
+  EXPECT_GT(parsed.coprefix_subtotals.size(), 0);
 }
 
 TEST_F(SstStatsCollectorTest, CollectorEndToEnd) {

--- a/src/yb/docdb/properties_collector/sst_stats_collector.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_collector.cc
@@ -28,7 +28,8 @@ DEFINE_NON_RUNTIME_bool(docdb_enable_sst_stats_collector, false,
 
 DEFINE_RUNTIME_bool(docdb_sst_stats_coprefix_subtotals, false,
     "Whether the DocDB SST statistics collector also records per-table (cotable / colocation id) "
-    "subtotals in colocated tablets. Applies to files built from then on.");
+    "subtotals. Only rows carrying a coprefix record subtotals, so plain (non-colocated) tablets "
+    "record none. Applies to files built from then on.");
 
 DEFINE_RUNTIME_uint32(sst_tombstone_mark_ratio_percent, 30,
     "Mark an SST file for compaction when at least this percentage of its entries are DocDB "

--- a/src/yb/docdb/properties_collector/sst_stats_collector.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_collector.cc
@@ -1,0 +1,286 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/docdb/properties_collector/sst_stats_collector.h"
+
+#include "yb/gutil/strings/escaping.h"
+#include "yb/gutil/walltime.h"
+
+#include "yb/util/flags.h"
+#include "yb/util/status_format.h"
+#include "yb/util/string_util.h"
+
+DEFINE_NON_RUNTIME_bool(docdb_enable_sst_stats_collector, false,
+    "Whether to register the DocDB SST statistics collector on the regular RocksDB of each tablet. "
+    "The collector stores garbage and chain statistics in each SST file's properties block. Takes "
+    "effect on tablet (re)open.");
+
+DEFINE_RUNTIME_bool(docdb_sst_stats_coprefix_subtotals, false,
+    "Whether the DocDB SST statistics collector also records per-table (cotable / colocation id) "
+    "subtotals in colocated tablets. Applies to files built from then on.");
+
+DEFINE_RUNTIME_uint32(sst_tombstone_mark_ratio_percent, 30,
+    "Mark an SST file for compaction when at least this percentage of its entries are DocDB "
+    "tombstones (in combination with sst_tombstone_mark_min_count). The mark is persisted in the "
+    "MANIFEST; nothing consumes it under DocDB's universal compaction until a picker or trigger "
+    "explicitly opts in.");
+
+DEFINE_RUNTIME_uint64(sst_tombstone_mark_min_count, 10000,
+    "Mark an SST file for compaction only when it contains at least this many DocDB tombstones "
+    "(in combination with sst_tombstone_mark_ratio_percent).");
+
+namespace yb::docdb {
+
+namespace {
+
+constexpr size_t kCoprefixSubtotalsMaxBytes = 4096;
+
+// UserCollectedProperties is a std::map<std::string, std::string> without a transparent
+// comparator, so lookups need an owning key.
+rocksdb::UserCollectedProperties::const_iterator Find(
+    const rocksdb::UserCollectedProperties& properties, std::string_view key) {
+  return properties.find(std::string(key));
+}
+
+void Set(rocksdb::UserCollectedProperties* properties, std::string_view key, std::string value) {
+  (*properties)[std::string(key)] = std::move(value);
+}
+
+std::string JoinCounts(const AgeBandCounts& counts) {
+  std::string result;
+  for (size_t i = 0; i < counts.size(); ++i) {
+    if (i != 0) {
+      result += ',';
+    }
+    result += std::to_string(counts[i]);
+  }
+  return result;
+}
+
+Result<AgeBandCounts> SplitCounts(const std::string& text) {
+  AgeBandCounts result{};
+  const auto parts = StringSplit(text, ',');
+  SCHECK_EQ(parts.size(), result.size(), Corruption, Format("Expected 8 age bands in '$0'", text));
+  for (size_t i = 0; i < parts.size(); ++i) {
+    try {
+      result[i] = std::stoull(parts[i]);
+    } catch (const std::exception& e) {
+      return STATUS_FORMAT(Corruption, "Malformed age band '$0': $1", parts[i], e.what());
+    }
+  }
+  return result;
+}
+
+std::string SerializeCoprefixSubtotals(const std::map<std::string, CoprefixSubtotal>& subtotals) {
+  std::string result;
+  for (const auto& [coprefix, subtotal] : subtotals) {
+    std::string item = Format(
+        "$0:$1:$2:$3:$4", strings::b2a_hex(coprefix), subtotal.entries, subtotal.tombstone_entries,
+        subtotal.reclaimable_entries, subtotal.rows);
+    if (result.size() + item.size() + 1 > kCoprefixSubtotalsMaxBytes) {
+      result += ";...";
+      break;
+    }
+    if (!result.empty()) {
+      result += ';';
+    }
+    result += item;
+  }
+  return result;
+}
+
+Result<std::map<std::string, CoprefixSubtotal>> ParseCoprefixSubtotals(const std::string& text) {
+  std::map<std::string, CoprefixSubtotal> result;
+  if (text.empty()) {
+    return result;
+  }
+  for (const auto& item : StringSplit(text, ';')) {
+    if (item == "...") {
+      continue;
+    }
+    const auto fields = StringSplit(item, ':');
+    SCHECK_EQ(fields.size(), 5, Corruption, Format("Malformed coprefix subtotal '$0'", item));
+    try {
+      auto& subtotal = result[strings::a2b_hex(fields[0])];
+      subtotal.entries = std::stoull(fields[1]);
+      subtotal.tombstone_entries = std::stoull(fields[2]);
+      subtotal.reclaimable_entries = std::stoull(fields[3]);
+      subtotal.rows = std::stoull(fields[4]);
+    } catch (const std::exception& e) {
+      return STATUS_FORMAT(Corruption, "Malformed coprefix subtotal '$0': $1", item, e.what());
+    }
+  }
+  return result;
+}
+
+Result<const std::string&> Get(
+    const rocksdb::UserCollectedProperties& properties, std::string_view key) {
+  const auto it = Find(properties, key);
+  SCHECK(it != properties.end(), NotFound, Format("Missing SST property $0", key));
+  return it->second;
+}
+
+Result<uint64_t> GetUint64(
+    const rocksdb::UserCollectedProperties& properties, std::string_view key) {
+  const auto& text = VERIFY_RESULT_REF(Get(properties, key));
+  try {
+    return std::stoull(text);
+  } catch (const std::exception& e) {
+    return STATUS_FORMAT(
+        Corruption, "Malformed SST property $0 = '$1': $2", key, text, e.what());
+  }
+}
+
+Result<ExponentialHistogram> GetHistogram(
+    const rocksdb::UserCollectedProperties& properties, std::string_view key) {
+  return ExponentialHistogram::Parse(VERIFY_RESULT_REF(Get(properties, key)));
+}
+
+Result<AgeBandCounts> GetAgeBands(
+    const rocksdb::UserCollectedProperties& properties, std::string_view key) {
+  return SplitCounts(VERIFY_RESULT_REF(Get(properties, key)));
+}
+
+class SstStatsCollector : public rocksdb::TablePropertiesCollector {
+ public:
+  SstStatsCollector()
+      : tracker_(GetCurrentTimeMicros(), FLAGS_docdb_sst_stats_coprefix_subtotals) {}
+
+  Status AddUserKey(
+      const Slice& key, const Slice& value, rocksdb::EntryType type, rocksdb::SequenceNumber seq,
+      uint64_t file_size) override {
+    // A properties collector must never fail the table build; the tracker records parse failures
+    // in chain_valid instead of returning them.
+    tracker_.Add(key, value);
+    return Status::OK();
+  }
+
+  Status Finish(rocksdb::UserCollectedProperties* properties) override {
+    SstStatsToProperties(tracker_.Finish(), properties);
+    return Status::OK();
+  }
+
+  rocksdb::UserCollectedProperties GetReadableProperties() const override {
+    rocksdb::UserCollectedProperties properties;
+    // GetReadableProperties may be called before Finish; report what has been seen so far without
+    // closing the open row.
+    SstStatsToProperties(tracker_.stats(), &properties);
+    return properties;
+  }
+
+  const char* Name() const override { return "DocDbSstStatsCollector"; }
+
+  // Sets FileMetaData::marked_for_compaction on the just-built file, which the MANIFEST persists.
+  // Nothing consumes the mark under DocDB's universal compaction; the raw counts are stored
+  // regardless, so thresholds can be revisited without losing information.
+  bool NeedCompact() const override {
+    const auto& stats = tracker_.stats();
+    return stats.tombstone_entries >= FLAGS_sst_tombstone_mark_min_count &&
+           stats.tombstone_entries * 100 >=
+               stats.total_entries * FLAGS_sst_tombstone_mark_ratio_percent;
+  }
+
+ private:
+  ChainTracker tracker_;
+};
+
+class SstStatsCollectorFactory : public rocksdb::TablePropertiesCollectorFactory {
+ public:
+  rocksdb::TablePropertiesCollector* CreateTablePropertiesCollector(
+      rocksdb::TablePropertiesCollectorFactory::Context context) override {
+    return new SstStatsCollector();
+  }
+
+  const char* Name() const override { return "DocDbSstStatsCollectorFactory"; }
+};
+
+}  // namespace
+
+void SstStatsToProperties(const SstStats& stats, rocksdb::UserCollectedProperties* properties) {
+  using K = SstStatsPropertyKeys;
+  Set(properties, K::kCollectorVersion, std::string(kSstStatsCollectorVersion));
+  Set(properties, K::kTotalEntries, std::to_string(stats.total_entries));
+  Set(properties, K::kTombstoneEntries, std::to_string(stats.tombstone_entries));
+  Set(properties, K::kPackedRowEntries, std::to_string(stats.packed_row_entries));
+  Set(properties, K::kMetaEntries, std::to_string(stats.meta_entries));
+  Set(properties, K::kChainEntries, std::to_string(stats.chain_entries));
+  Set(properties, K::kChainBytes, std::to_string(stats.chain_bytes));
+  Set(properties, K::kNumSubdocKeys, std::to_string(stats.num_subdoc_keys));
+  Set(properties, K::kNumRows, std::to_string(stats.num_rows));
+  Set(properties, K::kDeadRows, std::to_string(stats.dead_rows));
+  Set(properties, K::kDeadRowEntries, std::to_string(stats.dead_row_entries));
+  Set(properties, K::kReclaimableEntries, std::to_string(stats.reclaimable_entries));
+  Set(properties, K::kReclaimableBytes, std::to_string(stats.reclaimable_bytes));
+  Set(properties, K::kMaxRowChain, std::to_string(stats.max_row_chain));
+  Set(properties, K::kMaxStretch, std::to_string(stats.max_stretch));
+  Set(properties, K::kChainValid, stats.chain_valid ? "1" : "0");
+  Set(properties, K::kMinWriteHt, std::to_string(stats.min_write_ht.ToUint64()));
+  Set(properties, K::kMaxWriteHt, std::to_string(stats.max_write_ht.ToUint64()));
+  Set(properties, K::kAnchorMicros, std::to_string(stats.anchor_micros));
+  Set(properties, K::kRowChainHist, stats.row_chain_hist.Serialize());
+  Set(properties, K::kRowChainBytesHist, stats.row_chain_bytes_hist.Serialize());
+  Set(properties, K::kStretchHist, stats.stretch_hist.Serialize());
+  Set(properties, K::kStretchEntriesHist, stats.stretch_entries_hist.Serialize());
+  Set(properties, K::kStretchBytesHist, stats.stretch_bytes_hist.Serialize());
+  Set(properties, K::kDroppableAgeEntries, JoinCounts(stats.droppable_age_entries));
+  Set(properties, K::kDroppableAgeBytes, JoinCounts(stats.droppable_age_bytes));
+  if (!stats.coprefix_subtotals.empty()) {
+    Set(properties, K::kCoprefixSubtotals, SerializeCoprefixSubtotals(stats.coprefix_subtotals));
+  }
+}
+
+Result<SstStats> SstStatsFromProperties(const rocksdb::UserCollectedProperties& properties) {
+  using K = SstStatsPropertyKeys;
+  const auto version = Find(properties, K::kCollectorVersion);
+  SCHECK(version != properties.end(), NotFound, "No DocDB SST statistics in properties");
+  SCHECK_EQ(version->second, kSstStatsCollectorVersion, NotSupported,
+            Format("Unsupported DocDB SST statistics version $0", version->second));
+  SstStats stats;
+  stats.total_entries = VERIFY_RESULT(GetUint64(properties, K::kTotalEntries));
+  stats.tombstone_entries = VERIFY_RESULT(GetUint64(properties, K::kTombstoneEntries));
+  stats.packed_row_entries = VERIFY_RESULT(GetUint64(properties, K::kPackedRowEntries));
+  stats.meta_entries = VERIFY_RESULT(GetUint64(properties, K::kMetaEntries));
+  stats.chain_entries = VERIFY_RESULT(GetUint64(properties, K::kChainEntries));
+  stats.chain_bytes = VERIFY_RESULT(GetUint64(properties, K::kChainBytes));
+  stats.num_subdoc_keys = VERIFY_RESULT(GetUint64(properties, K::kNumSubdocKeys));
+  stats.num_rows = VERIFY_RESULT(GetUint64(properties, K::kNumRows));
+  stats.dead_rows = VERIFY_RESULT(GetUint64(properties, K::kDeadRows));
+  stats.dead_row_entries = VERIFY_RESULT(GetUint64(properties, K::kDeadRowEntries));
+  stats.reclaimable_entries = VERIFY_RESULT(GetUint64(properties, K::kReclaimableEntries));
+  stats.reclaimable_bytes = VERIFY_RESULT(GetUint64(properties, K::kReclaimableBytes));
+  stats.max_row_chain = VERIFY_RESULT(GetUint64(properties, K::kMaxRowChain));
+  stats.max_stretch = VERIFY_RESULT(GetUint64(properties, K::kMaxStretch));
+  stats.chain_valid = VERIFY_RESULT(GetUint64(properties, K::kChainValid)) != 0;
+  stats.min_write_ht = HybridTime(VERIFY_RESULT(GetUint64(properties, K::kMinWriteHt)));
+  stats.max_write_ht = HybridTime(VERIFY_RESULT(GetUint64(properties, K::kMaxWriteHt)));
+  stats.anchor_micros =
+      static_cast<int64_t>(VERIFY_RESULT(GetUint64(properties, K::kAnchorMicros)));
+  stats.row_chain_hist = VERIFY_RESULT(GetHistogram(properties, K::kRowChainHist));
+  stats.row_chain_bytes_hist = VERIFY_RESULT(GetHistogram(properties, K::kRowChainBytesHist));
+  stats.stretch_hist = VERIFY_RESULT(GetHistogram(properties, K::kStretchHist));
+  stats.stretch_entries_hist = VERIFY_RESULT(GetHistogram(properties, K::kStretchEntriesHist));
+  stats.stretch_bytes_hist = VERIFY_RESULT(GetHistogram(properties, K::kStretchBytesHist));
+  stats.droppable_age_entries = VERIFY_RESULT(GetAgeBands(properties, K::kDroppableAgeEntries));
+  stats.droppable_age_bytes = VERIFY_RESULT(GetAgeBands(properties, K::kDroppableAgeBytes));
+  const auto subtotals = Find(properties, K::kCoprefixSubtotals);
+  if (subtotals != properties.end()) {
+    stats.coprefix_subtotals = VERIFY_RESULT(ParseCoprefixSubtotals(subtotals->second));
+  }
+  return stats;
+}
+
+std::shared_ptr<rocksdb::TablePropertiesCollectorFactory> MakeSstStatsCollectorFactory() {
+  return std::make_shared<SstStatsCollectorFactory>();
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/sst_stats_collector.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_collector.cc
@@ -18,6 +18,7 @@
 
 #include "yb/util/flags.h"
 #include "yb/util/status_format.h"
+#include "yb/util/stol_utils.h"
 #include "yb/util/string_util.h"
 
 DEFINE_NON_RUNTIME_bool(docdb_enable_sst_stats_collector, false,
@@ -72,11 +73,9 @@ Result<AgeBandCounts> SplitCounts(const std::string& text) {
   const auto parts = StringSplit(text, ',');
   SCHECK_EQ(parts.size(), result.size(), Corruption, Format("Expected 8 age bands in '$0'", text));
   for (size_t i = 0; i < parts.size(); ++i) {
-    try {
-      result[i] = std::stoull(parts[i]);
-    } catch (const std::exception& e) {
-      return STATUS_FORMAT(Corruption, "Malformed age band '$0': $1", parts[i], e.what());
-    }
+    // CheckedStoull rejects signs, empty input and trailing garbage, unlike std::stoull.
+    result[i] = VERIFY_RESULT_PREPEND(
+        CheckedStoull(Slice(parts[i])), Format("Malformed age band '$0'", parts[i]));
   }
   return result;
 }
@@ -110,15 +109,15 @@ Result<std::map<std::string, CoprefixSubtotal>> ParseCoprefixSubtotals(const std
     }
     const auto fields = StringSplit(item, ':');
     SCHECK_EQ(fields.size(), 5, Corruption, Format("Malformed coprefix subtotal '$0'", item));
-    try {
-      auto& subtotal = result[strings::a2b_hex(fields[0])];
-      subtotal.entries = std::stoull(fields[1]);
-      subtotal.tombstone_entries = std::stoull(fields[2]);
-      subtotal.reclaimable_entries = std::stoull(fields[3]);
-      subtotal.rows = std::stoull(fields[4]);
-    } catch (const std::exception& e) {
-      return STATUS_FORMAT(Corruption, "Malformed coprefix subtotal '$0': $1", item, e.what());
-    }
+    auto& subtotal = result[strings::a2b_hex(fields[0])];
+    const auto parse = [&item](const std::string& field) -> Result<uint64_t> {
+      return VERIFY_RESULT_PREPEND(
+          CheckedStoull(Slice(field)), Format("Malformed coprefix subtotal '$0'", item));
+    };
+    subtotal.entries = VERIFY_RESULT(parse(fields[1]));
+    subtotal.tombstone_entries = VERIFY_RESULT(parse(fields[2]));
+    subtotal.reclaimable_entries = VERIFY_RESULT(parse(fields[3]));
+    subtotal.rows = VERIFY_RESULT(parse(fields[4]));
   }
   return result;
 }
@@ -133,12 +132,8 @@ Result<const std::string&> Get(
 Result<uint64_t> GetUint64(
     const rocksdb::UserCollectedProperties& properties, std::string_view key) {
   const auto& text = VERIFY_RESULT_REF(Get(properties, key));
-  try {
-    return std::stoull(text);
-  } catch (const std::exception& e) {
-    return STATUS_FORMAT(
-        Corruption, "Malformed SST property $0 = '$1': $2", key, text, e.what());
-  }
+  return VERIFY_RESULT_PREPEND(
+      CheckedStoull(Slice(text)), Format("Malformed SST property $0 = '$1'", key, text));
 }
 
 Result<ExponentialHistogram> GetHistogram(

--- a/src/yb/docdb/properties_collector/sst_stats_collector.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_collector.cc
@@ -13,6 +13,7 @@
 
 #include "yb/docdb/properties_collector/sst_stats_collector.h"
 
+#include "yb/gutil/strings/ascii_ctype.h"
 #include "yb/gutil/strings/escaping.h"
 #include "yb/gutil/walltime.h"
 
@@ -46,6 +47,8 @@ namespace yb::docdb {
 namespace {
 
 constexpr size_t kCoprefixSubtotalsMaxBytes = 4096;
+// Appended in place of the coprefix subtotals that did not fit under the cap.
+constexpr std::string_view kTruncationMarker = "...";
 
 // UserCollectedProperties is a std::map<std::string, std::string> without a transparent
 // comparator, so lookups need an owning key.
@@ -87,8 +90,14 @@ std::string SerializeCoprefixSubtotals(const std::map<std::string, CoprefixSubto
     std::string item = Format(
         "$0:$1:$2:$3:$4", strings::b2a_hex(coprefix), subtotal.entries, subtotal.tombstone_entries,
         subtotal.reclaimable_entries, subtotal.rows);
-    if (result.size() + item.size() + 1 > kCoprefixSubtotalsMaxBytes) {
-      result += ";...";
+    // Reserve room for the truncation marker so the value never exceeds the cap, and never emit a
+    // leading separator: ";..." would parse as an empty first item and fail the field count.
+    if (result.size() + item.size() + 1 + kTruncationMarker.size() + 1 >
+        kCoprefixSubtotalsMaxBytes) {
+      if (!result.empty()) {
+        result += ';';
+      }
+      result += kTruncationMarker;
       break;
     }
     if (!result.empty()) {
@@ -99,22 +108,34 @@ std::string SerializeCoprefixSubtotals(const std::map<std::string, CoprefixSubto
   return result;
 }
 
+// strings::a2b_hex only DCHECKs that its input is hex, so validate before calling it: the input
+// here is on-disk data, which can be corrupt.
+Result<std::string> DecodeHex(const std::string& text) {
+  SCHECK_EQ(text.size() % 2, 0, Corruption, Format("Odd-length hex string '$0'", text));
+  for (char c : text) {
+    SCHECK(ascii_isxdigit(static_cast<unsigned char>(c)), Corruption,
+           Format("Non-hex character in '$0'", text));
+  }
+  return strings::a2b_hex(text);
+}
+
 Result<std::map<std::string, CoprefixSubtotal>> ParseCoprefixSubtotals(
-    const std::string& text, bool* truncated) {
+    const std::string& text, bool& truncated) {
   std::map<std::string, CoprefixSubtotal> result;
+  truncated = false;
   if (text.empty()) {
     return result;
   }
   for (const auto& item : StringSplit(text, ';')) {
-    if (item == "...") {
+    if (item == kTruncationMarker) {
       // The serializer appends this marker when it stopped below the size cap: the map here is a
       // prefix of the tablet's tables, not all of them.
-      *truncated = true;
+      truncated = true;
       continue;
     }
     const auto fields = StringSplit(item, ':');
     SCHECK_EQ(fields.size(), 5, Corruption, Format("Malformed coprefix subtotal '$0'", item));
-    auto& subtotal = result[strings::a2b_hex(fields[0])];
+    auto& subtotal = result[VERIFY_RESULT(DecodeHex(fields[0]))];
     const auto parse = [&item](const std::string& field) -> Result<uint64_t> {
       return VERIFY_RESULT_PREPEND(
           CheckedStoull(Slice(field)), Format("Malformed coprefix subtotal '$0'", item));
@@ -275,7 +296,7 @@ Result<SstStats> SstStatsFromProperties(const rocksdb::UserCollectedProperties& 
   const auto subtotals = Find(properties, K::kCoprefixSubtotals);
   if (subtotals != properties.end()) {
     stats.coprefix_subtotals = VERIFY_RESULT(
-        ParseCoprefixSubtotals(subtotals->second, &stats.coprefix_subtotals_truncated));
+        ParseCoprefixSubtotals(subtotals->second, stats.coprefix_subtotals_truncated));
   }
   return stats;
 }

--- a/src/yb/docdb/properties_collector/sst_stats_collector.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_collector.cc
@@ -99,13 +99,17 @@ std::string SerializeCoprefixSubtotals(const std::map<std::string, CoprefixSubto
   return result;
 }
 
-Result<std::map<std::string, CoprefixSubtotal>> ParseCoprefixSubtotals(const std::string& text) {
+Result<std::map<std::string, CoprefixSubtotal>> ParseCoprefixSubtotals(
+    const std::string& text, bool* truncated) {
   std::map<std::string, CoprefixSubtotal> result;
   if (text.empty()) {
     return result;
   }
   for (const auto& item : StringSplit(text, ';')) {
     if (item == "...") {
+      // The serializer appends this marker when it stopped below the size cap: the map here is a
+      // prefix of the tablet's tables, not all of them.
+      *truncated = true;
       continue;
     }
     const auto fields = StringSplit(item, ':');
@@ -270,7 +274,8 @@ Result<SstStats> SstStatsFromProperties(const rocksdb::UserCollectedProperties& 
   stats.droppable_age_bytes = VERIFY_RESULT(GetAgeBands(properties, K::kDroppableAgeBytes));
   const auto subtotals = Find(properties, K::kCoprefixSubtotals);
   if (subtotals != properties.end()) {
-    stats.coprefix_subtotals = VERIFY_RESULT(ParseCoprefixSubtotals(subtotals->second));
+    stats.coprefix_subtotals = VERIFY_RESULT(
+        ParseCoprefixSubtotals(subtotals->second, &stats.coprefix_subtotals_truncated));
   }
   return stats;
 }

--- a/src/yb/docdb/properties_collector/sst_stats_collector.h
+++ b/src/yb/docdb/properties_collector/sst_stats_collector.h
@@ -38,8 +38,9 @@ namespace yb::docdb {
 //                by bytes). ExponentialHistogram::Serialize() form.
 //   age bands    reclaimable entries and bytes by age of what makes them droppable (8 bands).
 //   colocation   per-coprefix subtotals, only when enabled by flag.
-// A typical file adds well under 1 KB (histograms are sparse); the fully dense worst case is about
-// 1.7 KB per histogram.
+// Size: the fixed keys alone are ~620 bytes, and the properties block stores keys unshared and
+// uncompressed, so even a near-empty file adds ~0.8 KB; a typical file with populated (sparse)
+// histograms adds ~1-1.5 KB, and the fully dense worst case is ~1.7 KB per histogram on top.
 struct SstStatsPropertyKeys {
   static constexpr std::string_view kCollectorVersion = "yb.docdb.collector_version";
   static constexpr std::string_view kTotalEntries = "yb.docdb.total_entries";

--- a/src/yb/docdb/properties_collector/sst_stats_collector.h
+++ b/src/yb/docdb/properties_collector/sst_stats_collector.h
@@ -1,0 +1,88 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <memory>
+#include <string_view>
+
+#include "yb/docdb/properties_collector/chain_tracker.h"
+
+#include "yb/rocksdb/table_properties.h"
+
+namespace yb::docdb {
+
+// DocDB-aware SST properties collector: measures garbage (tombstones, shadowed versions, dead rows)
+// and chain / stretch distributions while an SST file is built, and stores them in the file's
+// user_collected_properties block. Design and vocabulary: properties_collector/README.md.
+
+// Keys of the properties this collector stores, all under "yb.docdb.". Values are decimal strings
+// unless noted. Groups:
+//   counts       total/tombstone/packed-row/meta entries; chain entries (Ec) and bytes; subdoc keys
+//                (K); rows (R); dead rows and their entries; reclaimable entries and bytes; max row
+//                chain; max stretch. Shadowed (Ec-K), repackable (K-R), collapsible (Ec-R) are
+//                identities, not stored.
+//   validity     collector_version, chain_valid.
+//   write range  exact min/max write hybrid time of chain-tracked entries; the age-band anchor.
+//   histograms   row-chain length (by rows, by bytes); stretch length (by stretches, by entries,
+//                by bytes). ExponentialHistogram::Serialize() form.
+//   age bands    reclaimable entries and bytes by age of what makes them droppable (8 bands).
+//   colocation   per-coprefix subtotals, only when enabled by flag.
+// A typical file adds well under 1 KB (histograms are sparse); the fully dense worst case is about
+// 1.7 KB per histogram.
+struct SstStatsPropertyKeys {
+  static constexpr std::string_view kCollectorVersion = "yb.docdb.collector_version";
+  static constexpr std::string_view kTotalEntries = "yb.docdb.total_entries";
+  static constexpr std::string_view kTombstoneEntries = "yb.docdb.tombstone_entries";
+  static constexpr std::string_view kPackedRowEntries = "yb.docdb.packed_row_entries";
+  static constexpr std::string_view kMetaEntries = "yb.docdb.meta_entries";
+  static constexpr std::string_view kChainEntries = "yb.docdb.chain_entries";
+  static constexpr std::string_view kChainBytes = "yb.docdb.chain_bytes";
+  static constexpr std::string_view kNumSubdocKeys = "yb.docdb.num_subdoc_keys";
+  static constexpr std::string_view kNumRows = "yb.docdb.num_rows";
+  static constexpr std::string_view kDeadRows = "yb.docdb.dead_rows";
+  static constexpr std::string_view kDeadRowEntries = "yb.docdb.dead_row_entries";
+  static constexpr std::string_view kReclaimableEntries = "yb.docdb.reclaimable_entries";
+  static constexpr std::string_view kReclaimableBytes = "yb.docdb.reclaimable_bytes";
+  static constexpr std::string_view kMaxRowChain = "yb.docdb.max_row_chain";
+  static constexpr std::string_view kMaxStretch = "yb.docdb.max_stretch";
+  static constexpr std::string_view kChainValid = "yb.docdb.chain_valid";  // "1" or "0"
+  // HybridTime::ToUint64().
+  static constexpr std::string_view kMinWriteHt = "yb.docdb.min_write_ht";
+  static constexpr std::string_view kMaxWriteHt = "yb.docdb.max_write_ht";
+  static constexpr std::string_view kAnchorMicros = "yb.docdb.stats_anchor_micros";
+  // ExponentialHistogram::Serialize().
+  static constexpr std::string_view kRowChainHist = "yb.docdb.row_chain_hist";
+  static constexpr std::string_view kRowChainBytesHist = "yb.docdb.row_chain_bytes_hist";
+  static constexpr std::string_view kStretchHist = "yb.docdb.stretch_hist";
+  static constexpr std::string_view kStretchEntriesHist = "yb.docdb.stretch_entries_hist";
+  static constexpr std::string_view kStretchBytesHist = "yb.docdb.stretch_bytes_hist";
+  // 8 comma-separated counts.
+  static constexpr std::string_view kDroppableAgeEntries = "yb.docdb.droppable_age_entries";
+  static constexpr std::string_view kDroppableAgeBytes = "yb.docdb.droppable_age_bytes";
+  // "<hex coprefix>:<entries>:<tombstones>:<reclaimable>:<rows>" items joined by ';'.
+  static constexpr std::string_view kCoprefixSubtotals = "yb.docdb.coprefix_subtotals";
+};
+
+// Value of kCollectorVersion written by this code.
+inline constexpr std::string_view kSstStatsCollectorVersion = "2";
+
+// Serializes statistics into a properties map (what Finish() writes) and reads them back.
+void SstStatsToProperties(const SstStats& stats, rocksdb::UserCollectedProperties* properties);
+Result<SstStats> SstStatsFromProperties(const rocksdb::UserCollectedProperties& properties);
+
+// Creates the collector factory. Registered on each tablet's regular RocksDB when
+// --docdb_enable_sst_stats_collector is set.
+std::shared_ptr<rocksdb::TablePropertiesCollectorFactory> MakeSstStatsCollectorFactory();
+
+}  // namespace yb::docdb

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -68,6 +68,7 @@
 #include "yb/docdb/docdb_rocksdb_util.h"
 #include "yb/docdb/docdb_statistics.h"
 #include "yb/docdb/docdb_util.h"
+#include "yb/docdb/properties_collector/sst_stats_collector.h"
 #include "yb/docdb/pgsql_operation.h"
 #include "yb/docdb/ql_rocksdb_storage.h"
 #include "yb/docdb/redis_operation.h"
@@ -366,6 +367,7 @@ DEFINE_RUNTIME_AUTO_bool(enable_transaction_metadata_update, kLocalPersisted, fa
 DECLARE_bool(cdc_immediate_transaction_cleanup);
 DECLARE_bool(cdc_enable_time_based_intent_retention);
 DECLARE_bool(consistent_restore);
+DECLARE_bool(docdb_enable_sst_stats_collector);
 DECLARE_bool(flush_rocksdb_on_shutdown);
 DECLARE_bool(TEST_invalidate_last_change_metadata_op);
 DECLARE_int32(client_read_write_timeout_ms);
@@ -1243,6 +1245,11 @@ Status Tablet::OpenRegularDB(const rocksdb::Options& common_options) {
     table_options.use_delta_encoding = UseDeltaEncoding(table_type_);
     docdb::InitRocksDBOptionsTableFactory(
         &regular_rocksdb_options, tablet_options_, std::move(table_options));
+  }
+
+  if (FLAGS_docdb_enable_sst_stats_collector) {
+    regular_rocksdb_options.table_properties_collector_factories.push_back(
+        docdb::MakeSstStatsCollectorFactory());
   }
 
   // Install the history cleanup handler. Note that TabletRetentionPolicy is going to hold a raw ptr


### PR DESCRIPTION

Summary:
The RocksDB-facing half of the SST statistics collector, on top of the
chain tracker from the previous change in this stack: property keys (all
under yb.docdb.*), SstStats <-> user_collected_properties serialization
(sparse histograms with a scale tag; 8 comma-separated age-band counts;
capped per-coprefix subtotals), the rocksdb::TablePropertiesCollector
wrapper, and per-tablet registration on the regular RocksDB.

The collector runs while an SST is built (flush or compaction, on every
replica) and stores what the tracker saw in the file's own properties
block. This is the storage-side signal the read-driven full-compaction
trigger lacks: followers and point-get workloads never populate the read
statistics (#33267), so garbage debt goes unmeasured until reads suffer.

NeedCompact() keeps the v1 semantics: tombstone-heavy files get
FileMetaData::marked_for_compaction (MANIFEST breadcrumb only; nothing
consumes it under universal compaction).

Registration is behind docdb_enable_sst_stats_collector, DEFAULT OFF.
Flipping the default is a separate change gated on performance results.

Not in this change: the per-tablet aggregate, the Prometheus gauges and
the full-compaction trigger clause that consume these properties. They
follow separately.

Replaces the Phorge draft D56928.

Test Plan:
./yb_build.sh release --cxx-test sst_stats_collector-test
(properties round trip; the collector end to end through the RocksDB
interface including NeedCompact)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
