### PR TITLE
[PLAT-22035] YBA: Resolve dependent CR universe references by yba-resource-id

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/common/operator/utils/OperatorUtils.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/operator/utils/OperatorUtils.java
@@ -320,23 +320,79 @@ public class OperatorUtils {
         .map(PlatformInstance::getUuid);
   }
 
-  public Universe getUniverseFromNameAndNamespace(
-      Long customerId, String universeName, String namespace) throws Exception {
+  /**
+   * Resolves the YBA universe backing a YBUniverse custom resource, given that resource's name and
+   * namespace.
+   *
+   * @param customerId the customer the universe must belong to
+   * @param crName the {@code metadata.name} of the YBUniverse custom resource, as named by the
+   *     {@code universe} field of a dependent resource's spec
+   * @param namespace the namespace holding the custom resource
+   * @return the universe, or null if either the custom resource or its universe does not exist
+   */
+  public Universe getUniverseFromNameAndNamespace(Long customerId, String crName, String namespace)
+      throws Exception {
     KubernetesResourceDetails ybUniverseResourceDetails = new KubernetesResourceDetails();
-    ybUniverseResourceDetails.name = universeName;
+    ybUniverseResourceDetails.name = crName;
     ybUniverseResourceDetails.namespace = namespace;
     YBUniverse ybUniverse = getYBUniverse(ybUniverseResourceDetails);
     if (ybUniverse == null) {
-      log.debug("YBUniverse '{}' not found in namespace '{}'", universeName, namespace);
+      log.debug("YBUniverse '{}' not found in namespace '{}'", crName, namespace);
       return null;
     }
-    String name = YBUniverseReconciler.getUniverseName(ybUniverse);
-    log.debug("Getting universe from name: {}", name);
-    Optional<Universe> universe = Universe.maybeGetUniverseByName(customerId, name);
-    if (universe.isPresent()) {
-      return universe.get();
+    return getUniverseFromCr(customerId, ybUniverse).orElse(null);
+  }
+
+  /**
+   * Resolves the YBA universe a YBUniverse custom resource represents, for the dependent resources
+   * - Backup, BackupSchedule, PitrConfig, RestoreJob, DrConfig, SupportBundle - that name a
+   * YBUniverse resource in their spec.
+   *
+   * <p>Resolution order follows YBUniverseReconciler.resolveExistingUniverse: the {@code
+   * yba-resource-id} annotation, then both historical naming schemes. The annotation is the only
+   * link that resolves an imported universe, which keeps the name it already had in YBA while
+   * {@link YBUniverseReconciler#getUniverseName} derives {@code <resourceName>-<hash>} from the
+   * resource metadata.
+   *
+   * <p>Read-only, unlike the reconciler's resolver: it neither annotates the resource nor reports
+   * an ambiguous match, both of which belong to the reconcile that owns the resource. It does scope
+   * the UUID lookup to the requesting customer, which {@link Universe#maybeGet} does not.
+   *
+   * @param customerId the customer the universe must belong to
+   * @param ybUniverse the custom resource to resolve
+   * @return the universe, or empty if no universe matches the custom resource
+   */
+  public static Optional<Universe> getUniverseFromCr(Long customerId, YBUniverse ybUniverse) {
+    if (ybUniverse == null) {
+      return Optional.empty();
     }
-    return null;
+    UUID ybaResourceId = getYbaResourceId(ybUniverse.getMetadata());
+    if (ybaResourceId != null) {
+      Optional<Universe> universe =
+          Universe.maybeGet(ybaResourceId).filter(u -> customerId.equals(u.getCustomerId()));
+      if (universe.isPresent()) {
+        return universe;
+      }
+      // Metadata is non-null here, getYbaResourceId only returns a value when it is set.
+      log.warn(
+          "YBUniverse '{}/{}' is annotated with YBA resource id {}, but no such universe exists for"
+              + " customer {}, falling back to name lookup",
+          ybUniverse.getMetadata().getNamespace(),
+          ybUniverse.getMetadata().getName(),
+          ybaResourceId,
+          customerId);
+    }
+    String metadataName = YBUniverseReconciler.getUniverseName(ybUniverse);
+    log.debug("Getting universe from name: {}", metadataName);
+    Optional<Universe> universe = Universe.maybeGetUniverseByName(customerId, metadataName);
+    if (universe.isPresent()) {
+      return universe;
+    }
+    String specName = ybUniverse.getSpec() == null ? null : ybUniverse.getSpec().getUniverseName();
+    if (StringUtils.isNotBlank(specName) && !specName.equals(metadataName)) {
+      return Universe.maybeGetUniverseByName(customerId, specName);
+    }
+    return Optional.empty();
   }
 
   public YBUniverse getYBUniverse(KubernetesResourceDetails name) throws Exception {
@@ -3044,7 +3100,21 @@ public class OperatorUtils {
               .build());
       BackupScheduleSpec spec = new BackupScheduleSpec();
       spec.setStorageConfig(storageConfigName);
-      spec.setUniverse(Universe.getOrBadRequest(ybBackupSchedule.getOwnerUUID()).getName());
+      // spec.universe names the YBUniverse custom resource, not the YBA universe: consumers read
+      // it back through getUniverseFromNameAndNamespace. The two names coincide only for an
+      // imported universe; for an operator-created one the YBA name carries a hash suffix the
+      // resource name lacks.
+      Universe scheduleUniverse = Universe.getOrBadRequest(ybBackupSchedule.getOwnerUUID());
+      KubernetesResourceDetails universeResourceDetails =
+          scheduleUniverse.getUniverseDetails().getKubernetesResourceDetails();
+      if (universeResourceDetails == null) {
+        throw new Exception(
+            String.format(
+                "Universe %s has no Kubernetes resource details, cannot resolve the YBUniverse"
+                    + " custom resource backing backup schedule %s",
+                scheduleUniverse.getName(), name));
+      }
+      spec.setUniverse(universeResourceDetails.name);
       spec.setBackupType(BackupScheduleSpec.BackupType.valueOf(params.backupType.toString()));
       spec.setTableByTableBackup(params.tableByTableBackup);
       spec.setKeyspace(params.keyspaceTableList.get(0).keyspace);

--- a/managed/src/test/java/com/yugabyte/yw/common/operator/utils/OperatorUtilsTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/common/operator/utils/OperatorUtilsTest.java
@@ -42,6 +42,7 @@ import com.yugabyte.yw.common.kms.util.KeyProvider;
 import com.yugabyte.yw.common.kms.util.OciEARServiceUtil.OciKmsAuthConfigField;
 import com.yugabyte.yw.common.kms.util.OciEARServiceUtil.OciKmsAuthType;
 import com.yugabyte.yw.common.kms.util.hashicorpvault.HashicorpVaultConfigParams;
+import com.yugabyte.yw.common.operator.KubernetesResourceDetails;
 import com.yugabyte.yw.common.services.YBClientService;
 import com.yugabyte.yw.forms.BackupRequestParams;
 import com.yugabyte.yw.forms.UniverseDefinitionTaskParams;
@@ -78,6 +79,7 @@ import com.yugabyte.yw.models.helpers.telemetry.ExportType;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -94,6 +96,8 @@ import io.fabric8.mockwebserver.ServerRequest;
 import io.fabric8.mockwebserver.ServerResponse;
 import io.yugabyte.operator.v1alpha1.KMSConfig;
 import io.yugabyte.operator.v1alpha1.KMSConfigSpec;
+import io.yugabyte.operator.v1alpha1.YBUniverse;
+import io.yugabyte.operator.v1alpha1.YBUniverseSpec;
 import io.yugabyte.operator.v1alpha1.kmsconfigspec.Aws;
 import io.yugabyte.operator.v1alpha1.kmsconfigspec.Azure;
 import io.yugabyte.operator.v1alpha1.kmsconfigspec.CipherTrust;
@@ -122,6 +126,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
@@ -381,6 +386,42 @@ public class OperatorUtilsTest extends FakeDBApplication {
 
   private void resetMockKubernetesClientForChecking() {
     kubernetesClient = kubernetesMockServer.createClient();
+  }
+
+  /** Marks the test universe as backed by a YBUniverse custom resource named {@code crName}. */
+  private void setUniverseResourceDetails(String crName, String namespace) {
+    Universe.saveDetails(
+        testUniverse.getUniverseUUID(),
+        universe -> {
+          UniverseDefinitionTaskParams details = universe.getUniverseDetails();
+          details.setKubernetesResourceDetails(new KubernetesResourceDetails(crName, namespace));
+          universe.setUniverseDetails(details);
+        });
+    testUniverse = Universe.getOrBadRequest(testUniverse.getUniverseUUID());
+  }
+
+  /**
+   * Builds a YBUniverse custom resource. A null {@code ybaResourceId} leaves the resource
+   * unannotated; {@code specUniverseName} exercises the legacy naming scheme, which YBA still
+   * resolves by but no longer names new universes after.
+   */
+  private YBUniverse makeYbUniverse(
+      String crName, String namespace, String specUniverseName, UUID ybaResourceId) {
+    ObjectMetaBuilder metaBuilder =
+        new ObjectMetaBuilder()
+            .withName(crName)
+            .withNamespace(namespace)
+            .withUid(UUID.randomUUID().toString());
+    if (ybaResourceId != null) {
+      metaBuilder.withAnnotations(
+          Map.of(ResourceAnnotationKeys.YBA_RESOURCE_ID, ybaResourceId.toString()));
+    }
+    YBUniverse ybUniverse = new YBUniverse();
+    ybUniverse.setMetadata(metaBuilder.build());
+    YBUniverseSpec spec = new YBUniverseSpec();
+    spec.setUniverseName(specUniverseName);
+    ybUniverse.setSpec(spec);
+    return ybUniverse;
   }
 
   @Test
@@ -781,6 +822,10 @@ public class OperatorUtilsTest extends FakeDBApplication {
     backupSchedule.setTaskParams(Json.toJson(params));
     backupSchedule.save();
 
+    // The custom resource is named differently from the universe, which is the normal case for an
+    // operator-created universe: its YBA name carries a hash suffix the resource name lacks.
+    setUniverseResourceDetails("operator-universe-cr", "test-namespace");
+
     operatorUtils.createBackupScheduleCr(
         backupSchedule, "test-schedule", "test-storage-config", "test-namespace");
 
@@ -798,7 +843,9 @@ public class OperatorUtilsTest extends FakeDBApplication {
 
     io.yugabyte.operator.v1alpha1.BackupScheduleSpec spec = schedule.getSpec();
     assertEquals(spec.getStorageConfig(), "test-storage-config");
-    assertEquals(spec.getUniverse(), "operator-universe");
+    // spec.universe must be the YBUniverse resource name, since that is what
+    // getUniverseFromNameAndNamespace looks the resource up by.
+    assertEquals(spec.getUniverse(), "operator-universe-cr");
     assertEquals("PGSQL_TABLE_TYPE", spec.getBackupType().toString());
     assertEquals("foo", spec.getKeyspace()); // From ModelFactory.createScheduleBackup
     assertEquals(
@@ -818,6 +865,7 @@ public class OperatorUtilsTest extends FakeDBApplication {
             testStorageConfig.getConfigUUID(),
             TaskType.BackupUniverse);
     backupSchedule.save();
+    setUniverseResourceDetails("operator-universe-cr", "test-namespace");
 
     // Create the first backup schedule
     operatorUtils.createBackupScheduleCr(
@@ -2430,5 +2478,135 @@ public class OperatorUtilsTest extends FakeDBApplication {
     assertTrue(
         "after invalidation the rotated file is read",
         operatorUtils.hasKubeConfigChanged(existing, desired));
+  }
+
+  /*--- getUniverseFromCr tests ---*/
+
+  @Test
+  public void testGetUniverseFromCrResolvesImportedUniverseByAnnotation() {
+    // An imported universe keeps the name it already had in YBA, while getUniverseName() derives
+    // "imported-cr-<hash>" from the resource metadata, so the annotation is the only link.
+    YBUniverse ybUniverse =
+        makeYbUniverse(
+            "imported-cr",
+            "test-namespace",
+            null /* specUniverseName */,
+            testUniverse.getUniverseUUID());
+
+    Optional<Universe> universe = OperatorUtils.getUniverseFromCr(testCustomer.getId(), ybUniverse);
+
+    assertTrue(universe.isPresent());
+    assertEquals(testUniverse.getUniverseUUID(), universe.get().getUniverseUUID());
+  }
+
+  @Test
+  public void testGetUniverseFromCrFallsBackToMetadataName() {
+    YBUniverse ybUniverse =
+        makeYbUniverse(
+            "unannotated-cr", "test-namespace", null /* specUniverseName */, null /* resourceId */);
+    Universe metadataNamedUniverse =
+        ModelFactory.createUniverse(
+            OperatorUtils.getYbaResourceName(ybUniverse.getMetadata()), testCustomer.getId());
+
+    Optional<Universe> universe = OperatorUtils.getUniverseFromCr(testCustomer.getId(), ybUniverse);
+
+    assertTrue(universe.isPresent());
+    assertEquals(metadataNamedUniverse.getUniverseUUID(), universe.get().getUniverseUUID());
+  }
+
+  @Test
+  public void testGetUniverseFromCrFallsBackToSpecNameWhenUnannotated() {
+    YBUniverse ybUniverse =
+        makeYbUniverse(
+            "imported-cr", "test-namespace", testUniverse.getName(), null /* ybaResourceId */);
+
+    Optional<Universe> universe = OperatorUtils.getUniverseFromCr(testCustomer.getId(), ybUniverse);
+
+    assertTrue(universe.isPresent());
+    assertEquals(testUniverse.getUniverseUUID(), universe.get().getUniverseUUID());
+  }
+
+  @Test
+  public void testGetUniverseFromCrFallsBackToNameWhenAnnotationIsStale() {
+    YBUniverse ybUniverse =
+        makeYbUniverse("imported-cr", "test-namespace", testUniverse.getName(), UUID.randomUUID());
+
+    Optional<Universe> universe = OperatorUtils.getUniverseFromCr(testCustomer.getId(), ybUniverse);
+
+    assertTrue(universe.isPresent());
+    assertEquals(testUniverse.getUniverseUUID(), universe.get().getUniverseUUID());
+  }
+
+  @Test
+  public void testGetUniverseFromCrDoesNotCrossCustomerBoundary() {
+    Customer otherCustomer = ModelFactory.testCustomer("other-customer");
+    YBUniverse ybUniverse =
+        makeYbUniverse(
+            "imported-cr",
+            "test-namespace",
+            testUniverse.getName(),
+            testUniverse.getUniverseUUID());
+
+    Optional<Universe> universe =
+        OperatorUtils.getUniverseFromCr(otherCustomer.getId(), ybUniverse);
+
+    assertFalse(universe.isPresent());
+  }
+
+  @Test
+  public void testGetUniverseFromCrNullResource() {
+    assertFalse(
+        OperatorUtils.getUniverseFromCr(testCustomer.getId(), null /* ybUniverse */).isPresent());
+  }
+
+  /*--- getUniverseFromNameAndNamespace tests ---*/
+
+  @Test
+  public void testGetUniverseFromNameAndNamespaceResolvesImportedUniverse() throws Exception {
+    String namespace = "test-namespace";
+    YBUniverse ybUniverse =
+        makeYbUniverse(
+            "imported-cr", namespace, null /* specUniverseName */, testUniverse.getUniverseUUID());
+    kubernetesClient
+        .resources(YBUniverse.class)
+        .inNamespace(namespace)
+        .resource(ybUniverse)
+        .create();
+
+    Universe universe =
+        operatorUtils.getUniverseFromNameAndNamespace(
+            testCustomer.getId(), "imported-cr", namespace);
+
+    assertNotNull(universe);
+    assertEquals(testUniverse.getUniverseUUID(), universe.getUniverseUUID());
+  }
+
+  @Test
+  public void testGetUniverseFromNameAndNamespaceMissingCustomResource() throws Exception {
+    assertNull(
+        operatorUtils.getUniverseFromNameAndNamespace(
+            testCustomer.getId(), "does-not-exist", "test-namespace"));
+  }
+
+  @Test
+  public void testCreateBackupScheduleCrWithoutResourceDetailsThrows() {
+    Schedule backupSchedule =
+        ModelFactory.createScheduleBackupRequestParams(
+            testCustomer.getUuid(),
+            testUniverse.getUniverseUUID(),
+            testStorageConfig.getConfigUUID(),
+            TaskType.BackupUniverse);
+    backupSchedule.save();
+
+    // testUniverse has no Kubernetes resource details, so there is no resource name to point at.
+    Exception ex =
+        assertThrows(
+            Exception.class,
+            () ->
+                operatorUtils.createBackupScheduleCr(
+                    backupSchedule, "test-schedule", "test-storage-config", "test-namespace"));
+    // createBackupScheduleCr wraps anything it catches, so the guard message lands on the cause.
+    assertNotNull(ex.getCause());
+    assertTrue(ex.getCause().getMessage().contains("has no Kubernetes resource details"));
   }
 }


### PR DESCRIPTION
## Summary

A YBUniverse custom resource is named in a dependent resource's spec (`Backup`,
`BackupSchedule`, `PitrConfig`, `RestoreJob`, `DrConfig`, `SupportBundle`) by its
`metadata.name`, and `OperatorUtils.getUniverseFromNameAndNamespace` turns that into a YBA
universe. It did so purely by name, via `YBUniverseReconciler.getUniverseName`, which since
PLAT-21329 always derives `<resourceName>-<hash(name+namespace+uid)>` from the resource
metadata. An imported universe keeps the name it already had in YBA, so the lookup never
matches it and every dependent reconcile fails with `No universe found with name ...`.

The resolver now goes through the `io.yugabyte.operator/yba-resource-id` annotation first
and falls back to both historical naming schemes - the resolution order
`YBUniverseReconciler.resolveExistingUniverse` already applies to the YBUniverse CR itself.
That reconcile writes the annotation back onto the resource, so it is set by the time a
dependent CR reconciles. The two resolvers stay separate: the reconciler's owns
self-healing and ambiguity reporting, this one is read-only, and it scopes the UUID lookup
to the requesting customer (the name lookup enforces that; `Universe.maybeGet` does not).

`createBackupScheduleCr` had the mirror-image bug on the write side: it put the YBA universe
name into `BackupSchedule` `spec.universe`, which consumers read back as a YBUniverse
resource name. Those coincide only for an imported universe; for an operator-created one the
YBA name carries the hash suffix. It now writes `kubernetesResourceDetails.name`, matching
`createBackupCr`, and fails loudly if the universe has no resource details rather than
emitting a CR that points at nothing.

## Test plan

- [x] `build-support/lint.sh --rev upstream/master` - clean; google-java-format reports no diff on
      either file.
- [ ] `sbt "testOnly com.yugabyte.yw.common.operator.utils.OperatorUtilsTest"` - runs in CI; a local
      run was not possible (`com.yugabyte#yba-client-v2;1.8.3` does not resolve in my environment).
      New cases cover annotation resolution, both name fallbacks, a stale annotation, and the
      customer boundary; the two existing `createBackupScheduleCr` cases now assert the YBUniverse
      resource name in `spec.universe`.
