### PR TITLE
[#33597] YSQL: Account for key, response, and entry memory in PgResponseCache

### DIFF
--- a/src/yb/tserver/CMakeLists.txt
+++ b/src/yb/tserver/CMakeLists.txt
@@ -459,6 +459,7 @@ if (NOT APPLE)
   ADD_YB_TEST(tserver_cgroup_manager-test)
 endif()
 ADD_YB_TEST(header_manager_impl-test)
+ADD_YB_TEST(pg_response_cache-test)
 ADD_YB_TEST(backup_service-test)
 ADD_YB_TEST(clone_operation-test)
 

--- a/src/yb/tserver/pg_response_cache-test.cc
+++ b/src/yb/tserver/pg_response_cache-test.cc
@@ -1,0 +1,93 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "yb/tserver/pg_response_cache.h"
+
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "yb/tserver/pg_client.messages.h"
+
+#include "yb/util/mem_tracker.h"
+#include "yb/util/metrics.h"
+#include "yb/util/size_literals.h"
+#include "yb/util/test_macros.h"
+
+METRIC_DECLARE_entity(server);
+
+namespace yb::tserver {
+namespace {
+
+using namespace std::chrono_literals;
+
+class TestResponseWaiter : public PgResponseCacheWaiter {
+ public:
+  void Apply(const PgResponseCache::Response&) override {
+    ++apply_count_;
+  }
+
+  size_t apply_count() const {
+    return apply_count_;
+  }
+
+ private:
+  size_t apply_count_ = 0;
+};
+
+// Entry memory (key bytes and the copied response) must be reflected in the cache's MemTracker
+// and released when the entry is destroyed.
+TEST(PgResponseCacheTest, EntryMemoryIsTracked) {
+  MetricRegistry metric_registry;
+  auto metric_entity = METRIC_ENTITY_server.Instantiate(&metric_registry, "response-cache-test");
+  auto parent_tracker = MemTracker::CreateTracker(-1, "response-cache-test");
+
+  constexpr size_t kKeySize = 1_MB;
+  const std::string key(kKeySize, 'k');
+  auto waiter = std::make_shared<TestResponseWaiter>();
+  std::shared_ptr<MemTracker> cache_tracker;
+
+  {
+    PgResponseCache cache(parent_tracker, metric_entity.get());
+
+    ThreadSafeArena first_arena;
+    LWPgPerformOptionsPB_LWCachingInfoPB first_cache_info(&first_arena);
+    first_cache_info.set_key_group(1);
+    first_cache_info.dup_key_value(Slice(key));
+    auto setter = ASSERT_RESULT(cache.Get(
+        &first_cache_info, CoarseMonoClock::Now() + 1min, waiter));
+    ASSERT_TRUE(setter);
+
+    LWPgPerformResponsePB response(&first_arena);
+    setter(PgResponseCache::Response(response, {}));
+
+    cache_tracker = parent_tracker->FindChild("PgResponseCache");
+    ASSERT_TRUE(cache_tracker);
+    ASSERT_GE(cache_tracker->consumption(), static_cast<int64_t>(kKeySize));
+
+    ThreadSafeArena second_arena;
+    LWPgPerformOptionsPB_LWCachingInfoPB second_cache_info(&second_arena);
+    second_cache_info.set_key_group(1);
+    second_cache_info.dup_key_value(Slice(key));
+    auto second_setter = ASSERT_RESULT(cache.Get(
+        &second_cache_info, CoarseMonoClock::Now() + 1min, waiter));
+
+    ASSERT_FALSE(second_setter);
+    ASSERT_EQ(waiter->apply_count(), 1);
+  }
+
+  ASSERT_EQ(cache_tracker->consumption(), 0);
+}
+
+}  // namespace
+}  // namespace yb::tserver

--- a/src/yb/tserver/pg_response_cache.cc
+++ b/src/yb/tserver/pg_response_cache.cc
@@ -152,10 +152,7 @@ class MetricUpdater {
   void Consume(size_t bytes) {
     DCHECK(bytes);
     if (mem_tracker().TryConsume(bytes)) {
-      size_t expected = 0;
-      [[maybe_unused]] const auto changed = consumption_.compare_exchange_strong(
-          expected, bytes, std::memory_order::acq_rel);
-      DCHECK(changed);
+      [[maybe_unused]] auto before = consumption_.fetch_add(bytes, std::memory_order::acq_rel);
     }
   }
 
@@ -195,13 +192,10 @@ class Data {
           ReadHybridTime::SingleTime(HybridTime::FromMicros(
               FLAGS_TEST_pg_response_cache_catalog_read_time_usec)));
     }
-    auto new_state = DataState::kReadyFailure;
-    size_t sz = 0;
-    if (IsOk(value)) {
-      for (const auto& data : value.rows_data) {
-        sz += data.size();
-      }
-      new_state = DataState::kReadyOK;
+    const auto new_state = IsOk(value) ? DataState::kReadyOK : DataState::kReadyFailure;
+    size_t sz = value.response_memory_footprint;
+    for (const auto& data : value.rows_data) {
+      sz += data.size();
     }
     decltype(waiters_) waiters;
     // Since response_ is not changed after assignment, we could store pointer to it to make
@@ -217,11 +211,15 @@ class Data {
     for (auto waiter : waiters) {
       waiter->Apply(*response);
     }
-    if (sz) {
-      auto updater = metric_updater_.lock();
-      if (updater) {
-        updater->Consume(sz);
-      }
+    Consume(sz);
+  }
+
+  void Consume(size_t bytes) {
+    if (!bytes) {
+      return;
+    }
+    if (auto updater = metric_updater_.lock()) {
+      updater->Consume(bytes);
     }
   }
 
@@ -380,23 +378,33 @@ class PgResponseCache::Impl : private GarbageCollector {
         renew_metric->Increment();
       }
     });
-    std::lock_guard lock(mutex_);
-    const auto group = cache_info->key_group();
-    const auto& bucket = GetKeyGroupBucket(group);
-    if (bucket.disabler.lock()) {
-      return nullptr;
+    std::shared_ptr<Data> data;
+    size_t entry_bytes = 0;
+    {
+      std::lock_guard lock(mutex_);
+      const auto group = cache_info->key_group();
+      const auto& bucket = GetKeyGroupBucket(group);
+      if (bucket.disabler.lock()) {
+        return nullptr;
+      }
+      auto actual_version = bucket.version;
+      const auto& entry = *entries_.emplace(
+          group, std::move(*cache_info->mutable_key_value()));
+      const auto& value = entry.value;
+      data = value.data();
+      if (data && !IsRenewRequired(data->creation_time(), now, *cache_info, &renew_metric) &&
+          data->IsValid(now, actual_version)) {
+        return data;
+      }
+      VLOG(5) << "(Re)Building element group=" << group << " actual_version=" << actual_version;
+      const_cast<Value&>(value) = Value(actual_version, &metric_context_, now, deadline);
+      data = value.data();
+      entry_bytes = sizeof(Entry) + entry.key.value.size();
     }
-    auto actual_version = bucket.version;
-    const auto& value = entries_.emplace(
-        group, std::move(*cache_info->mutable_key_value()))->value;
-    auto data = value.data();
-    if (data && !IsRenewRequired(data->creation_time(), now, *cache_info, &renew_metric) &&
-        data->IsValid(now, actual_version)) {
-      return data;
-    }
-    VLOG(5) << "(Re)Building element group=" << group << " actual_version=" << actual_version;
-    const_cast<Value&>(value) = Value(actual_version, &metric_context_, now, deadline);
-    return value.data();
+    // Consume outside the lock: MemTracker::TryConsume may run CollectGarbage, which
+    // acquires mutex_.
+    data->Consume(entry_bytes);
+    return data;
   }
 
  public:
@@ -549,8 +557,11 @@ PgResponseCache::Disabler PgResponseCache::Disable(KeyGroup key_group) {
 
 PgResponseCache::Response::Response(
     const PgPerformResponseMsg& response_, std::vector<RefCntSlice> rows_data_)
-    : response(rpc::SharedMessage<PgPerformResponseMsg>(response_)),
-      rows_data(std::move(rows_data_)) {
+    : rows_data(std::move(rows_data_)) {
+  auto arena = SharedThreadSafeArena();
+  auto* copied_response = arena->NewArenaObject<PgPerformResponseMsg>(response_);
+  response_memory_footprint = arena->memory_footprint();
+  response = std::shared_ptr<PgPerformResponseMsg>(std::move(arena), copied_response);
   DCHECK_EQ(response->responses().size(), rows_data.size());
 }
 

--- a/src/yb/tserver/pg_response_cache.h
+++ b/src/yb/tserver/pg_response_cache.h
@@ -56,6 +56,7 @@ class PgResponseCache {
 
     std::shared_ptr<LWPgPerformResponsePB> response;
     std::vector<RefCntSlice> rows_data;
+    size_t response_memory_footprint = 0;
   };
 
   using Setter = std::function<void(Response&&)>;


### PR DESCRIPTION
## Summary

`Impl::CollectGarbage` evicts entries by the consumption they report to the cache's MemTracker, so each entry must account for its full memory; entries that under-report keep the cache below its configured limit on paper while its real footprint grows unbounded (#33597).

With this change each entry consumes:

- the cache key bytes and `sizeof(Entry)` LRU-node overhead, when the entry is built in `GetEntryData`;
- the copied response protobuf's arena footprint plus the `rows_data` slices, when the response is stored in `Data::Set` -- for failure responses as well as successes.

`MetricUpdater::Consume` now accumulates with `fetch_add` since an entry consumes at two points; the destructor releases the accumulated total. Key and entry bytes are consumed after releasing `Impl::mutex_` because `MemTracker::TryConsume` may run `CollectGarbage`, which acquires that mutex.

The `Response` constructor captures the arena's `memory_footprint()` between copying the message and wrapping the arena into the aliasing `shared_ptr`, where the arena is last reachable.

## Test plan

- [x] New unit test: `./yb_build.sh debug --cxx-test pg_response_cache-test` -- `PgResponseCacheTest.EntryMemoryIsTracked` verifies key/entry memory is tracked on build and fully released on destruction.
- [x] `./yb_build.sh debug --cxx-test pg_catalog_perf-test --gtest_filter 'PgCatalogPerfTest.ResponseCache*'` -- all 9 tests pass, including `ResponseCacheMemoryLimit` (peak consumption stays within `pg_response_cache_size_bytes` under the larger accounting).
