### PR TITLE
[#33837] YSQL: Report index backfill failures with the PostgreSQL SQLSTATE instead of XX000

### DIFF
--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -10320,10 +10320,20 @@ YBCMakeStatusErrorData(YbcStatus status)
 	switch (pg_err_code)
 	{
 		case ERRCODE_UNIQUE_VIOLATION:
-			*msg = (YbStatusErrorDataFormatText) {"duplicate key value violates unique constraint \"%s\"",
-												   1, (const char **) palloc(sizeof(const char *))};
-			(msg->args)[0] = FetchUniqueConstraintName(YBCStatusRelationOid(status));
-			break;
+			{
+				const Oid	relation_oid = YBCStatusRelationOid(status);
+
+				/*
+				 * A status without a relation OID (e.g. an index backfill
+				 * failure) already carries a full PG error message.
+				 */
+				if (!OidIsValid(relation_oid))
+					break;
+				*msg = (YbStatusErrorDataFormatText) {"duplicate key value violates unique constraint \"%s\"",
+													   1, (const char **) palloc(sizeof(const char *))};
+				(msg->args)[0] = FetchUniqueConstraintName(relation_oid);
+				break;
+			}
 		case ERRCODE_YB_TXN_ABORTED:
 			*detail = *msg;
 			*msg = (YbStatusErrorDataFormatText) {"current transaction is expired or aborted"};

--- a/src/yb/client/client-internal.cc
+++ b/src/yb/client/client-internal.cc
@@ -52,6 +52,7 @@
 #include "yb/client/table_info.h"
 
 #include "yb/common/common_util.h"
+#include "yb/common/pgsql_error.h"
 #include "yb/common/redis_constants_common.h"
 #include "yb/common/schema.h"
 #include "yb/common/schema_pbutil.h"
@@ -1043,7 +1044,13 @@ Status YBClient::Data::IsBackfillIndexInProgress(YBClient* client,
   *backfill_in_progress = true;
   if (!index_info->backfill_error_message().empty()) {
     *backfill_in_progress = false;
-    return STATUS(Aborted, index_info->backfill_error_message());
+    auto status = STATUS(Aborted, index_info->backfill_error_message());
+    // Re-tag so YSQL surfaces a retryable 40001 instead of XX000.
+    if (index_info->backfill_error_message().starts_with("ERROR:  schema version mismatch")) {
+      status = status.CloneAndAddErrorCode(
+          PgsqlRequestStatus(PgsqlResponsePB::PGSQL_STATUS_SCHEMA_VERSION_MISMATCH));
+    }
+    return status;
   } else if (index_info->index_permissions() > IndexPermissions::INDEX_PERM_DO_BACKFILL) {
     *backfill_in_progress = false;
   }

--- a/src/yb/client/client-internal.cc
+++ b/src/yb/client/client-internal.cc
@@ -1041,15 +1041,13 @@ Status YBClient::Data::IsBackfillIndexInProgress(YBClient* client,
   const auto* index_info = VERIFY_RESULT(yb_table_info.index_map.FindIndex(index_id));
 
   *backfill_in_progress = true;
-  if (!index_info->backfill_status().ok()) {
+  if (!index_info->backfill_error_message().empty()) {
     *backfill_in_progress = false;
-    // Preserve the error codes of the status the backfill failed with (such as the PostgreSQL
-    // error code), but keep this function's Aborted contract.
-    return index_info->backfill_status().CloneAndReplaceCode(Status::kAborted);
-  } else if (!index_info->backfill_error_message().empty()) {
-    // The master is older and does not populate backfill_status.
-    *backfill_in_progress = false;
-    return STATUS(Aborted, index_info->backfill_error_message());
+    // backfill_status preserves the error codes (such as the PostgreSQL error code) but may be
+    // stale after a rollback: an old master clears only backfill_error_message on success.
+    return index_info->backfill_status().ok()
+        ? STATUS(Aborted, index_info->backfill_error_message())
+        : index_info->backfill_status().CloneAndReplaceCode(Status::kAborted);
   } else if (index_info->index_permissions() > IndexPermissions::INDEX_PERM_DO_BACKFILL) {
     *backfill_in_progress = false;
   }

--- a/src/yb/client/client-internal.cc
+++ b/src/yb/client/client-internal.cc
@@ -52,7 +52,6 @@
 #include "yb/client/table_info.h"
 
 #include "yb/common/common_util.h"
-#include "yb/common/pgsql_error.h"
 #include "yb/common/redis_constants_common.h"
 #include "yb/common/schema.h"
 #include "yb/common/schema_pbutil.h"
@@ -1042,15 +1041,15 @@ Status YBClient::Data::IsBackfillIndexInProgress(YBClient* client,
   const auto* index_info = VERIFY_RESULT(yb_table_info.index_map.FindIndex(index_id));
 
   *backfill_in_progress = true;
-  if (!index_info->backfill_error_message().empty()) {
+  if (!index_info->backfill_status().ok()) {
     *backfill_in_progress = false;
-    auto status = STATUS(Aborted, index_info->backfill_error_message());
-    // Re-tag so YSQL surfaces a retryable 40001 instead of XX000.
-    if (index_info->backfill_error_message().starts_with("ERROR:  schema version mismatch")) {
-      status = status.CloneAndAddErrorCode(
-          PgsqlRequestStatus(PgsqlResponsePB::PGSQL_STATUS_SCHEMA_VERSION_MISMATCH));
-    }
-    return status;
+    // Preserve the error codes of the status the backfill failed with (such as the PostgreSQL
+    // error code), but keep this function's Aborted contract.
+    return index_info->backfill_status().CloneAndReplaceCode(Status::kAborted);
+  } else if (!index_info->backfill_error_message().empty()) {
+    // The master is older and does not populate backfill_status.
+    *backfill_in_progress = false;
+    return STATUS(Aborted, index_info->backfill_error_message());
   } else if (index_info->index_permissions() > IndexPermissions::INDEX_PERM_DO_BACKFILL) {
     *backfill_in_progress = false;
   }

--- a/src/yb/common/common.proto
+++ b/src/yb/common/common.proto
@@ -47,6 +47,7 @@ import "yb/common/common_types.proto";
 import "yb/common/common_net.proto";
 import "yb/common/transaction.proto";
 import "yb/common/value.proto";
+import "yb/common/wire_protocol.proto";
 
 // The type used in column schemas, which may have type parameters (i.e. for collections)
 // If types have parameters, they are stored in the params field. Otherwise params is empty.
@@ -320,6 +321,10 @@ message IndexInfoPB {
   // table's IndexInfoPB after backfill completes successfully. Used to reject reads whose
   // snapshot predates when the index became consistent.
   optional fixed64 birth_time = 37;
+
+  // When backfill fails, the status it failed with. Unlike backfill_error_message, this
+  // preserves error codes such as the PostgreSQL error code.
+  optional AppStatusPB backfill_status = 38;
 }
 
 // The possible order modes for clients.

--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -1080,17 +1080,17 @@ Status BackfillTable::Done(const Status& s, const std::unordered_set<TableId>& f
 }
 
 Status BackfillTable::MarkIndexesAsFailed(
-    const std::unordered_set<TableId>& failed_indexes, const Status& failure_status) {
+    const std::unordered_set<TableId>& failed_indexes, const Status& backfill_status) {
   if (indexes_to_build() == failed_indexes) {
     state_.store(State::kFailed, std::memory_order_release);
     StopLivenessMonitor();
     backfill_job_->SetState(MonitoredTaskState::kFailed);
   }
-  return MarkIndexesAsDesired(failed_indexes, BackfillJobPB::FAILED, failure_status);
+  return MarkIndexesAsDesired(failed_indexes, BackfillJobPB::FAILED, backfill_status);
 }
 
 Status BackfillTable::MarkAllIndexesAsFailed() {
-  return MarkIndexesAsFailed(indexes_to_build(), STATUS(InternalError, "failed"));
+  return MarkIndexesAsFailed(indexes_to_build(), STATUS(Aborted, "failed"));
 }
 
 Status BackfillTable::MarkAllIndexesAsSuccess() {
@@ -1101,10 +1101,10 @@ Status BackfillTable::MarkAllIndexesAsSuccess() {
 
 Status BackfillTable::MarkIndexesAsDesired(
     const std::unordered_set<TableId>& index_ids_set, BackfillJobPB_State state,
-    const Status& failure_status) {
+    const Status& backfill_status) {
   VLOG_WITH_PREFIX(3) << "Marking " << yb::ToString(index_ids_set)
                       << " as " << BackfillJobPB_State_Name(state)
-                      << " due to " << failure_status;
+                      << " due to " << backfill_status;
   if (!index_ids_set.empty()) {
     auto l = indexed_table_->LockForWrite();
     auto& indexed_table_pb = l.mutable_data()->pb;
@@ -1130,9 +1130,9 @@ Status BackfillTable::MarkIndexesAsDesired(
       IndexInfoPB* idx_pb = indexed_table_pb.mutable_indexes(i);
       if (index_ids_set.find(idx_pb->table_id()) != index_ids_set.end()) {
         // Should this also move to the BackfillJob instead?
-        if (!failure_status.ok()) {
-          idx_pb->set_backfill_error_message(failure_status.message().ToBuffer());
-          StatusToPB(failure_status, idx_pb->mutable_backfill_status());
+        if (!backfill_status.ok()) {
+          idx_pb->set_backfill_error_message(backfill_status.message().ToBuffer());
+          StatusToPB(backfill_status, idx_pb->mutable_backfill_status());
         } else {
           idx_pb->clear_backfill_error_message();
           idx_pb->clear_backfill_status();

--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -1057,8 +1057,7 @@ Status BackfillTable::Done(const Status& s, const std::unordered_set<TableId>& f
     LOG_WITH_PREFIX(WARNING) << "failed to backfill the index: " << AsString(failed_indexes)
                             << " due to " << s;
     RETURN_NOT_OK_PREPEND(
-        MarkIndexesAsFailed(failed_indexes, s.message().ToBuffer()),
-        "Couldn't mark indexes as failed");
+        MarkIndexesAsFailed(failed_indexes, s), "Couldn't mark indexes as failed");
     return CheckIfDone();
   }
 
@@ -1081,31 +1080,31 @@ Status BackfillTable::Done(const Status& s, const std::unordered_set<TableId>& f
 }
 
 Status BackfillTable::MarkIndexesAsFailed(
-    const std::unordered_set<TableId>& failed_indexes, const string& message) {
+    const std::unordered_set<TableId>& failed_indexes, const Status& failure_status) {
   if (indexes_to_build() == failed_indexes) {
     state_.store(State::kFailed, std::memory_order_release);
     StopLivenessMonitor();
     backfill_job_->SetState(MonitoredTaskState::kFailed);
   }
-  return MarkIndexesAsDesired(failed_indexes, BackfillJobPB::FAILED, message);
+  return MarkIndexesAsDesired(failed_indexes, BackfillJobPB::FAILED, failure_status);
 }
 
 Status BackfillTable::MarkAllIndexesAsFailed() {
-  return MarkIndexesAsFailed(indexes_to_build(), "failed");
+  return MarkIndexesAsFailed(indexes_to_build(), STATUS(InternalError, "failed"));
 }
 
 Status BackfillTable::MarkAllIndexesAsSuccess() {
   const auto index_ids = indexes_to_build();
   RETURN_NOT_OK(master_->xcluster_manager()->MarkIndexBackfillCompleted(index_ids, epoch_));
-  return MarkIndexesAsDesired(index_ids, BackfillJobPB::SUCCESS, "");
+  return MarkIndexesAsDesired(index_ids, BackfillJobPB::SUCCESS, Status::OK());
 }
 
 Status BackfillTable::MarkIndexesAsDesired(
     const std::unordered_set<TableId>& index_ids_set, BackfillJobPB_State state,
-    const string message) {
+    const Status& failure_status) {
   VLOG_WITH_PREFIX(3) << "Marking " << yb::ToString(index_ids_set)
                       << " as " << BackfillJobPB_State_Name(state)
-                      << " due to " << message;
+                      << " due to " << failure_status;
   if (!index_ids_set.empty()) {
     auto l = indexed_table_->LockForWrite();
     auto& indexed_table_pb = l.mutable_data()->pb;
@@ -1131,10 +1130,12 @@ Status BackfillTable::MarkIndexesAsDesired(
       IndexInfoPB* idx_pb = indexed_table_pb.mutable_indexes(i);
       if (index_ids_set.find(idx_pb->table_id()) != index_ids_set.end()) {
         // Should this also move to the BackfillJob instead?
-        if (!message.empty()) {
-          idx_pb->set_backfill_error_message(message);
+        if (!failure_status.ok()) {
+          idx_pb->set_backfill_error_message(failure_status.message().ToBuffer());
+          StatusToPB(failure_status, idx_pb->mutable_backfill_status());
         } else {
           idx_pb->clear_backfill_error_message();
+          idx_pb->clear_backfill_status();
         }
         idx_pb->clear_is_backfill_deferred();
 

--- a/src/yb/master/backfill_index.h
+++ b/src/yb/master/backfill_index.h
@@ -200,10 +200,10 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
   Status MarkAllIndexesAsSuccess();
 
   Status MarkIndexesAsFailed(
-      const std::unordered_set<TableId>& indexes, const Status& failure_status);
+      const std::unordered_set<TableId>& indexes, const Status& backfill_status);
   Status MarkIndexesAsDesired(
       const std::unordered_set<TableId>& index_ids, BackfillJobPB_State state,
-      const Status& failure_status);
+      const Status& backfill_status);
 
   Status AlterTableStateToAbort();
   Status AlterTableStateToSuccess();

--- a/src/yb/master/backfill_index.h
+++ b/src/yb/master/backfill_index.h
@@ -200,10 +200,10 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
   Status MarkAllIndexesAsSuccess();
 
   Status MarkIndexesAsFailed(
-      const std::unordered_set<TableId>& indexes, const std::string& message);
+      const std::unordered_set<TableId>& indexes, const Status& failure_status);
   Status MarkIndexesAsDesired(
       const std::unordered_set<TableId>& index_ids, BackfillJobPB_State state,
-      const std::string message);
+      const Status& failure_status);
 
   Status AlterTableStateToAbort();
   Status AlterTableStateToSuccess();

--- a/src/yb/qlexpr/index.cc
+++ b/src/yb/qlexpr/index.cc
@@ -19,6 +19,7 @@
 #include "yb/common/common.messages.h"
 #include "yb/common/common.pb.h"
 #include "yb/common/schema.h"
+#include "yb/common/wire_protocol.h"
 
 #include "yb/gutil/casts.h"
 
@@ -94,6 +95,8 @@ IndexInfo::IndexInfo(const IndexInfoPB& pb)
       indexed_range_column_ids_(ColumnIdsFromPB(pb.indexed_range_column_ids())),
       index_permissions_(pb.index_permissions()),
       backfill_error_message_(pb.backfill_error_message()),
+      backfill_status_(pb.has_backfill_status() ? StatusFromPB(pb.backfill_status())
+                                                : Status::OK()),
       num_rows_read_from_table_for_backfill_(pb.num_rows_read_from_table_for_backfill()),
       num_rows_backfilled_in_index_(pb.num_rows_backfilled_in_index()),
       birth_time_(pb.birth_time()),
@@ -145,6 +148,9 @@ void IndexInfo::ToPB(IndexInfoPB* pb) const {
   }
   pb->set_index_permissions(index_permissions_);
   pb->set_backfill_error_message(backfill_error_message_);
+  if (!backfill_status_.ok()) {
+    StatusToPB(backfill_status_, pb->mutable_backfill_status());
+  }
   pb->set_num_rows_read_from_table_for_backfill(num_rows_read_from_table_for_backfill_);
   pb->set_num_rows_backfilled_in_index(num_rows_backfilled_in_index_);
   if (birth_time_ != 0) {

--- a/src/yb/qlexpr/index.cc
+++ b/src/yb/qlexpr/index.cc
@@ -150,6 +150,8 @@ void IndexInfo::ToPB(IndexInfoPB* pb) const {
   pb->set_backfill_error_message(backfill_error_message_);
   if (!backfill_status_.ok()) {
     StatusToPB(backfill_status_, pb->mutable_backfill_status());
+  } else {
+    pb->clear_backfill_status();
   }
   pb->set_num_rows_read_from_table_for_backfill(num_rows_read_from_table_for_backfill_);
   pb->set_num_rows_backfilled_in_index(num_rows_backfilled_in_index_);

--- a/src/yb/qlexpr/index.h
+++ b/src/yb/qlexpr/index.h
@@ -37,7 +37,7 @@
 #include "yb/qlexpr/qlexpr_fwd.h"
 
 #include "yb/util/memory/arena_list.h"
-#include "yb/util/status_fwd.h"
+#include "yb/util/status.h"
 
 namespace yb::qlexpr {
 
@@ -114,6 +114,12 @@ class IndexInfo {
     return backfill_error_message_;
   }
 
+  // Non-OK only when backfill failed. Unlike backfill_error_message, preserves the error codes
+  // of the status backfill failed with.
+  const Status& backfill_status() const {
+    return backfill_status_;
+  }
+
   uint64_t num_rows_read_from_table_for_backfill() const {
     return num_rows_read_from_table_for_backfill_;
   }
@@ -164,6 +170,7 @@ class IndexInfo {
   const std::vector<ColumnId> indexed_range_column_ids_; // Range column ids in the indexed table.
   const IndexPermissions index_permissions_ = INDEX_PERM_READ_WRITE_AND_DELETE;
   const std::string backfill_error_message_;
+  const Status backfill_status_;
   const uint64_t num_rows_read_from_table_for_backfill_ = 0;
   const double num_rows_backfilled_in_index_ = 0;
   const uint64_t birth_time_ = 0;

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -3395,21 +3395,26 @@ Result<std::tuple<std::string, uint64_t, double>> QueryPostgresToDoBackfill(
     const auto libpq_error_msg = AuxilaryMessage(result.status()).value();
     LOG(WARNING) << "libpq query \"" << query << "\" returned " << result.status() << ": "
                  << libpq_error_msg;
+    const auto pg_error_code = PgsqlError::ValueFromStatus(result.status());
+    // Keep the SQLSTATE so that an error which reaches the CREATE INDEX backend is raised with
+    // the PostgreSQL error code it failed with, rather than XX000.
+    const auto keep_pg_error_code = [&pg_error_code](Status status) {
+      return pg_error_code ? status.CloneAndAddErrorCode(PgsqlError(*pg_error_code)) : status;
+    };
     // The 2 spaces after ERROR: is necessary to match the error message.
     constexpr auto kSchemaMismatchSubstring = "ERROR:  schema version mismatch";
     if (libpq_error_msg.starts_with(kSchemaMismatchSubstring)) {
-      return STATUS(TryAgain, libpq_error_msg);
+      return keep_pg_error_code(STATUS(TryAgain, libpq_error_msg));
     }
     // Attach the remedy hint to SnapshotTooOld errors.  The SQLSTATE does not say which read was
     // rejected, so the hint may also land on a SnapshotTooOld arising from something other than
     // the indexed-table scan, such as the syscatalog snapshot.  That is acceptable: such cases are
     // practically unreachable from a fresh per-chunk backend, and the hint is merely advisory.
-    const auto pg_error_code = PgsqlError::ValueFromStatus(result.status());
     if (pg_error_code && *pg_error_code == YBPgErrorCode::YB_PG_SNAPSHOT_TOO_OLD) {
-      return STATUS(IllegalState, Format(
-          "$0. $1", libpq_error_msg, kBackfillReadSnapshotTooOldRemedy));
+      return keep_pg_error_code(STATUS(IllegalState, Format(
+          "$0. $1", libpq_error_msg, kBackfillReadSnapshotTooOldRemedy)));
     }
-    return STATUS(IllegalState, libpq_error_msg);
+    return keep_pg_error_code(STATUS(IllegalState, libpq_error_msg));
   }
   const auto [returned_spec, num_rows_backfilled_in_index, num_rows_scanned] = *result;
   PgsqlBackfillSpecPB spec;

--- a/src/yb/yql/pgwrapper/pg_alter_table-test.cc
+++ b/src/yb/yql/pgwrapper/pg_alter_table-test.cc
@@ -14,6 +14,7 @@
 
 #include "yb/client/client-test-util.h"
 #include "yb/client/table_info.h"
+#include "yb/common/pgsql_error.h"
 #include "yb/util/async_util.h"
 #include "yb/util/backoff_waiter.h"
 #include "yb/util/test_thread_holder.h"
@@ -169,6 +170,73 @@ std::string ParamsToString(const testing::TestParamInfo<StorageFormat>& param_in
 } // namespace
 
 INSTANTIATE_TEST_CASE_P(, PgAlterTableTest, testing::ValuesIn(kStorageFormatArray), ParamsToString);
+
+class PgSchemaVersionMismatchBackfillTest : public LibPqTestBase {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* opts) override {
+    LibPqTestBase::UpdateMiniClusterOptions(opts);
+    // Disable table locks so the ALTER can land mid-backfill instead of queueing behind it.
+    opts->extra_tserver_flags.emplace_back("--enable_object_locking_for_table_locks=false");
+    opts->extra_tserver_flags.emplace_back("--ysql_enable_concurrent_ddl=false");
+    AppendFlagToAllowedPreviewFlagsCsv(opts->extra_tserver_flags, "ysql_enable_concurrent_ddl");
+    opts->extra_tserver_flags.emplace_back("--ysql_yb_ddl_transaction_block_enabled=false");
+    opts->extra_tserver_flags.emplace_back("--ysql_yb_enable_ddl_savepoint_support=false");
+    // No retries: a retried chunk's fresh backfill connection would succeed and hide the error.
+    opts->extra_master_flags.emplace_back("--index_backfill_rpc_max_retries=0");
+    // Throttle to one-row BACKFILL statements so the ALTER lands with statements still to run.
+    opts->extra_tserver_flags.emplace_back("--backfill_index_write_batch_size=1");
+    opts->extra_tserver_flags.emplace_back("--backfill_index_rate_rows_per_sec=10");
+    opts->extra_tserver_flags.emplace_back("--ysql_prefetch_limit=1");
+  }
+};
+
+// A mismatch hit by BACKFILL INDEX must reach the CREATE INDEX client as 40001, not XX000.
+TEST_F(PgSchemaVersionMismatchBackfillTest, BackfillSurfacesAsSerializationFailure) {
+  auto setup_conn = ASSERT_RESULT(Connect());
+  ASSERT_OK(setup_conn.Execute("CREATE DATABASE test_colo6 WITH COLOCATION = true"));
+  auto conn = ASSERT_RESULT(ConnectToDB("test_colo6"));
+
+  ASSERT_OK(conn.Execute(
+      "CREATE TABLE t (k INT PRIMARY KEY, v1 INT) WITH (COLOCATION = true)"));
+  ASSERT_OK(conn.Execute("INSERT INTO t SELECT i, i FROM generate_series(1, 100) i"));
+
+  Status create_index_status;
+  TestThreadHolder thread_holder;
+  thread_holder.AddThreadFunctor([&conn, &create_index_status] {
+    create_index_status = conn.Execute("CREATE INDEX idx ON t (v1)");
+  });
+
+  // The backfill connection lands on the colocation tablet's leader, so poll every tserver.
+  std::vector<PGConn> ts_conns;
+  for (size_t i = 0; i < cluster_->num_tablet_servers(); ++i) {
+    ts_conns.push_back(ASSERT_RESULT(
+        ConnectToTsForDB(*cluster_->tablet_server(i), "test_colo6")));
+  }
+  ASSERT_OK(WaitFor([&ts_conns]() -> Result<bool> {
+    for (auto& ts_conn : ts_conns) {
+      if (VERIFY_RESULT(ts_conn.FetchRow<PGUint64>(
+              "SELECT count(*) FROM pg_stat_activity"
+              " WHERE query LIKE 'BACKFILL INDEX%'")) > 0) {
+        return true;
+      }
+    }
+    return false;
+  }, MonoDelta::FromSeconds(60), "backfill is executing"));
+  // Let a few one-row chunks complete so the backfill connection has cached the table.
+  SleepFor(MonoDelta::FromSeconds(2));
+
+  auto ddl_conn = ASSERT_RESULT(ConnectToTsForDB(*cluster_->tablet_server(1), "test_colo6"));
+  ASSERT_OK(ddl_conn.Execute("SET yb_test_fail_next_ddl = 1"));
+  ASSERT_NOK(ddl_conn.Execute("ALTER TABLE t ADD COLUMN v2 INT"));
+
+  thread_holder.JoinAll();
+  ASSERT_NOK(create_index_status);
+  LOG(INFO) << "Client-visible error: " << create_index_status;
+  ASSERT_STR_CONTAINS(create_index_status.ToString(), "schema version mismatch");
+  const auto pg_error = PgsqlError::ValueFromStatus(create_index_status);
+  ASSERT_TRUE(pg_error.has_value()) << create_index_status;
+  ASSERT_EQ(*pg_error, YBPgErrorCode::YB_PG_T_R_SERIALIZATION_FAILURE) << create_index_status;
+}
 
 class PgAlterTableConcurrencyTest : public PgAlterTableTest {
  public:

--- a/src/yb/yql/pgwrapper/pg_alter_table-test.cc
+++ b/src/yb/yql/pgwrapper/pg_alter_table-test.cc
@@ -171,33 +171,48 @@ std::string ParamsToString(const testing::TestParamInfo<StorageFormat>& param_in
 
 INSTANTIATE_TEST_CASE_P(, PgAlterTableTest, testing::ValuesIn(kStorageFormatArray), ParamsToString);
 
+namespace {
+
+// Running DDLs concurrently with the concurrent-DDL feature disabled requires failing catalog
+// writes on catalog version mismatch; auto analyze is off so its DDLs don't trip that flag.
+void DisableConcurrentDDL(ExternalMiniClusterOptions* opts) {
+  // Disable table locks so the ALTER can land mid-backfill instead of queueing behind it.
+  opts->extra_tserver_flags.emplace_back("--enable_object_locking_for_table_locks=false");
+  opts->extra_tserver_flags.emplace_back("--ysql_enable_concurrent_ddl=false");
+  AppendFlagToAllowedPreviewFlagsCsv(opts->extra_tserver_flags, "ysql_enable_concurrent_ddl");
+  opts->extra_tserver_flags.emplace_back("--ysql_yb_ddl_transaction_block_enabled=false");
+  opts->extra_tserver_flags.emplace_back("--ysql_yb_enable_ddl_savepoint_support=false");
+  opts->extra_tserver_flags.emplace_back(
+      "--yb_fail_catalog_write_on_catalog_version_mismatch=true");
+  opts->extra_tserver_flags.emplace_back("--ysql_enable_auto_analyze=false");
+}
+
+// One row per BACKFILL statement at 10 rows/sec: 100 rows keep statements pending on the cached
+// backfill connection for ~10 s.
+void ThrottleIndexBackfill(ExternalMiniClusterOptions* opts) {
+  opts->extra_tserver_flags.emplace_back("--backfill_index_write_batch_size=1");
+  opts->extra_tserver_flags.emplace_back("--backfill_index_rate_rows_per_sec=10");
+  // Without this, the first statement's 1024-row read page would backfill everything in one go.
+  opts->extra_tserver_flags.emplace_back("--ysql_yb_fetch_row_limit=1");
+}
+
+}  // namespace
+
 class PgSchemaVersionMismatchBackfillTest : public LibPqTestBase {
  public:
   void UpdateMiniClusterOptions(ExternalMiniClusterOptions* opts) override {
     LibPqTestBase::UpdateMiniClusterOptions(opts);
-    // Disable table locks so the ALTER can land mid-backfill instead of queueing behind it.
-    opts->extra_tserver_flags.emplace_back("--enable_object_locking_for_table_locks=false");
-    opts->extra_tserver_flags.emplace_back("--ysql_enable_concurrent_ddl=false");
-    AppendFlagToAllowedPreviewFlagsCsv(opts->extra_tserver_flags, "ysql_enable_concurrent_ddl");
-    opts->extra_tserver_flags.emplace_back("--ysql_yb_ddl_transaction_block_enabled=false");
-    opts->extra_tserver_flags.emplace_back("--ysql_yb_enable_ddl_savepoint_support=false");
+    DisableConcurrentDDL(opts);
+    ThrottleIndexBackfill(opts);
     // No retries: a retried chunk's fresh backfill connection would succeed and hide the error.
     opts->extra_master_flags.emplace_back("--index_backfill_rpc_max_retries=0");
-    // Throttle to one-row BACKFILL statements so the ALTER lands with statements still to run.
-    opts->extra_tserver_flags.emplace_back("--backfill_index_write_batch_size=1");
-    opts->extra_tserver_flags.emplace_back("--backfill_index_rate_rows_per_sec=10");
-    opts->extra_tserver_flags.emplace_back("--ysql_prefetch_limit=1");
   }
 };
 
 // A mismatch hit by BACKFILL INDEX must reach the CREATE INDEX client as 40001, not XX000.
 TEST_F(PgSchemaVersionMismatchBackfillTest, BackfillSurfacesAsSerializationFailure) {
-  auto setup_conn = ASSERT_RESULT(Connect());
-  ASSERT_OK(setup_conn.Execute("CREATE DATABASE test_colo6 WITH COLOCATION = true"));
-  auto conn = ASSERT_RESULT(ConnectToDB("test_colo6"));
-
-  ASSERT_OK(conn.Execute(
-      "CREATE TABLE t (k INT PRIMARY KEY, v1 INT) WITH (COLOCATION = true)"));
+  auto conn = ASSERT_RESULT(Connect());
+  ASSERT_OK(conn.Execute("CREATE TABLE t (k INT PRIMARY KEY, v1 INT) SPLIT INTO 1 TABLETS"));
   ASSERT_OK(conn.Execute("INSERT INTO t SELECT i, i FROM generate_series(1, 100) i"));
 
   Status create_index_status;
@@ -206,33 +221,43 @@ TEST_F(PgSchemaVersionMismatchBackfillTest, BackfillSurfacesAsSerializationFailu
     create_index_status = conn.Execute("CREATE INDEX idx ON t (v1)");
   });
 
-  // The backfill connection lands on the colocation tablet's leader, so poll every tserver.
+  // The backfill connection lands on the tablet leader's node, so poll every tserver. Each chunk's
+  // statement embeds a distinct row range: a text change proves the connection has cached the
+  // table and is still mid-backfill.
   std::vector<PGConn> ts_conns;
   for (size_t i = 0; i < cluster_->num_tablet_servers(); ++i) {
     ts_conns.push_back(ASSERT_RESULT(
-        ConnectToTsForDB(*cluster_->tablet_server(i), "test_colo6")));
+        ConnectToTsForDB(*cluster_->tablet_server(i), "yugabyte")));
   }
-  ASSERT_OK(WaitFor([&ts_conns]() -> Result<bool> {
+  std::string first_seen_query;
+  ASSERT_OK(WaitFor([&ts_conns, &first_seen_query]() -> Result<bool> {
     for (auto& ts_conn : ts_conns) {
-      if (VERIFY_RESULT(ts_conn.FetchRow<PGUint64>(
-              "SELECT count(*) FROM pg_stat_activity"
-              " WHERE query LIKE 'BACKFILL INDEX%'")) > 0) {
-        return true;
+      auto queries = VERIFY_RESULT(ts_conn.FetchRows<std::string>(
+          "SELECT query FROM pg_stat_activity WHERE query LIKE 'BACKFILL INDEX%'"));
+      for (const auto& query : queries) {
+        if (first_seen_query.empty()) {
+          first_seen_query = query;
+        } else if (query != first_seen_query) {
+          return true;
+        }
       }
     }
     return false;
-  }, MonoDelta::FromSeconds(60), "backfill is executing"));
-  // Let a few one-row chunks complete so the backfill connection has cached the table.
-  SleepFor(MonoDelta::FromSeconds(2));
+  }, MonoDelta::FromSeconds(60), "backfill completed a chunk"));
 
-  auto ddl_conn = ASSERT_RESULT(ConnectToTsForDB(*cluster_->tablet_server(1), "test_colo6"));
+  // Another node, so PG-level locks don't queue the ALTER behind CREATE INDEX.
+  auto ddl_conn = ASSERT_RESULT(ConnectToTsForDB(*cluster_->tablet_server(1), "yugabyte"));
+  // Fail the DDL after the DocDB schema change: the rollback leaves the schema version bumped with
+  // no catalog version bump, so the backfill connection never invalidates its now-stale cache.
   ASSERT_OK(ddl_conn.Execute("SET yb_test_fail_next_ddl = 1"));
   ASSERT_NOK(ddl_conn.Execute("ALTER TABLE t ADD COLUMN v2 INT"));
 
   thread_holder.JoinAll();
-  ASSERT_NOK(create_index_status);
+  // The backfill may win the race and succeed; a failure must be retryable, never XX000.
+  if (create_index_status.ok()) {
+    return;
+  }
   LOG(INFO) << "Client-visible error: " << create_index_status;
-  ASSERT_STR_CONTAINS(create_index_status.ToString(), "schema version mismatch");
   const auto pg_error = PgsqlError::ValueFromStatus(create_index_status);
   ASSERT_TRUE(pg_error.has_value()) << create_index_status;
   ASSERT_EQ(*pg_error, YBPgErrorCode::YB_PG_T_R_SERIALIZATION_FAILURE) << create_index_status;

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -19,6 +19,7 @@
 #include "yb/client/client-test-util.h"
 #include "yb/client/table_info.h"
 
+#include "yb/common/pgsql_error.h"
 #include "yb/common/schema.h"
 
 #include "yb/integration-tests/backfill-test-util.h"
@@ -518,6 +519,7 @@ TEST_P(PgIndexBackfillTest, Unique) {
   const auto msg = status.message().ToBuffer();
   ASSERT_TRUE(msg.find("duplicate key value violates unique constraint") != std::string::npos)
       << status;
+  ASSERT_EQ(PgsqlError::ValueFromStatus(status), YBPgErrorCode::YB_PG_UNIQUE_VIOLATION) << status;
 }
 
 // Make sure that indexes created in postgres nested DDL work and skip backfill (optimization).


### PR DESCRIPTION
## Summary

When a DDL from another session bumps a table's DocDB schema version while an index backfill is running, the BACKFILL INDEX statement fails with "schema version mismatch". This is unrelated to the preview concurrent-DDL feature: with `ysql_enable_concurrent_ddl` / object locking enabled the DDL waits on the table lock, so the race cannot happen, and strictly serial DDLs cannot hit it either since CREATE INDEX only returns after the backfill completes. The exposure is the default configuration (feature off), where nothing stops a second session from running a DDL against the table mid-backfill.

The error is flattened to plain text on its way to the master (`IndexInfoPB.backfill_error_message`), and the YBClient inside the tserver hosting the CREATE INDEX backend re-raised it as an `Aborted` status with no error codes attached (`Aborted` is the `Status` code, not `TransactionErrorCode::kAborted`, and plays no part in the resulting SQLSTATE). The session running CREATE INDEX therefore sees XX000 (`internal_error`) instead of the retryable 40001 (`serialization_failure`) that every other schema-mismatch path (read and write DML) already delivers.

Fix: propagate the real failure status end-to-end instead of re-tagging by message text:

- The tserver's `QueryPostgresToDoBackfill` keeps the PostgreSQL error code from the libpq error (e.g. 40001 for schema version mismatch) on the status it returns, instead of dropping it when rebuilding the status.
- The master persists the full status in a new `IndexInfoPB.backfill_status` field, alongside `backfill_error_message`, which stays populated for old readers.
- `YBClient::Data::IsBackfillIndexInProgress` re-raises the persisted status (as `Aborted`, keeping its error codes), so pggate's `FetchErrorCode` maps the schema mismatch to 40001. Against an older master that doesn't populate `backfill_status`, it falls back to the message string as before.
- The backend's unique-violation message rewrite (`YBCMakeStatusErrorData`) now skips statuses without a relation OID. Backfill duplicate-key failures now reach it with error code 23505 but no relation OID attached, and the rewrite crashed the backend dereferencing the missing relation. Such statuses already carry a fully formatted PG error message, which is now raised unchanged — so CREATE UNIQUE INDEX failing on duplicate data surfaces as 23505 (`unique_violation`, matching vanilla PostgreSQL) instead of XX000.

## Upgrade/Rollback safety

`IndexInfoPB.backfill_status` is a new optional field.

- New master, old tserver/client: old readers ignore the field; `backfill_error_message` is still populated, so behavior is unchanged.
- Old master, new client: `backfill_status` is never set; the client uses the `backfill_error_message` fallback (pre-change behavior, XX000).
- Rollback: the field is ignored again and `backfill_error_message` remains authoritative. No migration needed either way.

## Test plan

- [x] `PgSchemaVersionMismatchBackfillTest.BackfillSurfacesAsSerializationFailure` — new regression test; fails with XX000 without the fix. Passed 20 consecutive iterations.
- [x] `pg_index_backfill-test` — full suite. Four duplicate-key tests caught the backend crash and pass with the `YBCMakeStatusErrorData` guard.
- [x] `pg_op_buffering-test` — covers the DML duplicate-key path through the changed unique-violation rewrite.
- [x] `cassandra_cpp_driver-test` — YCQL backfill failure path through the changed master code.
