### PR TITLE
[BACKPORT 2026.1][PLAT-22125] YBA: Validate YSQL/YCQL auth and password consistency in the operator (#33687)

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/common/operator/YBUniverseReconciler.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/operator/YBUniverseReconciler.java
@@ -76,7 +76,6 @@ import io.yugabyte.operator.v1alpha1.ybuniversespec.YcqlPassword;
 import io.yugabyte.operator.v1alpha1.ybuniversespec.YsqlPassword;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -1280,7 +1279,8 @@ public class YBUniverseReconciler extends AbstractReconciler<YBUniverse> {
     return createTaskParams(ybUniverse, customerUUID, provider);
   }
 
-  private UserIntent createUserIntent(
+  @VisibleForTesting
+  protected UserIntent createUserIntent(
       YBUniverse ybUniverse, UUID customerUUID, boolean isCreate, Provider provider) {
     Optional<Universe> optUniverse = Optional.empty();
     if (!isCreate) {
@@ -1390,31 +1390,40 @@ public class YBUniverseReconciler extends AbstractReconciler<YBUniverse> {
       }
 
       // Handle Passwords
+      // enableYSQLAuth/enableYCQLAuth in the spec decide whether auth is enabled - the password
+      // secret only carries the password itself. On create the two must agree, and the secret must
+      // hold a password. On edit the secret is not read at all, so dropping the password from the
+      // spec, or pointing it at a secret that is empty or deleted, is a no-op rather than a silent
+      // change to the stored intent or a failed reconcile of everything else in the spec.
       YsqlPassword ysqlPassword = ybUniverse.getSpec().getYsqlPassword();
-      if (ysqlPassword != null) {
-        Secret ysqlSecret = getSecret(ysqlPassword.getSecretName());
-        trackDependency(ybUniverse, ysqlSecret);
-        String password = parseSecretForKey(ysqlSecret, YSQL_PASSWORD_SECRET_KEY);
-        if (password == null) {
-          log.error("could not find ysqlPassword in secret {}", ysqlPassword.getSecretName());
-          throw new RuntimeException(
-              "could not find ysqlPassword in secret " + ysqlPassword.getSecretName());
-        }
-        userIntent.enableYSQLAuth = true;
-        userIntent.ysqlPassword = password;
-      }
       YcqlPassword ycqlPassword = ybUniverse.getSpec().getYcqlPassword();
-      if (ycqlPassword != null) {
-        Secret ycqlSecret = getSecret(ycqlPassword.getSecretName());
-        trackDependency(ybUniverse, ycqlSecret);
-        String password = parseSecretForKey(ycqlSecret, YCQL_PASSWORD_SECRET_KEY);
-        if (password == null) {
-          log.error("could not find ycqlPassword in secret {}", ycqlPassword.getSecretName());
-          throw new RuntimeException(
-              "could not find ycqlPassword in secret " + ycqlPassword.getSecretName());
+      String ysqlSecretName = ysqlPassword != null ? ysqlPassword.getSecretName() : null;
+      String ycqlSecretName = ycqlPassword != null ? ycqlPassword.getSecretName() : null;
+      if (isCreate) {
+        userIntent.enableYSQLAuth = ybUniverse.getSpec().getEnableYSQLAuth();
+        validateAuthSpec(userIntent.enableYSQLAuth, ysqlSecretName != null, "YSQL", "ysqlPassword");
+        if (ysqlSecretName != null) {
+          userIntent.ysqlPassword =
+              getPasswordFromSecret(ybUniverse, ysqlSecretName, YSQL_PASSWORD_SECRET_KEY);
         }
-        userIntent.enableYCQLAuth = true;
-        userIntent.ycqlPassword = password;
+        userIntent.enableYCQLAuth = ybUniverse.getSpec().getEnableYCQLAuth();
+        validateAuthSpec(userIntent.enableYCQLAuth, ycqlSecretName != null, "YCQL", "ycqlPassword");
+        if (ycqlSecretName != null) {
+          userIntent.ycqlPassword =
+              getPasswordFromSecret(ybUniverse, ycqlSecretName, YCQL_PASSWORD_SECRET_KEY);
+        }
+      } else {
+        // TODO: PLAT-22298 to actually add support for password rotation.
+        // This will need to call into UniverseYbDbAdminController.setDatabaseCredentials ONLY when
+        // the password is actually being changed, and should happen directly in the edit call
+        // when a new secret is provided.
+        userIntent.enableYSQLAuth = ybUniverse.getSpec().getEnableYSQLAuth();
+        userIntent.enableYCQLAuth = ybUniverse.getSpec().getEnableYCQLAuth();
+        // The password itself is not read here, but the secrets stay registered as dependencies:
+        // this is the only pass that registers them for universes whose CRs predate
+        // operator_resource, and the rows drive HA restore and orphan cleanup.
+        trackPasswordSecret(ybUniverse, ysqlSecretName);
+        trackPasswordSecret(ybUniverse, ycqlSecretName);
       }
       userIntent.specificGFlags = operatorUtils.getGFlagsFromSpec(ybUniverse, provider);
 
@@ -2107,17 +2116,58 @@ public class YBUniverseReconciler extends AbstractReconciler<YBUniverse> {
     return client.secrets().inNamespace("default").withName(name).get();
   }
 
-  // parseSecretForKey checks secret data for the key. If not found, it will then check stringData.
-  // Returns null if the key is not found at all.
-  // Also handles null secret.
-  private String parseSecretForKey(Secret secret, String key) {
-    if (secret == null) {
+  // trackPasswordSecret registers the named secret as a dependency of the universe in
+  // operator_resource and returns it, without reading anything out of it. The dependency row is
+  // what HA failover restores the secret from and what marks it orphaned when the CR is deleted,
+  // so it has to be refreshed on every reconcile, including the ones that never read the password.
+  // A reference to a secret that does not exist is logged and ignored - it must not fail the
+  // reconcile of the rest of the spec.
+  private Secret trackPasswordSecret(YBUniverse ybUniverse, @Nullable String secretName) {
+    if (secretName == null) {
       return null;
     }
-    if (secret.getData().get(key) != null) {
-      return new String(Base64.getDecoder().decode(secret.getData().get(key)));
+    Secret secret = getSecret(secretName);
+    if (secret == null) {
+      log.warn(
+          "secret {} referenced by universe {} not found",
+          secretName,
+          ybUniverse.getMetadata().getName());
+      return null;
     }
-    return secret.getStringData().get(key);
+    trackDependency(ybUniverse, secret);
+    return secret;
+  }
+
+  // getPasswordFromSecret returns the password held by the named secret, failing if the secret is
+  // missing or holds no password. Only used when creating a universe - on edit a secret that cannot
+  // be read is ignored, see the note on passwords in createUserIntent.
+  private String getPasswordFromSecret(
+      YBUniverse ybUniverse, String secretName, String passwordKey) {
+    String password =
+        operatorUtils.parseSecretForKey(trackPasswordSecret(ybUniverse, secretName), passwordKey);
+    if (StringUtils.isBlank(password)) {
+      log.error("could not find {} in secret {}", passwordKey, secretName);
+      throw new RuntimeException(
+          String.format("could not find %s in secret %s", passwordKey, secretName));
+    }
+    return password;
+  }
+
+  // validateAuthSpec fails if the spec's auth flag and its password secret reference disagree.
+  // Auth cannot be turned on without a password to set it to, and a password is meaningless
+  // without auth. Only enforced when creating a universe: a universe imported into the operator
+  // by OperatorUtils.createUniverseCr has auth enabled with no secret to reference, because the
+  // import writes no Secret, so enforcing this on the edit path would break that flow.
+  private void validateAuthSpec(
+      boolean authEnabled, boolean passwordSet, String apiName, String specFieldName) {
+    if (authEnabled && !passwordSet) {
+      throw new RuntimeException(
+          String.format("%s must be set when enable%sAuth is true", specFieldName, apiName));
+    }
+    if (!authEnabled && passwordSet) {
+      throw new RuntimeException(
+          String.format("enable%sAuth must be true when %s is set", apiName, specFieldName));
+    }
   }
 
   private void createAutoProviderCR(YBUniverse ybUniverse, String providerName, UUID customerUUID) {

--- a/managed/src/main/java/com/yugabyte/yw/common/operator/utils/OperatorUtils.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/operator/utils/OperatorUtils.java
@@ -1364,10 +1364,11 @@ public class OperatorUtils {
     if (secret == null) {
       return null;
     }
-    if (secret.getData().get(key) != null) {
+    // A secret carries data, stringData, or neither - whichever is absent comes back null.
+    if (secret.getData() != null && secret.getData().get(key) != null) {
       return new String(Base64.getDecoder().decode(secret.getData().get(key)));
     }
-    return secret.getStringData().get(key);
+    return secret.getStringData() != null ? secret.getStringData().get(key) : null;
   }
 
   /*

--- a/managed/src/test/java/com/yugabyte/yw/common/operator/YBUniverseReconcilerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/common/operator/YBUniverseReconcilerTest.java
@@ -75,6 +75,9 @@ import com.yugabyte.yw.models.helpers.provider.region.KubernetesRegionInfo;
 import com.yugabyte.yw.models.helpers.telemetry.ExportType;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
@@ -84,6 +87,8 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 import io.yugabyte.operator.v1alpha1.YBUniverse;
 import io.yugabyte.operator.v1alpha1.ybuniversespec.KubernetesOverrides;
 import io.yugabyte.operator.v1alpha1.ybuniversespec.Telemetry;
+import io.yugabyte.operator.v1alpha1.ybuniversespec.YcqlPassword;
+import io.yugabyte.operator.v1alpha1.ybuniversespec.YsqlPassword;
 import io.yugabyte.operator.v1alpha1.ybuniversespec.kubernetesoverrides.Resource;
 import io.yugabyte.operator.v1alpha1.ybuniversespec.kubernetesoverrides.resource.Master;
 import io.yugabyte.operator.v1alpha1.ybuniversespec.kubernetesoverrides.resource.master.Limits;
@@ -97,6 +102,7 @@ import io.yugabyte.operator.v1alpha1.ybuniversespec.telemetry.YsqlConnMgrLogs;
 import io.yugabyte.operator.v1alpha1.ybuniversespec.telemetry.auditlogs.YcqlAuditConfig;
 import io.yugabyte.operator.v1alpha1.ybuniversespec.telemetry.auditlogs.YsqlAuditConfig;
 import io.yugabyte.operator.v1alpha1.ybuniversespec.telemetry.querylogs.YsqlQueryLogConfig;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -136,6 +142,15 @@ public class YBUniverseReconcilerTest extends FakeDBApplication {
       inNamespaceYBUClient;
 
   @Mock io.fabric8.kubernetes.client.dsl.Resource<YBUniverse> ybUniverseResource;
+
+  @Mock
+  MixedOperation<Secret, SecretList, io.fabric8.kubernetes.client.dsl.Resource<Secret>>
+      secretClient;
+
+  @Mock
+  NonNamespaceOperation<Secret, SecretList, io.fabric8.kubernetes.client.dsl.Resource<Secret>>
+      inNamespaceSecretClient;
+
   @Mock RuntimeConfGetter confGetter;
   @Mock RuntimeConfGetter confGetterForOperatorUtils;
   @Mock YBInformerFactory informerFactory;
@@ -2473,5 +2488,254 @@ public class YBUniverseReconcilerTest extends FakeDBApplication {
     String createdName = captor.getValue().getPrimaryCluster().userIntent.universeName;
     assertEquals(OperatorUtils.getYbaResourceName(ybUniverse.getMetadata()), createdName);
     assertFalse("user-chosen-name".equals(createdName));
+  }
+
+  // ---------- YSQL/YCQL auth and password secret handling ----------
+
+  @SuppressWarnings("unchecked")
+  private void mockSecretLookup(String secretName, Secret secret) {
+    Mockito.when(client.secrets()).thenReturn(secretClient);
+    Mockito.when(secretClient.inNamespace(namespace)).thenReturn(inNamespaceSecretClient);
+    io.fabric8.kubernetes.client.dsl.Resource<Secret> secretResource =
+        Mockito.mock(io.fabric8.kubernetes.client.dsl.Resource.class);
+    Mockito.when(inNamespaceSecretClient.withName(secretName)).thenReturn(secretResource);
+    Mockito.when(secretResource.get()).thenReturn(secret);
+  }
+
+  // A null password builds a secret that exists but holds no password.
+  private Secret secretWithPassword(String secretName, String key, String password) {
+    Secret secret = new Secret();
+    ObjectMeta metadata = new ObjectMeta();
+    metadata.setName(secretName);
+    metadata.setNamespace(namespace);
+    secret.setMetadata(metadata);
+    if (password != null) {
+      secret.setStringData(Collections.singletonMap(key, password));
+    }
+    return secret;
+  }
+
+  private void setYsqlAuthSpec(YBUniverse ybUniverse, boolean authEnabled, String secretName) {
+    ybUniverse.getSpec().setEnableYSQLAuth(authEnabled);
+    if (secretName != null) {
+      YsqlPassword ysqlPassword = new YsqlPassword();
+      ysqlPassword.setSecretName(secretName);
+      ybUniverse.getSpec().setYsqlPassword(ysqlPassword);
+    }
+  }
+
+  private void setYcqlAuthSpec(YBUniverse ybUniverse, boolean authEnabled, String secretName) {
+    ybUniverse.getSpec().setEnableYCQL(true);
+    ybUniverse.getSpec().setEnableYCQLAuth(authEnabled);
+    if (secretName != null) {
+      YcqlPassword ycqlPassword = new YcqlPassword();
+      ycqlPassword.setSecretName(secretName);
+      ybUniverse.getSpec().setYcqlPassword(ycqlPassword);
+    }
+  }
+
+  // Creates a universe with both APIs' auth already enabled, as it would be after a create with
+  // passwords or after being imported into the operator from YBA.
+  private Universe createUniverseWithAuthEnabled(YBUniverse ybUniverse) throws Exception {
+    UniverseDefinitionTaskParams taskParams =
+        ybUniverseReconciler.createTaskParams(ybUniverse, defaultCustomer.getUuid());
+    Universe universe = Universe.create(taskParams, defaultCustomer.getId());
+    return Universe.saveDetails(
+        universe.getUniverseUUID(),
+        u -> {
+          UniverseDefinitionTaskParams details = u.getUniverseDetails();
+          UserIntent userIntent = details.getPrimaryCluster().userIntent;
+          userIntent.enableYSQLAuth = true;
+          userIntent.ysqlPassword = "stored-ysql-pass";
+          userIntent.enableYCQLAuth = true;
+          userIntent.ycqlPassword = "stored-ycql-pass";
+          u.setUniverseDetails(details);
+        });
+  }
+
+  @Test
+  public void testCreateUserIntentSetsAuthAndPasswordsFromSpec() {
+    YBUniverse ybUniverse = ModelFactory.createYbUniverse("test-auth-from-spec", defaultProvider);
+    setYsqlAuthSpec(ybUniverse, true, "ysql-secret");
+    setYcqlAuthSpec(ybUniverse, true, "ycql-secret");
+    mockSecretLookup("ysql-secret", secretWithPassword("ysql-secret", "ysqlPassword", "ysqlPass"));
+    mockSecretLookup("ycql-secret", secretWithPassword("ycql-secret", "ycqlPassword", "ycqlPass"));
+
+    UserIntent userIntent =
+        ybUniverseReconciler.createUserIntent(
+            ybUniverse, defaultCustomer.getUuid(), true /* isCreate */, defaultProvider);
+
+    assertTrue(userIntent.enableYSQLAuth);
+    assertEquals("ysqlPass", userIntent.ysqlPassword);
+    assertTrue(userIntent.enableYCQLAuth);
+    assertEquals("ycqlPass", userIntent.ycqlPassword);
+  }
+
+  @Test
+  public void testCreateUserIntentNoAuthWhenSpecHasNeither() {
+    // ModelFactory's spec sets neither auth flag nor a password secret.
+    YBUniverse ybUniverse = ModelFactory.createYbUniverse("test-auth-unset", defaultProvider);
+
+    UserIntent userIntent =
+        ybUniverseReconciler.createUserIntent(
+            ybUniverse, defaultCustomer.getUuid(), true /* isCreate */, defaultProvider);
+
+    assertFalse(userIntent.enableYSQLAuth);
+    assertNull(userIntent.ysqlPassword);
+    assertFalse(userIntent.enableYCQLAuth);
+    assertNull(userIntent.ycqlPassword);
+  }
+
+  @Test
+  public void testCreateUserIntentFailsWhenYsqlAuthEnabledWithoutPassword() {
+    YBUniverse ybUniverse = ModelFactory.createYbUniverse("test-ysql-auth-nopass", defaultProvider);
+    setYsqlAuthSpec(ybUniverse, true, null);
+
+    RuntimeException e =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                ybUniverseReconciler.createUserIntent(
+                    ybUniverse, defaultCustomer.getUuid(), true /* isCreate */, defaultProvider));
+    assertTrue(
+        e.getMessage(),
+        e.getMessage().contains("ysqlPassword must be set when enableYSQLAuth is true"));
+  }
+
+  @Test
+  public void testCreateUserIntentFailsWhenYcqlAuthEnabledWithoutPassword() {
+    YBUniverse ybUniverse = ModelFactory.createYbUniverse("test-ycql-auth-nopass", defaultProvider);
+    setYcqlAuthSpec(ybUniverse, true, null);
+
+    RuntimeException e =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                ybUniverseReconciler.createUserIntent(
+                    ybUniverse, defaultCustomer.getUuid(), true /* isCreate */, defaultProvider));
+    assertTrue(
+        e.getMessage(),
+        e.getMessage().contains("ycqlPassword must be set when enableYCQLAuth is true"));
+  }
+
+  @Test
+  public void testCreateUserIntentFailsWhenYsqlPasswordSetWithoutAuth() {
+    YBUniverse ybUniverse = ModelFactory.createYbUniverse("test-ysql-pass-noauth", defaultProvider);
+    setYsqlAuthSpec(ybUniverse, false, "ysql-secret");
+
+    RuntimeException e =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                ybUniverseReconciler.createUserIntent(
+                    ybUniverse, defaultCustomer.getUuid(), true /* isCreate */, defaultProvider));
+    assertTrue(
+        e.getMessage(),
+        e.getMessage().contains("enableYSQLAuth must be true when ysqlPassword is set"));
+  }
+
+  @Test
+  public void testCreateUserIntentFailsWhenYcqlPasswordSetWithoutAuth() {
+    YBUniverse ybUniverse = ModelFactory.createYbUniverse("test-ycql-pass-noauth", defaultProvider);
+    setYcqlAuthSpec(ybUniverse, false, "ycql-secret");
+
+    RuntimeException e =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                ybUniverseReconciler.createUserIntent(
+                    ybUniverse, defaultCustomer.getUuid(), true /* isCreate */, defaultProvider));
+    assertTrue(
+        e.getMessage(),
+        e.getMessage().contains("enableYCQLAuth must be true when ycqlPassword is set"));
+  }
+
+  @Test
+  public void testCreateUserIntentFailsWhenSecretHoldsNoPassword() {
+    YBUniverse ybUniverse = ModelFactory.createYbUniverse("test-empty-secret", defaultProvider);
+    setYsqlAuthSpec(ybUniverse, true, "ysql-secret");
+    mockSecretLookup("ysql-secret", secretWithPassword("ysql-secret", "ysqlPassword", null));
+
+    RuntimeException e =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                ybUniverseReconciler.createUserIntent(
+                    ybUniverse, defaultCustomer.getUuid(), true /* isCreate */, defaultProvider));
+    assertTrue(
+        e.getMessage(),
+        e.getMessage().contains("could not find ysqlPassword in secret ysql-secret"));
+  }
+
+  @Test
+  public void testCreateUserIntentFailsWhenSecretMissing() {
+    YBUniverse ybUniverse = ModelFactory.createYbUniverse("test-missing-secret", defaultProvider);
+    setYcqlAuthSpec(ybUniverse, true, "ycql-secret");
+    mockSecretLookup("ycql-secret", null);
+
+    RuntimeException e =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                ybUniverseReconciler.createUserIntent(
+                    ybUniverse, defaultCustomer.getUuid(), true /* isCreate */, defaultProvider));
+    assertTrue(
+        e.getMessage(),
+        e.getMessage().contains("could not find ycqlPassword in secret ycql-secret"));
+  }
+
+  // Asserts that an edit reconcile left the universe's own auth settings untouched. The operator
+  // cannot toggle auth or rotate a password yet, so an edit must never write either back.
+  private void assertUniverseAuthUnchanged(UUID universeUuid) {
+    Universe universe = Universe.getOrBadRequest(universeUuid);
+    UserIntent storedIntent = universe.getUniverseDetails().getPrimaryCluster().userIntent;
+    assertTrue("edit must not disable YSQL auth", storedIntent.enableYSQLAuth);
+    assertTrue("edit must not disable YCQL auth", storedIntent.enableYCQLAuth);
+    assertEquals("stored-ysql-pass", storedIntent.ysqlPassword);
+    assertEquals("stored-ycql-pass", storedIntent.ycqlPassword);
+  }
+
+  @Test
+  public void testEditUserIntentKeepsAuthWhenPasswordRemovedFromSpec() throws Exception {
+    YBUniverse ybUniverse =
+        ModelFactory.createYbUniverse("test-auth-edit-removed", defaultProvider);
+    Universe universe = createUniverseWithAuthEnabled(ybUniverse);
+    // Auth stays on in the spec, but the password secret has been dropped from it entirely.
+    setYsqlAuthSpec(ybUniverse, true, null /* secretName */);
+    setYcqlAuthSpec(ybUniverse, true, null /* secretName */);
+
+    UserIntent userIntent =
+        ybUniverseReconciler.createUserIntent(
+            ybUniverse, defaultCustomer.getUuid(), false /* isCreate */, defaultProvider);
+
+    // Auth follows the spec flags, and no password is resolved - removing it is a no-op.
+    assertTrue(userIntent.enableYSQLAuth);
+    assertTrue(userIntent.enableYCQLAuth);
+    assertNull(userIntent.ysqlPassword);
+    assertNull(userIntent.ycqlPassword);
+    assertUniverseAuthUnchanged(universe.getUniverseUUID());
+  }
+
+  @Test
+  public void testEditUserIntentIgnoresUnreadablePasswordSecrets() throws Exception {
+    YBUniverse ybUniverse = ModelFactory.createYbUniverse("test-auth-edit-secret", defaultProvider);
+    Universe universe = createUniverseWithAuthEnabled(ybUniverse);
+    // The spec still points at secrets that no longer resolve - one deleted outright, one left
+    // without the password key. The edit path looks them up to keep the dependency rows current
+    // but never reads a password out of them, so neither may fail the reconcile.
+    setYsqlAuthSpec(ybUniverse, true, "gone-secret");
+    setYcqlAuthSpec(ybUniverse, true, "empty-secret");
+    mockSecretLookup("gone-secret", null);
+    mockSecretLookup("empty-secret", secretWithPassword("empty-secret", "ycqlPassword", null));
+
+    UserIntent userIntent =
+        ybUniverseReconciler.createUserIntent(
+            ybUniverse, defaultCustomer.getUuid(), false /* isCreate */, defaultProvider);
+
+    assertTrue(userIntent.enableYSQLAuth);
+    assertTrue(userIntent.enableYCQLAuth);
+    assertNull(userIntent.ysqlPassword);
+    assertNull(userIntent.ycqlPassword);
+    assertUniverseAuthUnchanged(universe.getUniverseUUID());
   }
 }

--- a/managed/src/test/java/com/yugabyte/yw/common/operator/YBUniverseReconcilerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/common/operator/YBUniverseReconcilerTest.java
@@ -2684,17 +2684,6 @@ public class YBUniverseReconcilerTest extends FakeDBApplication {
         e.getMessage().contains("could not find ycqlPassword in secret ycql-secret"));
   }
 
-  // Asserts that an edit reconcile left the universe's own auth settings untouched. The operator
-  // cannot toggle auth or rotate a password yet, so an edit must never write either back.
-  private void assertUniverseAuthUnchanged(UUID universeUuid) {
-    Universe universe = Universe.getOrBadRequest(universeUuid);
-    UserIntent storedIntent = universe.getUniverseDetails().getPrimaryCluster().userIntent;
-    assertTrue("edit must not disable YSQL auth", storedIntent.enableYSQLAuth);
-    assertTrue("edit must not disable YCQL auth", storedIntent.enableYCQLAuth);
-    assertEquals("stored-ysql-pass", storedIntent.ysqlPassword);
-    assertEquals("stored-ycql-pass", storedIntent.ycqlPassword);
-  }
-
   @Test
   public void testEditUserIntentKeepsAuthWhenPasswordRemovedFromSpec() throws Exception {
     YBUniverse ybUniverse =
@@ -2713,7 +2702,6 @@ public class YBUniverseReconcilerTest extends FakeDBApplication {
     assertTrue(userIntent.enableYCQLAuth);
     assertNull(userIntent.ysqlPassword);
     assertNull(userIntent.ycqlPassword);
-    assertUniverseAuthUnchanged(universe.getUniverseUUID());
   }
 
   @Test
@@ -2736,6 +2724,5 @@ public class YBUniverseReconcilerTest extends FakeDBApplication {
     assertTrue(userIntent.enableYCQLAuth);
     assertNull(userIntent.ysqlPassword);
     assertNull(userIntent.ycqlPassword);
-    assertUniverseAuthUnchanged(universe.getUniverseUUID());
   }
 }


### PR DESCRIPTION
## Summary

The Kubernetes operator ignored the `enableYSQLAuth` and
`enableYCQLAuth` spec fields
entirely and inferred auth solely from whether a password secret was
referenced. Two
misconfigurations were accepted silently and produced a universe that
did not match the CR:

- `enableYSQLAuth: true` with no `ysqlPassword` created a universe with
auth **disabled**.
- A `ysqlPassword` with the flag left `false` created a universe with
auth **enabled**.

This makes the spec flags authoritative and validates the pair when a
universe is created:
auth cannot be enabled without a password, and a password is rejected
without auth. Both
directions are enforced for YSQL and YCQL, and the failure surfaces on
the CR as
`ERROR_CREATING` before any universe is created.

### Why the reconciler and not the CRD

The obvious home for this is `x-kubernetes-validations` on
`universeCrd.yaml`, but a
CRD-level rule would permanently break the operator's universe-import
path. A universe
imported from YBA via `OperatorUtils.createUniverseCr` has auth enabled
with no secret to
reference — the import writes no Secret at all — so the CR it writes
would be rejected by its
own schema and the import would fail with no way to satisfy it.

Enforcement therefore lives in `createUserIntent`, gated on the existing
`isCreate` flag.
Imported CRs resolve to an existing universe and take the edit path, so
they never reach it.
The cost is that the error arrives as CR status rather than a `kubectl
apply` rejection.

### Edit path

No password is read out of the secret on edit. Dropping the password
from the spec, or
pointing it at a secret that is empty or deleted, is now a no-op instead
of aborting the
reconcile of everything else in the spec — previously a deleted secret
threw an NPE while
being tracked as a dependency, and a secret without the expected key
threw outright, so an
unrelated edit (node count, gflags, software version) could not proceed
until the secret was
restored.

The secrets are still registered as dependencies on every edit pass.
That registration is
what `OperatorResourceRestorer` restores from on HA failover and what
marks the Secret
orphaned when the CR is deleted, and for universes whose CRs predate the
`operator_resource`
table it is the only pass that ever writes those rows.

Changing a password through the operator is not supported here and is
tracked as PLAT-22298.

Also hardens `parseSecretForKey`, which dereferenced whichever of `data`
or `stringData` was
absent.

Original commit: c01ae6f32edeab6b1743cbe7902ab114c259b74e / #33687

## Test plan

- [x] `sbt "testOnly
com.yugabyte.yw.common.operator.YBUniverseReconcilerTest"` — 73 passed,
0 failed. 10 new cases, symmetric across YSQL and YCQL: auth+password
from the spec, neither set, all four validation failures, a secret
holding no password, a missing secret, and two edit-path cases (password
removed from the spec; secrets deleted/emptied).
- [x] End-to-end on a Kubernetes cluster with
`kubernetesOperatorEnabled`, using a locally built YBA:
- [x] All five invalid CRs were accepted by the API server and rejected
by the reconciler with the expected per-API message, each CR landing in
`Error Creating`, and the YBA universe list stayed empty — validation
fails before any universe or task is created.
- [x] A single-node RF1 universe with auth enabled on both APIs and both
password secrets present created successfully; connecting with the
secret's password succeeded and a wrong password was rejected,
confirming auth was actually enabled.
- [x] Removing `ysqlPassword`/`ycqlPassword` from that live CR was a
no-op: universe stayed `Ready`, both auth flags stayed enabled in YBA,
both passwords still authenticated, and no password-path errors appeared
in the operator log.
- [x] Deleting both referenced Secret objects outright was also a no-op,
with no NPE — the case that previously aborted the reconcile.

## Merge conflicts

- `managed/src/test/java/com/yugabyte/yw/common/operator/YBUniverseReconcilerTest.java:105` — import block only: 2026.1 has already dropped `java.util.Date`, so kept the branch's list and added the cherry-pick's `java.util.Collections`.
