### PR TITLE
[doc] Fix typo: "acts as a catalog manager" in Architecture overview

### DIFF
--- a/docs/content/stable/architecture/_index.md
+++ b/docs/content/stable/architecture/_index.md
@@ -70,7 +70,7 @@ To understand how transactions work in YugabyteDB, see [Transactions](transactio
 
 ## Master server
 
-The master service acts a catalog manager and cluster orchestrator, and manages many background tasks.
+The master service acts as a catalog manager and cluster orchestrator, and manages many background tasks.
 
 {{<lead link="./yb-master">}}
 For more details, see [YB-Master](./yb-master).

--- a/docs/content/v2.20/architecture/_index.md
+++ b/docs/content/v2.20/architecture/_index.md
@@ -68,7 +68,7 @@ To understand how transactions work in YugabyteDB, see [Transactions](transactio
 
 ## Master server
 
-The master service acts a catalog manager and cluster orchestrator, and manages many background tasks.
+The master service acts as a catalog manager and cluster orchestrator, and manages many background tasks.
 
 {{<lead link="./yb-master">}}
 For more details, see [YB-Master](./yb-master).

--- a/docs/content/v2024.2/architecture/_index.md
+++ b/docs/content/v2024.2/architecture/_index.md
@@ -68,7 +68,7 @@ To understand how transactions work in YugabyteDB, see [Transactions](transactio
 
 ## Master server
 
-The master service acts a catalog manager and cluster orchestrator, and manages many background tasks.
+The master service acts as a catalog manager and cluster orchestrator, and manages many background tasks.
 
 {{<lead link="./yb-master">}}
 For more details, see [YB-Master](./yb-master).

--- a/docs/content/v2025.1/architecture/_index.md
+++ b/docs/content/v2025.1/architecture/_index.md
@@ -68,7 +68,7 @@ To understand how transactions work in YugabyteDB, see [Transactions](transactio
 
 ## Master server
 
-The master service acts a catalog manager and cluster orchestrator, and manages many background tasks.
+The master service acts as a catalog manager and cluster orchestrator, and manages many background tasks.
 
 {{<lead link="./yb-master">}}
 For more details, see [YB-Master](./yb-master).

--- a/docs/content/v2025.2/architecture/_index.md
+++ b/docs/content/v2025.2/architecture/_index.md
@@ -68,7 +68,7 @@ To understand how transactions work in YugabyteDB, see [Transactions](transactio
 
 ## Master server
 
-The master service acts a catalog manager and cluster orchestrator, and manages many background tasks.
+The master service acts as a catalog manager and cluster orchestrator, and manages many background tasks.
 
 {{<lead link="./yb-master">}}
 For more details, see [YB-Master](./yb-master).


### PR DESCRIPTION
Fixes a missing word in the Architecture overview page (`architecture/_index.md`):

> The master service acts **a** catalog manager → acts **as a** catalog manager

Applied to `stable` and the versioned copies (`v2025.2`, `v2025.1`, `v2024.2`, `v2.20`), which all carry the same sentence.