### PR TITLE
[DOC-1433] DocDB: Note that follower eviction and WAL retention flags should match

### DIFF
--- a/src/yb/consensus/consensus_queue.cc
+++ b/src/yb/consensus/consensus_queue.cc
@@ -84,7 +84,8 @@ DECLARE_double(leader_failure_max_missed_heartbeat_periods);
 DEFINE_RUNTIME_int32(follower_unavailable_considered_failed_sec, 900,
              "Seconds that a leader is unable to successfully heartbeat to a "
              "follower after which the follower is considered to be failed and "
-             "evicted from the config.");
+             "evicted from the config. This value should match "
+             "log_min_seconds_to_retain.");
 TAG_FLAG(follower_unavailable_considered_failed_sec, advanced);
 DEFINE_validator(follower_unavailable_considered_failed_sec,
   FLAG_DELAYED_COND_VALIDATOR(

--- a/src/yb/consensus/log.cc
+++ b/src/yb/consensus/log.cc
@@ -112,7 +112,7 @@ DEFINE_RUNTIME_int32(log_min_seconds_to_retain, 900,
     "set long enough such that a tablet server which has temporarily failed can be "
     "restarted within the given time period. If a server is down for longer than this "
     "amount of time, it is possible that its tablets will be re-replicated on other "
-    "machines.");
+    "machines. This value should match follower_unavailable_considered_failed_sec.");
 TAG_FLAG(log_min_seconds_to_retain, advanced);
 
 // Flag to enable background log sync. When enabled, we DON'T wait for performing fsync until


### PR DESCRIPTION
## Summary

The handwritten yb-tserver configuration reference says `follower_unavailable_considered_failed_sec` should match `log_min_seconds_to_retain`. The generated All YB-TServer flags page omitted that, because it is built from DEFINE help strings.

Add the match note to both flags' help strings so the generated list carries the same guidance. Help text only; no validator or default change.

## Test plan

- [x] Inspected the DEFINE help-string diff
- [x] No runtime behavior change (help text only)
