### PR TITLE
[PLAT-22333] YBA: Fix as_root upgrade failure after an older yba-ctl rewrote the installer state

### DIFF
--- a/managed/yba-installer/cmd/init.go
+++ b/managed/yba-installer/cmd/init.go
@@ -135,6 +135,8 @@ func handleRootCheck(cmdName string) {
 			log.Warn("Failed to set as_root in config file, please set it manually")
 			log.Fatal("Failed to set as_root in config file: " + err.Error())
 		}
+		// Reload so the as_root state migration copies the value just written, not the unset one.
+		common.InitViper()
 		return
 	} else if user.Uid == "0" && !viper.GetBool("as_root") {
 		log.Fatal("running as root user with 'as_root' set to false is not supported")

--- a/managed/yba-installer/pkg/ybactlstate/json.go
+++ b/managed/yba-installer/pkg/ybactlstate/json.go
@@ -1,6 +1,7 @@
 package ybactlstate
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -12,15 +13,16 @@ type _stateEncoder struct {
 	Internal internalFields `json:"__internal"`
 }
 
-// UnmarshalJSON into state struct. Allows un-exported internal fields"
+// UnmarshalJSON into state struct. Allows un-exported internal fields and keeps the loaded
+// document for MarshalJSON and the migrations.
 func (s *State) UnmarshalJSON(data []byte) error {
 	var state _stateAlias
 	if err := json.Unmarshal(data, &state); err != nil {
 		return err
 	}
 	*s = State(state)
-	var t map[string]interface{}
-	if err := json.Unmarshal(data, &t); err != nil {
+	t, err := unmarshalDocument(data)
+	if err != nil {
 		return err
 	}
 	internal, ok := t["__internal"]
@@ -34,11 +36,65 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(iData, &s._internalFields); err != nil {
 		return err
 	}
+	s._loadedFields = t
 	return nil
 }
 
-// MarshalJSON out of state struct, allows un-exported internal fields.
+// MarshalJSON out of state struct, allows un-exported internal fields. Keys of the loaded
+// document that this binary does not know are carried through, so a mix of yba-ctl versions
+// rewriting the same state file cannot drop fields.
 func (s State) MarshalJSON() ([]byte, error) {
-	state := _stateEncoder{_stateAlias(s), s._internalFields}
-	return json.Marshal(state)
+	data, err := json.Marshal(_stateEncoder{_stateAlias(s), s._internalFields})
+	if err != nil || s._loadedFields == nil {
+		return data, err
+	}
+	doc, err := unmarshalDocument(data)
+	if err != nil {
+		return nil, err
+	}
+	carryUnknownFields(doc, s._loadedFields)
+	return json.Marshal(doc)
+}
+
+// unmarshalDocument decodes json into nested maps, keeping numbers verbatim so values that are
+// only carried through are not rounded to float64.
+func unmarshalDocument(data []byte) (map[string]interface{}, error) {
+	var doc map[string]interface{}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&doc); err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+// carryUnknownFields copies into doc every key of loaded that doc does not have, recursing into
+// objects present on both sides. Values doc already has always win.
+func carryUnknownFields(doc, loaded map[string]interface{}) {
+	for key, loadedVal := range loaded {
+		docVal, ok := doc[key]
+		if !ok {
+			doc[key] = loadedVal
+			continue
+		}
+		docObj, docIsObj := docVal.(map[string]interface{})
+		loadedObj, loadedIsObj := loadedVal.(map[string]interface{})
+		if docIsObj && loadedIsObj {
+			carryUnknownFields(docObj, loadedObj)
+		}
+	}
+}
+
+func hasJsonPath(doc map[string]interface{}, path []string) bool {
+	var cur interface{} = doc
+	for _, key := range path {
+		obj, ok := cur.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		if cur, ok = obj[key]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/managed/yba-installer/pkg/ybactlstate/json_test.go
+++ b/managed/yba-installer/pkg/ybactlstate/json_test.go
@@ -1,0 +1,48 @@
+package ybactlstate
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestStateJsonCarriesUnknownFields(t *testing.T) {
+	loaded := `{"version":"2026.1.0.0-b1","config":{"hostname":"old","future_flag":true},` +
+		`"future_section":{"id":12345678901234567890},` +
+		`"__internal":{"change_id":1,"schema":1,"run_schemas":[1],"future_internal":"x"}}`
+	state := &State{}
+	if err := json.Unmarshal([]byte(loaded), state); err != nil {
+		t.Fatalf("unmarshal failed: %s", err.Error())
+	}
+	state.Config.Hostname = "new"
+
+	out, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal failed: %s", err.Error())
+	}
+	for _, want := range []string{
+		`"hostname":"new"`,          // struct value wins over the loaded one
+		`"as_root":false`,           // known fields are always written
+		`"future_flag":true`,        // unknown nested key kept
+		`"id":12345678901234567890`, // unknown value kept verbatim, not rounded
+		`"future_internal":"x"`,     // unknown key inside __internal kept
+		`"run_schemas":[1]`,         // internal fields still written
+	} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("expected %s in %s", want, out)
+		}
+	}
+	if strings.Contains(string(out), `"hostname":"old"`) {
+		t.Errorf("loaded value must not override the struct: %s", out)
+	}
+}
+
+func TestStateJsonWithoutLoadedDocument(t *testing.T) {
+	out, err := json.Marshal(&State{Version: "v"})
+	if err != nil {
+		t.Fatalf("marshal failed: %s", err.Error())
+	}
+	if !strings.Contains(string(out), `"__internal"`) || !strings.Contains(string(out), `"version":"v"`) {
+		t.Errorf("unexpected output %s", out)
+	}
+}

--- a/managed/yba-installer/pkg/ybactlstate/migration.go
+++ b/managed/yba-installer/pkg/ybactlstate/migration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/viper"
 
@@ -41,17 +42,23 @@ func handleMigration(state *State) error {
 	updateMade := false
 	for nextSchema < endSchema {
 		nextSchema++
+		migrate, defined := migrations[nextSchema]
 		if slices.Contains(state._internalFields.RunSchemas, nextSchema) {
-			continue
+			if !defined || !state.lostStateField(migrate.stateField) {
+				continue
+			}
+			log.Warn(fmt.Sprintf("state file is missing %s, re-running migration %d",
+				strings.Join(migrate.stateField, "."), nextSchema))
+			state._internalFields.RunSchemas = slices.DeleteFunc(state._internalFields.RunSchemas,
+				func(s int) bool { return s == nextSchema })
 		}
-		migrate := getMigrationHandler(nextSchema)
-		if migrate == nil {
+		if !defined {
 			log.Debug("skipping migration " + strconv.Itoa(nextSchema) + " as it is not defined")
 			continue
 		}
 		updateMade = true
 		log.Debug(fmt.Sprintf("running migration %d", nextSchema))
-		if err := migrate(state); err != nil {
+		if err := migrate.run(state); err != nil {
 			return fmt.Errorf("failed to run migration %d: %w", nextSchema, err)
 		}
 		log.Debug(fmt.Sprintf("migration %d complete", nextSchema))
@@ -63,6 +70,12 @@ func handleMigration(state *State) error {
 	}
 	// StoreState in order to persist migration SchemaVersion
 	return StoreState(state)
+}
+
+// lostStateField reports whether a field written by a migration is absent from the state file
+// this state was loaded from.
+func (s *State) lostStateField(path []string) bool {
+	return len(path) > 0 && s._loadedFields != nil && !hasJsonPath(s._loadedFields, path)
 }
 
 // Update how we track the schema version. Previously, we tracked the max version with the schema
@@ -90,6 +103,16 @@ func updateSchemaTracking(state *State) error {
 }
 
 type migrator func(state *State) error
+
+// migration pairs the function that runs a schema change with, for migrations that write into
+// the state file, the json path of the field they populate. A yba-ctl older than that field
+// drops it when it rewrites the state file (e.g. reconfigure with the installed binary after a
+// failed upgrade attempt) while the migration stays marked as run, so handleMigration uses the
+// path to notice the loss and run the migration again.
+type migration struct {
+	run        migrator
+	stateField []string
+}
 
 // Migrate on default is a no-op, mainly assuming that the default values given to struct fields
 // are sufficient.
@@ -376,30 +399,22 @@ func migrateNodeExporterConfig(state *State) error {
 	return nil
 }
 
-var migrations map[int]migrator = map[int]migrator{
-	defaultMigratorValue: defaultMigrate,
-	promConfigMV:         migratePrometheus,
-	postgresUserMV:       migratePostgresUser,
-	ymlTypeFixMV:         migrateYmlTypes,
-	promOomConfgMV:       migratePrometheusOOMConfig,
-	promTLSCipherSuites:  migratePrometheusTLSCipherSuites,
-	asRoot:               migrateAsRootConfig,
-	ybaWait:              migrateYbaWait,
-	initialized:          migrateInitialized,
-	asRootRetry:          migrateAsRootConfig,
-	improvedCertHandling: migrateCertHandler,
-	stateServices:        migrateStateServices,
-	asRootState:          migrateAsRootState,
-	nodeExporterConfig:   migrateNodeExporterConfig,
-	perfAdvisorConfig:    migratePerfAdvisorConfig,
-}
-
-func getMigrationHandler(toSchema int) migrator {
-	m, ok := migrations[toSchema]
-	if !ok {
-		return nil
-	}
-	return m
+var migrations = map[int]migration{
+	defaultMigratorValue: {run: defaultMigrate},
+	promConfigMV:         {run: migratePrometheus},
+	postgresUserMV:       {run: migratePostgresUser},
+	ymlTypeFixMV:         {run: migrateYmlTypes},
+	promOomConfgMV:       {run: migratePrometheusOOMConfig},
+	promTLSCipherSuites:  {run: migratePrometheusTLSCipherSuites},
+	asRoot:               {run: migrateAsRootConfig},
+	ybaWait:              {run: migrateYbaWait},
+	initialized:          {run: migrateInitialized, stateField: []string{"initialized"}},
+	asRootRetry:          {run: migrateAsRootConfig},
+	improvedCertHandling: {run: migrateCertHandler, stateField: []string{"config", "self_signed_cert"}},
+	stateServices:        {run: migrateStateServices, stateField: []string{"services"}},
+	asRootState:          {run: migrateAsRootState, stateField: []string{"config", "as_root"}},
+	nodeExporterConfig:   {run: migrateNodeExporterConfig},
+	perfAdvisorConfig:    {run: migratePerfAdvisorConfig},
 }
 
 func getSchemaVersion() int {
@@ -413,6 +428,6 @@ func getSchemaVersion() int {
 	return schemaVersionCache
 }
 
-func getMigrations() map[int]migrator {
+func getMigrations() map[int]migration {
 	return migrations
 }

--- a/managed/yba-installer/pkg/ybactlstate/migration_test.go
+++ b/managed/yba-installer/pkg/ybactlstate/migration_test.go
@@ -1,9 +1,14 @@
 package ybactlstate
 
 import (
+	"encoding/json"
+	"maps"
 	"slices"
 	"testing"
 )
+
+// The real migration table, captured before any test swaps it out.
+var realMigrations = migrations
 
 func TestHandleMigrationAllRun(t *testing.T) {
 	fs = mockFS{
@@ -13,7 +18,7 @@ func TestHandleMigrationAllRun(t *testing.T) {
 	state := &State{}
 	state._internalFields = internalFields{}
 	state._internalFields.RunSchemas = make([]int, 0)
-	migrations = make(map[int]migrator)
+	migrations = make(map[int]migration)
 	for i := range 8 {
 		addToMigrationMap(i + 1)
 	}
@@ -38,7 +43,7 @@ func TestHandleMigrationsPartialFullRun(t *testing.T) {
 	state._internalFields = internalFields{}
 	prev := []int{1, 2, 3, 4}
 	state._internalFields.RunSchemas = prev
-	migrations = make(map[int]migrator)
+	migrations = make(map[int]migration)
 	for i := range 8 {
 		addToMigrationMap(i + 1)
 	}
@@ -63,7 +68,7 @@ func TestHandleMigrationsSkippedMigration(t *testing.T) {
 	state._internalFields = internalFields{}
 	prev := []int{1, 2, 3, 4, 6, 7, 8}
 	state._internalFields.RunSchemas = prev
-	migrations = make(map[int]migrator)
+	migrations = make(map[int]migration)
 	for i := range 8 {
 		addToMigrationMap(i)
 	}
@@ -88,7 +93,7 @@ func TestHandleMigrationTransition(t *testing.T) {
 	state := &State{}
 	state._internalFields = internalFields{}
 	state._internalFields.SchemaVersion = 6
-	migrations = make(map[int]migrator)
+	migrations = make(map[int]migration)
 	for i := range 8 {
 		addToMigrationMap(i + 1)
 	}
@@ -112,7 +117,7 @@ func TestNoMigrationDefinedForIndex(t *testing.T) {
 	state := &State{}
 	state._internalFields = internalFields{}
 	// Skipping definition of migration 5
-	migrations = make(map[int]migrator)
+	migrations = make(map[int]migration)
 	for _, v := range []int{1, 2, 3, 4, 6, 7, 8} {
 		addToMigrationMap(v)
 	}
@@ -138,7 +143,7 @@ func TestUpdateTrackingWithSkippedMigration(t *testing.T) {
 	state._internalFields = internalFields{}
 	state._internalFields.SchemaVersion = 6
 	state._internalFields.RunSchemas = nil
-	migrations = make(map[int]migrator)
+	migrations = make(map[int]migration)
 	for _, i := range []int{2, 3, 4, 5, 6, 8, 9} {
 		addToMigrationMap(i)
 	}
@@ -163,5 +168,62 @@ func expectedRunSchemas(v int) []int {
 }
 
 func addToMigrationMap(index int) {
-	migrations[index] = defaultMigrate
+	migrations[index] = migration{run: defaultMigrate}
+}
+
+func TestHandleMigrationRerunsLostStateField(t *testing.T) {
+	fs = mockFS{
+		WriteBuffer: &devNullWriter{}, // we don't care about storing the state
+	}
+	tests := []struct {
+		name   string
+		loaded string      // state file content, empty for a state that was not loaded from a file
+		runs   map[int]int // migrations expected to run, and how often
+	}{
+		{"fields present",
+			`{"config":{"as_root":true},"services":{},"__internal":{"run_schemas":[1,2,3]}}`,
+			map[int]int{}},
+		{"nested field lost",
+			`{"config":{"hostname":"h"},"services":{},"__internal":{"run_schemas":[1,2,3]}}`,
+			map[int]int{1: 1}},
+		{"top level field lost",
+			`{"config":{"as_root":true},"__internal":{"run_schemas":[1,2,3]}}`,
+			map[int]int{2: 1}},
+		{"not run yet is not a loss",
+			`{"config":{},"__internal":{"run_schemas":[3]}}`,
+			map[int]int{1: 1, 2: 1}},
+		{"not loaded from a file", "", map[int]int{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runs := map[int]int{}
+			counting := func(schema int) migrator {
+				return func(*State) error { runs[schema]++; return nil }
+			}
+			migrations = map[int]migration{
+				1: {run: counting(1), stateField: []string{"config", "as_root"}},
+				2: {run: counting(2), stateField: []string{"services"}},
+				3: {run: counting(3)},
+			}
+			schemaVersionCache = 3
+			state := &State{}
+			if test.loaded == "" {
+				state._internalFields.RunSchemas = []int{1, 2, 3}
+			} else if err := json.Unmarshal([]byte(test.loaded), state); err != nil {
+				t.Fatalf("bad test state: %s", err.Error())
+			}
+
+			if err := handleMigration(state); err != nil {
+				t.Fatalf("running migrations failed: %s", err.Error())
+			}
+			if !maps.Equal(runs, test.runs) {
+				t.Errorf("expected runs %v. Found runs %v", test.runs, runs)
+			}
+			for schema := range runs {
+				if !slices.Contains(state._internalFields.RunSchemas, schema) {
+					t.Errorf("expected %d to be marked as run: %v", schema, state._internalFields.RunSchemas)
+				}
+			}
+		})
+	}
 }

--- a/managed/yba-installer/pkg/ybactlstate/state.go
+++ b/managed/yba-installer/pkg/ybactlstate/state.go
@@ -26,6 +26,10 @@ type State struct {
 	Services            Services                 `json:"services"`
 	RestoreDBOnRollback bool                     `json:"restore_db_on_rollback"`
 	_internalFields     internalFields
+	// The document this state was loaded from. Keys in it that this binary does not know are
+	// written back out by MarshalJSON, and migrations use it to notice fields an older binary
+	// dropped.
+	_loadedFields map[string]interface{}
 }
 
 type PostgresState struct {

--- a/managed/yba-installer/pkg/ybactlstate/store_test.go
+++ b/managed/yba-installer/pkg/ybactlstate/store_test.go
@@ -3,6 +3,11 @@ package ybactlstate
 import (
 	"bytes"
 	"io"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
 )
 
 type mockFilesystem struct {
@@ -27,4 +32,65 @@ func patchFS() (*mockFilesystem, func()) {
 	ms := &mockFilesystem{}
 	fs = ms
 	return ms, func() { fs = old_fs }
+}
+
+// State as rewritten by a 2025.2 yba-ctl after a 2026.1 preflight had already run migration 13:
+// the migration is marked as run but config.as_root is gone.
+const lostAsRootState = `{"version":"2025.2.5.2-b5","config":{"hostname":"192.0.2.10","self_signed_cert":true},` +
+	`"services":{"yb-perf-advisor":false,"yb-platform":true},` +
+	`"__internal":{"change_id":7,"schema":12,"run_schemas":[2,3,4,5,6,7,8,9,10,11,12,13]}}`
+
+func TestLoadStateRerunsLostAsRootMigration(t *testing.T) {
+	mockFS, deferFunc := patchFS()
+	defer deferFunc()
+	migrations = map[int]migration{
+		stateServices: realMigrations[stateServices],
+		asRootState:   realMigrations[asRootState],
+	}
+	schemaVersionCache = asRootState
+	viper.Set("as_root", true)
+	defer viper.Reset()
+	mockFS.OpenBuffer = bytes.NewBufferString(lostAsRootState)
+	mockFS.CreateBuffer = new(bytes.Buffer)
+
+	state, err := LoadState()
+	if err != nil {
+		t.Fatalf("LoadState failed: %s", err.Error())
+	}
+	if !state.Config.AsRoot {
+		t.Errorf("expected as_root to be re-derived from the config")
+	}
+	if !slices.Contains(state._internalFields.RunSchemas, asRootState) {
+		t.Errorf("expected migration %d to be marked as run: %v", asRootState, state._internalFields.RunSchemas)
+	}
+	if stored := mockFS.CreateBuffer.String(); !strings.Contains(stored, `"as_root":true`) {
+		t.Errorf("expected repaired state to be stored, found %s", stored)
+	}
+}
+
+func TestLoadStateKeepsStoredAsRoot(t *testing.T) {
+	mockFS, deferFunc := patchFS()
+	defer deferFunc()
+	migrations = map[int]migration{
+		stateServices: realMigrations[stateServices],
+		asRootState:   realMigrations[asRootState],
+	}
+	schemaVersionCache = asRootState
+	viper.Set("as_root", true)
+	defer viper.Reset()
+	mockFS.OpenBuffer = bytes.NewBufferString(strings.Replace(lostAsRootState,
+		`"self_signed_cert":true`, `"self_signed_cert":true,"as_root":false`, 1))
+	mockFS.CreateBuffer = new(bytes.Buffer)
+
+	state, err := LoadState()
+	if err != nil {
+		t.Fatalf("LoadState failed: %s", err.Error())
+	}
+	// A stored false is a real value, so ValidateReconfig can still catch a change to as_root
+	if state.Config.AsRoot {
+		t.Errorf("expected stored as_root to be kept")
+	}
+	if stored := mockFS.CreateBuffer.String(); stored != "" {
+		t.Errorf("expected no migrations to run, found stored state %s", stored)
+	}
 }


### PR DESCRIPTION
## Summary

Upgrading YBA Installer from 2025.2.x to 2026.1.x could fail with

```
FATAL invalid reconfigure during upgrade: cannot change as_root from false
```

even though `yba-ctl.yml` says `as_root: true`. The state file in these cases has `run_schemas` containing 13 but no `config.as_root` key:

1. A 2026.1 `yba-ctl preflight --upgrade` / `upgrade` runs migration 13, stores `config.as_root` and marks it run, then fails on some other precheck (no rollback on preflight failure).
2. The operator runs the **installed 2025.2** binary (`yba-ctl reconfigure` always ends in `StoreState`). Its `Config` struct has no `AsRoot`, so `json.Unmarshal` drops the key and the file is written back without it; `run_schemas` is a plain `[]int` and survives.
3. The next 2026.1 run skips migration 13, `Config.AsRoot` loads as the zero value `false`, and `ValidateReconfig` fatals. Every retry fails until the state file is hand-edited.

Changes in `pkg/ybactlstate`:

* The `migrations` table holds `migration{run, stateField}`. Migrations that write into the state file (9 `initialized`, 11 `config.self_signed_cert`, 12 `services`, 13 `config.as_root`) declare the json path they populate; `handleMigration` re-runs one that is marked run but whose field is missing from the loaded document, logging `state file is missing config.as_root, re-running migration 13`. This is the repair for state files already damaged by shipped binaries.
* `State` keeps the document it was loaded from; `MarshalJSON` merges the struct's output over it (struct wins, unknown keys carried through, numbers kept verbatim). Once the writer is a build with this change, an older/newer yba-ctl mix can no longer drop fields.

`cmd/init.go`: `handleRootCheck` reloads viper after writing `as_root` into `yba-ctl.yml`, so migration 13 in the same process copies the value just written rather than the unset one.

## Upgrade/Rollback safety

* On load, a state file whose `run_schemas` includes a state-writing migration but lacks that migration's field triggers a re-run of that migration (and a `StoreState`). Only migrations 9, 11, 12 and 13 declare a field; all four are idempotent.
* The state file is now written with sorted keys and carries through keys this binary does not know. Older yba-ctl versions read it unchanged (they ignore unknown keys); an older binary that rewrites the file still drops the keys it does not know, exactly as before — a build with this change repairs that on its next run.
* Workaround for installs already stuck on a build without this change: add `"as_root": true` (root install) or `false` to the `config` object in `/opt/yba-ctl/.yba_installer.state`, then retry the upgrade.

## Test plan

- [x] `go test ./...` in `managed/yba-installer` (new: `TestHandleMigrationRerunsLostStateField`, `TestLoadStateRerunsLostAsRootMigration`, `TestLoadStateKeepsStoredAsRoot`, `TestStateJsonCarriesUnknownFields`, `TestStateJsonWithoutLoadedDocument`).
- [x] Reproduced on a test VM: install 2025.2.5.2-b5 → stock 2026.1.1.1-b2 `preflight --upgrade` (fails on disk) → 2025.2 `yba-ctl reconfigure` → stock 2026.1.1.1-b2 `upgrade` fails with `cannot change as_root from false`; state shows `run_schemas [..14]` and no `config.as_root`.
- [x] Same flow with this change built on top of the 2026.1.1.1-b2 tag, after also injecting unknown keys (`config.future_flag`, `future_section.id: 12345678901234567890`) into the damaged state: `upgrade` logs `re-running migration 13`, completes, and the final state has `as_root: true` plus both injected keys intact (id not rounded). `yba-ctl status` afterwards leaves the file unchanged.
