### PR TITLE
[#33099] DocDB: Build PostgreSQL before computing the thin client link command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -930,7 +930,7 @@ if(APPLE)
   yb_allow_flat_namespace_lookup(yb-cql)
   yb_allow_flat_namespace_lookup(yb_pgwrapper)
   # yb_pggate_util and yb_dockv have a mutual (circular) dependency that cannot be expressed as a
-  # link edge between shared libraries, so yb_pggate_util resolves yb_dockv/yb_ash symbols at runtime.
+  # link edge between shared libraries, so yb_pggate_util resolves yb_dockv symbols at runtime.
   yb_allow_flat_namespace_lookup(yb_pggate_util)
   # Test-utility libraries form mutually circular dependencies (integration-tests depends on
   # yb_client_test_util and tools_test_utils, which reference it back), which cannot be link edges.

--- a/src/yb/thin_client/yb_release
+++ b/src/yb/thin_client/yb_release
@@ -76,15 +76,37 @@ lto_out="$build_root/lib/$lib_name"
 # --incomplete-build means it needs no other built artifact. That archive is not a declared CMake
 # by-product -- only libpgcommon.a and libpgport.a are -- so it cannot be requested by name; it
 # appears as a side effect of the make that builds libpgcommon.a. Without this, a tree that has
-# never built PostgreSQL aborts in `ar -t` on a file nothing created, and the failure only stays
-# hidden where an earlier full build happened to leave one behind.
-log "Building the PostgreSQL static libraries the whole-program link reads"
+# never built PostgreSQL aborts in `ar -t` on a file nothing created.
+#
+# This is not cheap, and it is the one place the script does build the wide tree: requesting those
+# byproducts forces the `postgres` custom target, which add_dependencies ties to yb_pggate and
+# server_process (src/postgres/CMakeLists.txt), pulling in the server closure and the PG backend --
+# the same ~14000 files the note above says building the .so target would drag in. The archive has
+# no finer-grained ninja edge, so there is nothing smaller to ask for. On a warm tree that closure
+# is already current and only the incremental PG make runs.
+log "Building PostgreSQL (and, unavoidably, its server closure) for the archives the link reads"
+pgcommon_srv="$build_root/postgres_build/src/common/libpgcommon_srv.a"
+srv_before=$( stat -c '%Y %s' "$pgcommon_srv" 2>/dev/null || echo missing )
+prereq_rc=0
 ( cd "$build_root" && YB_BUILD_ROOT="$build_root" \
     ninja -k 0 postgres_build/src/common/libpgcommon.a postgres_build/src/port/libpgport.a ) \
-  || log "note: a non-closure byproduct failed to link (expected with --no-tcmalloc); continuing"
-pgcommon_srv="$build_root/postgres_build/src/common/libpgcommon_srv.a"
-[[ -f "$pgcommon_srv" ]] || fatal "PostgreSQL build did not produce $pgcommon_srv, which the \
+  || prereq_rc=$?
+srv_after=$( stat -c '%Y %s' "$pgcommon_srv" 2>/dev/null || echo missing )
+
+[[ "$srv_after" != missing ]] || fatal "PostgreSQL build did not produce $pgcommon_srv, which the \
 whole-program link step reads"
+# Existence alone is not enough. `postgres` is an always-out-of-date custom target whose edge
+# order-only-depends on yb_pggate/server_process, so when one of those fails to link under the
+# --no-undefined that --no-tcmalloc turns on, ninja skips the postgres edge and the previous
+# configuration's *_srv.o survive untouched -- and lto.py would bake those stale members into the
+# link args. If the build reported a failure, only trust the archive when this run refreshed it.
+if [[ $prereq_rc -ne 0 && "$srv_after" == "$srv_before" ]]; then
+  fatal "$pgcommon_srv was not refreshed and the PostgreSQL build reported errors -- the postgres \
+edge was likely skipped, so this archive predates the current configuration and the link would \
+ship a mismatched .so. Check the ninja output above."
+fi
+[[ $prereq_rc -eq 0 ]] || \
+  log "note: a non-closure byproduct failed to link (expected with --no-tcmalloc); continuing"
 
 # Emit the link command without running the linker. Needs only the configured build graph, not built
 # objects (--incomplete-build), and it names every object the client links -- our build work-list.
@@ -103,7 +125,7 @@ link_args_file="${lto_out}_lto_link_cmd_args.txt"
 
 # libpgcommon/libpgport are byproducts of the monolithic postgres target, so request the archives
 # rather than the individual objects.
-log "Building the client's real link closure only (not the full server/PG tree)"
+log "Building the client's real link closure"
 mapfile -t closure_objs < <(
   grep -oE '[^ ]+\.cc\.o' "$link_args_file" | grep -F "$build_root/" |
     sed "s#${build_root}/##" | sort -u )

--- a/src/yb/thin_client/yb_release
+++ b/src/yb/thin_client/yb_release
@@ -71,6 +71,21 @@ log "Full-LTO build root: $build_root"
 
 lto_out="$build_root/lib/$lib_name"
 
+# Build PostgreSQL first: the link-command step below reads
+# postgres_build/src/common/libpgcommon_srv.a (lto.py add_pgcommon_srv_library) even though
+# --incomplete-build means it needs no other built artifact. That archive is not a declared CMake
+# by-product -- only libpgcommon.a and libpgport.a are -- so it cannot be requested by name; it
+# appears as a side effect of the make that builds libpgcommon.a. Without this, a tree that has
+# never built PostgreSQL aborts in `ar -t` on a file nothing created, and the failure only stays
+# hidden where an earlier full build happened to leave one behind.
+log "Building the PostgreSQL static libraries the whole-program link reads"
+( cd "$build_root" && YB_BUILD_ROOT="$build_root" \
+    ninja -k 0 postgres_build/src/common/libpgcommon.a postgres_build/src/port/libpgport.a ) \
+  || log "note: a non-closure byproduct failed to link (expected with --no-tcmalloc); continuing"
+pgcommon_srv="$build_root/postgres_build/src/common/libpgcommon_srv.a"
+[[ -f "$pgcommon_srv" ]] || fatal "PostgreSQL build did not produce $pgcommon_srv, which the \
+whole-program link step reads"
+
 # Emit the link command without running the linker. Needs only the configured build graph, not built
 # objects (--incomplete-build), and it names every object the client links -- our build work-list.
 log "Computing the whole-program link command (and the real object closure) for $lib_name"

--- a/src/yb/yql/pggate/util/CMakeLists.txt
+++ b/src/yb/yql/pggate/util/CMakeLists.txt
@@ -26,8 +26,9 @@ set(PGGATE_UTIL_SRCS
     )
 
 set(PGGATE_UTIL_LIBS
-    yb_util
-    yb_common)
+    yb_ash
+    yb_common
+    yb_util)
 
 ADD_YB_LIBRARY(yb_pggate_util
                SRCS ${PGGATE_UTIL_SRCS}


### PR DESCRIPTION
## Summary

`yb_release` for the thin client cannot package from a tree that has never built PostgreSQL. It
aborts in the link-command step with `ar -t .../libpgcommon_srv.a` returning exit 9 on a file
nothing created: `lto.py add_pgcommon_srv_library` reads that archive while emitting the
whole-program link command, but the step ran before the script built any PostgreSQL archive, and
`--incomplete-build` means nothing else forced one.

The archive cannot be requested from ninja by name -- it is not a declared CMake by-product (only
`libpgcommon.a` and `libpgport.a` are, because Odyssey links those) and appears as a side effect of
the same PostgreSQL make. So build that target first, then assert the archive appeared. The exit
code is tolerated for the same reason the closure build below already tolerates it: these pull in
byproduct `.so` links that trip the `--no-undefined` check `--no-tcmalloc` turns on. The archive
check is the real gate.

The failure stayed hidden because every prior run was on a build root where an earlier full build
had left the archive behind. A fresh clone, CI, or a cleaned build root hits it on the first run.

Also declares `yb_ash` on `yb_pggate_util`, which `ybc_util.cc` has been using to format ASH wait
states. Nothing forced the declaration because normal builds do not pass `--no-undefined`, so the
symbols resolved at load time from another library in the process.

## Known remaining gap

This is **not** by itself enough to package from a clean tree, and the description should not imply
otherwise. `ybc_util.cc` also calls into `yb_dockv` (`YBCDecodeMultiColumnHashLeftBound` /
`...RightBound` / `YBCDecodeRangePartitionKey`), and that dependency cannot be declared: `yb_dockv`
already depends on `yb_pggate_util` (`src/yb/dockv/CMakeLists.txt`, via `pg_row.cc` and
`partition.cc`), so CMake rejects the cycle among shared libraries. Under `--no-undefined` those
symbols keep `libyb_pggate_util.so` from linking, which blocks the PostgreSQL archives this change
requests.

Closing that needs either the cycle broken (move those three functions above `yb_dockv`) or the
archives built in a tcmalloc-enabled configuration first. Both are larger than this change; packaging
still requires a tree that has had a full build.

## Upgrade/Rollback safety

No wire, storage, or runtime change. A release script and one CMake dependency declaration.

## Cost

Requesting the archives forces the `postgres` custom target, which `add_dependencies` ties to
`yb_pggate` and `server_process`, so this step builds the server closure and the PG backend -- the
same wide tree the script otherwise avoids. `libpgcommon_srv.a` has no finer-grained ninja edge, so
there is nothing smaller to ask for. On a warm tree that closure is already current and only the
incremental PG make runs.

## Test Plan

- `bash -n src/yb/thin_client/yb_release` clean; `./build-support/lint.sh` clean.
- Verified the `yb_ash` declaration in a clean full-LTO tree configured with `--no-tcmalloc` (which
  is what enables `--no-undefined`): `libyb_ash.so` now appears on the link line for
  `lib/libyb_pggate_util.so` and the `yb::ash::*` undefined symbols are gone. The `yb::dockv::*`
  ones remain, as described above.
- Exercised the new staleness guard on a build root with no `libpgcommon_srv.a`: `yb_release` now
  fails with a named error naming the archive and the skipped PostgreSQL build, instead of `ar -t`
  exiting 9 inside `lto.py`.
- The PostgreSQL prereq step is the same sequence that, run by hand, produced
  `yb_thin_client-2026.1.2.0-b0-...tar.gz` from an otherwise unmodified tree.
