### PR TITLE
[docs] Note that Npgsql pool size applies per node

### DIFF
--- a/docs/content/stable/develop/drivers-orms/csharp/yb-npgsql-reference.md
+++ b/docs/content/stable/develop/drivers-orms/csharp/yb-npgsql-reference.md
@@ -72,6 +72,8 @@ The following connection properties need to be added to enable load balancing:
 
 By default, the driver refreshes the list of nodes every 300 seconds (5 minutes). You can change this value by including the `YB Servers Refresh Interval` connection parameter.
 
+When load balancing is enabled, the driver creates a separate connection pool for each node in the cluster, so `Maximum Pool Size` applies per node, and not to the cluster as a whole. The maximum number of connections an application can open is `Maximum Pool Size` multiplied by the number of nodes.
+
 ### Use the driver
 
 To use the driver, pass new connection properties for load balancing in the connection URL or properties pool.

--- a/docs/content/stable/develop/drivers-orms/csharp/yb-npgsql-reference.md
+++ b/docs/content/stable/develop/drivers-orms/csharp/yb-npgsql-reference.md
@@ -72,7 +72,7 @@ The following connection properties need to be added to enable load balancing:
 
 By default, the driver refreshes the list of nodes every 300 seconds (5 minutes). You can change this value by including the `YB Servers Refresh Interval` connection parameter.
 
-When load balancing is enabled, the driver creates a separate connection pool for each node in the cluster, so `Maximum Pool Size` applies per node, and not to the cluster as a whole. The maximum number of connections an application can open is `Maximum Pool Size` multiplied by the number of nodes.
+When load balancing is enabled, the driver maintains a separate connection pool for each eligible node in the cluster, so `Maximum Pool Size` applies per node, and not to the cluster as a whole. The maximum number of connections an application can open is `Maximum Pool Size` multiplied by the number of eligible nodes.
 
 ### Use the driver
 

--- a/docs/content/stable/develop/drivers-orms/smart-drivers.md
+++ b/docs/content/stable/develop/drivers-orms/smart-drivers.md
@@ -264,7 +264,7 @@ String url2Cluster1 = "jdbc:yugabytedb://<another-host-in-cluster1>:5433/databas
 
 The application can initiate connections using any of the URLs, and the driver will ensure the connection goes to the least loaded server in the respective cluster.
 
-Multi-cluster is supported in YugabyteDB v2024.1.6.0, v2024.2.3.0, and v2.25.2.0. You can also include URLs from a _maximum of one_ cluster running an older (unsupported) version of YugabyteDB. Using the preceding example, _Cluster1_ could be running an unsupported version, but not both _Cluster1_ and _Cluster2_.
+Multi-cluster is supported in YugabyteDB v2024.1.6.0, v2024.2.3.0, and v2.25.2.0 or later. You can also include URLs from a _maximum of one_ cluster running an older (unsupported) version of YugabyteDB. Using the preceding example, _Cluster1_ could be running an unsupported version, but not both _Cluster1_ and _Cluster2_.
 
 Currently, multi-cluster connections are available only in the Java (JDBC) smart driver (v42.7.3-yb-4 or later).
 


### PR DESCRIPTION
Adds one line clarifying that `Maximum Pool Size` applies per node, not cluster-wide, since the smart driver creates one connection pool per node when load balancing is enabled.
