### PR TITLE
[#33804] DocDB: float16 coordinate storage for vector index chunks

### DIFF
--- a/architecture/design/docdb-vector-index-narrowed-storage.md
+++ b/architecture/design/docdb-vector-index-narrowed-storage.md
@@ -1,0 +1,154 @@
+# Vector index narrowed coordinate storage
+
+A DocDB vector index (`ybhnsw`) can store the coordinates of a served chunk as `float16` rather
+than `float32`. The HNSW graph is always built at full `float32` precision -- only the copy
+written into the immutable chunk file is narrowed.
+
+`float32` is the default and writes version-1 chunks, so an index that does not opt in is
+unaffected.
+
+## Record layout
+
+`VectorStorageKind` names the encoding. Per vector at 768 dimensions:
+
+| encoding | coordinates | record | vs `float32` | bytes per distance |
+|---|---|---|---|---|
+| `float32` | 3072 | 3092 | 1.00x | 3072 |
+| `float16` | 1536 | 1556 | 0.50x | 1536 |
+
+The 20-byte overhead is the per-vector `YbHnswVectorData` header.
+
+`coordinate_codec.{h,cc}` owns both directions and nothing else narrows coordinates: writer and
+query path must round identically, or a vector stops being at distance zero from itself and the
+graph's neighbour choices stop agreeing with the distances used to search it.
+
+## Measured
+
+VectorDBBench `Performance768D1M` (Cohere, cosine), `k=100`, 30 clients, versus `float32` at the
+same `ef_search`:
+
+| setup | ef | recall delta | throughput |
+|---|---|---|---|
+| RF3 | 100 | +0.14% | +17.0% |
+| RF3 | 200 | +0.06% | +12.5% |
+| RF1 | 100 | +0.05% | +17.0% |
+| RF1 | 200 | -0.02% | +20.6% |
+
+Recall moves by at most 0.14% in either direction across all four cells, which is what makes the
+encoding safe to consider as a default.
+
+Throughput gains less than the halved byte count suggests, for two reasons. The `*_f16_haswell`
+kernels widen each coordinate to fp32 and accumulate there, so halving the bytes does not halve
+the work. And fitting `speedup = 1/((1-f) + f/c)` across these cells, `c` being the coordinate-byte
+ratio, gives **f ~ 0.3**: only about 30% of end-to-end query time scales with coordinate bytes.
+The rest is tablet fan-out, resolving and fetching `LIMIT` rows per query, neighbour-list reads
+that no encoding shrinks, and YSQL/RPC overhead. That puts a ceiling near 1.43x on what any
+coordinate encoding can buy here.
+
+## Index size and memory footprint
+
+Halving the coordinate bytes halves what the index costs on disk and in the block cache. Measured
+file sizes for 1M vectors at 768 dimensions (from a single-node `ef_search=200` run, not the
+RF1/RF3 runs above):
+
+| encoding | record | vs `float32` | index size | records per fixed cache budget |
+|---|---|---|---|---|
+| `float32` | 3092 | 1.00x | 3.19 GB | 1.00x |
+| `float16` | 1556 | 0.50x | **1.65 GB** | **1.99x** |
+
+The file ratio is 0.52x rather than 0.50x because the graph and aux data do not shrink. That is
+the whole of the discrepancy: 1M records account for 3.09 GB at `float32` and 1.56 GB at
+`float16`, leaving ~0.10 GB of neighbour lists and aux entries unchanged, and 1.56 + 0.10 = 1.65 GB
+is what was measured. So the on-disk saving is predicted by the record layout alone -- there is no
+second effect to account for.
+
+The block cache holds records, so the same budget keeps ~2x as many vectors resident. That matters
+more than the disk saving: at 1M x 768d a `float32` index does not fit a typical cache, and the
+traversal is what pays for the misses.
+
+## Chunk format
+
+Each chunk records its own encoding in its footer, under a serialization version:
+
+| version | contents |
+|---|---|
+| 1 | base layout; always `float32` |
+| 2 | adds `Header::storage_kind` |
+
+The writer emits the lowest version that can represent the header, which keeps a `float32` index
+at version 1. `Load` rejects a version outside the supported range rather than reading the fields
+it knows and consuming the remainder as block offsets, and `ValidateHeader` then checks the parsed
+header against itself before any record is read through it: a `vector_data_size` disagreeing with
+the encoding would read past every record into the next, and an out-of-range encoding enum would
+reach `FATAL_INVALID_ENUM_VALUE` and abort the process rather than failing the one file.
+
+## Search hot path
+
+Two changes here are independent of which encoding an index uses.
+
+**Neighbour prefetch** (`yb_hnsw_prefetch_neighbors`, default on). Visiting a neighbour costs two
+dependent cache misses the CPU cannot speculate through: `blocks_[index]`, then the record it
+points at. The loop filters a node's neighbours through the visited set, resolves all their
+record addresses and prefetches each, before computing any distance, so the misses overlap. Both
+loop shapes call one `visit` lambda in neighbour order, so results are identical --
+`PrefetchMatchesSerialResolution` asserts that, including equal cache query and hit counts. The
+visited filter must stay first, or resolving addresses for already-visited neighbours would
+`Take()` blocks the search does not need. **Measured neutral** (see Caveats); the flag allows
+A/B in one process.
+
+**Batched cache counters.** `cache_query`/`cache_hit` are accumulated in `SearchCache` and
+flushed once per search rather than incremented inside `CachedBlock::Take`, which a query calls
+thousands of times. `Take` reports residency through a `was_hit` out-parameter; a caller passing
+`nullptr` gets no accounting, as the header states.
+
+## Enabling the encoding
+
+A **master** flag chooses the encoding, stamped into the index's catalog entry at `CREATE INDEX`.
+It is therefore fixed for the life of that index and identical on every replica, rather than
+following each tserver's local flags.
+
+```bash
+# On every yb-master. Runtime-settable; no restart needed.
+--vector_index_storage_coordinate_type=float16   # or float32 (default)
+```
+
+An index keeps the encoding it was created with, so the flag's value at query time says nothing
+about an index created earlier. To see what an index got, read `vector_data_size` from the index
+flush log line: `20 + 4*d` for `float32`, `20 + 2*d` for `float16`.
+
+### Downgrade
+
+Selecting `float16` is one-way for the chunks written while it is selected: a version-2 chunk is
+unreadable by a binary that only understands version 1. Clearing the flag stops new chunks from
+using the encoding but does not rewrite existing ones, and an index created while it was set
+keeps its encoding in the catalog. Moving such a cluster to a binary without the encoding
+requires those indexes be dropped and rebuilt.
+
+## SIMD kernels
+
+x86-64 builds at `-march=ivybridge`, so no AVX-512 family enables itself from its `-march` macro
+and `usearch_include_wrapper_internal.h` forces the SimSIMD targets the encoding needs:
+`HASWELL` and `SKYLAKE`. Forcing a target is safe -- each kernel carries its own target attribute
+so it compiles under the Ivy Bridge baseline, and `simsimd_capabilities()` dispatches on CPUID, so
+a kernel the host cannot run is never called.
+
+`float16` distances use the 256-bit `*_f16_haswell` kernels, which widen each coordinate to fp32
+and accumulate there. The `#define`s reach only translation units including
+`usearch_include_wrapper_internal.h`, directly or through `hnsw.h`: 5 production files, all
+vector-index code, plus 4 tests. `hnsw.h` is included by no other header, so nothing in
+`tserver`, `master`, `rocksdb` or `postgres` is reached. Vector indexes are YSQL-only, so none of
+this can reach a YCQL workload.
+
+## Caveats
+
+- **No sanitizer coverage of the SIMD kernels.** SimSIMD is disabled under ASAN and TSAN, whose
+  builds exercise usearch's scalar metric instead. The wide intrinsic loads largely evade
+  instrumentation, so a bad read inside one faults or is missed rather than reported.
+- **One workload.** Every number above is Cohere 768d/1M, `k=100`, 30 clients, read-only. The
+  dispatch split, the 30% byte-proportional fraction, and the balance between bytes moved and
+  kernel cost will differ on another host, at another dimension count, at a different `LIMIT`, or
+  under a mixed read/write load.
+- **Latency is unmeasured.** The table reports recall and throughput only.
+- **The prefetch is not earning its place.** Isolated at `float32` it straddles zero
+  (+4.9%/+2.1% RF3, -3.4%/-4.9% RF1). It should either be shown to pay on some workload or be
+  turned off.

--- a/src/yb/ann_methods/CMakeLists.txt
+++ b/src/yb/ann_methods/CMakeLists.txt
@@ -42,4 +42,5 @@ set(YB_TEST_LINK_LIBS ann_methods ann_methods_test_proto yrpc hnsw_test_util ${Y
 
 ADD_YB_TEST(index_merge-test)
 ADD_YB_TEST(vector_index_perf-test)
+ADD_YB_TEST(yb_hnsw_storage-test)
 ADD_YB_TEST(vector_lsm-test)

--- a/src/yb/ann_methods/usearch_wrapper.cc
+++ b/src/yb/ann_methods/usearch_wrapper.cc
@@ -137,7 +137,7 @@ class UsearchIndex :
         block_cache_(block_cache),
         dimensions_(options.dimensions),
         distance_kind_(options.distance_kind),
-        metric_(options.CreateMetric<Vector>()),
+        metric_(options.CreateBuildMetric<Vector>()),
         backend_(backend),
         index_(IndexImpl::make(metric_, CreateIndexDenseConfig(options))) {
     CHECK_GT(dimensions_, 0);
@@ -374,7 +374,7 @@ class UsearchIndexTraits :
       const MemTrackerPtr& mem_tracker)
       : block_cache_(block_cache), options_(options), backend_(backend),
         mem_tracker_(mem_tracker),
-        metric_(options.CreateMetric<Vector>()) {
+        metric_(options.CreateBuildMetric<Vector>()) {
     LOG_IF(DFATAL, backend != HnswBackend::USEARCH && backend != HnswBackend::YB_HNSW_USEARCH) <<
         "Invalid backend for usearch index: " << HnswBackend_Name(backend);
   }

--- a/src/yb/ann_methods/vector_index_perf-test.cc
+++ b/src/yb/ann_methods/vector_index_perf-test.cc
@@ -17,6 +17,7 @@
 #include "yb/ann_methods/hnswlib_wrapper.h"
 #include "yb/ann_methods/usearch_wrapper.h"
 
+#include "yb/util/env.h"
 #include "yb/util/size_literals.h"
 
 namespace yb::ann_methods {
@@ -44,6 +45,11 @@ class VectorIndexPerfTest : public hnsw::VectorIndexTestBase {
     vector_index::HNSWOptions options = {
       .dimensions = dimensions_,
     };
+    // Same options apart from the on-disk encoding, so the graph built in RAM is identical and
+    // the set isolates what narrowing the served records costs.
+    auto float16_options = options;
+    float16_options.storage_kind = vector_index::VectorStorageKind::kFloat16;
+
     indexes_.emplace_back(
         "usearch",
         ASSERT_RESULT((CreateUsearchIndexTraits<Vector, DistanceResult>(
@@ -53,6 +59,11 @@ class VectorIndexPerfTest : public hnsw::VectorIndexTestBase {
         "hnswlib",
         ASSERT_RESULT((CreateHnswlibIndexTraits<Vector, DistanceResult>(
             block_cache_, options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)))
+            ->Create(vector_index::FactoryMode::kCreate, vector_index::StoreVectorPayload::kFalse));
+    indexes_.emplace_back(
+        "hnswlib_f16_source",
+        ASSERT_RESULT((CreateHnswlibIndexTraits<Vector, DistanceResult>(
+            block_cache_, float16_options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)))
             ->Create(vector_index::FactoryMode::kCreate, vector_index::StoreVectorPayload::kFalse));
     for (const auto& [_, index] : indexes_) {
       ASSERT_OK(index->Reserve(
@@ -66,11 +77,20 @@ class VectorIndexPerfTest : public hnsw::VectorIndexTestBase {
 
     indexes_.emplace_back(
         "yb_hnsw",
-        ASSERT_RESULT(indexes_.front().second->SaveToFile(GetTestPath("0.yb_hnsw"))));
+        ASSERT_RESULT(indexes_[0].second->SaveToFile(GetTestPath("0.yb_hnsw"))));
 
     indexes_.emplace_back(
         "yb_hnsw_hnswlib",
         ASSERT_RESULT(indexes_[1].second->SaveToFile(GetTestPath("1.yb_hnsw"))));
+
+    indexes_.emplace_back(
+        "yb_hnsw_hnswlib_f16",
+        ASSERT_RESULT(indexes_[2].second->SaveToFile(GetTestPath("2.yb_hnsw"))));
+
+    for (const auto& name : {"1.yb_hnsw", "2.yb_hnsw"}) {
+      LOG(INFO) << name << " size: "
+                << ASSERT_RESULT(Env::Default()->GetFileSize(GetTestPath(name)));
+    }
   }
 
   void InsertRandomVector(Vector& holder) {

--- a/src/yb/ann_methods/yb_hnsw_storage-test.cc
+++ b/src/yb/ann_methods/yb_hnsw_storage-test.cc
@@ -1,0 +1,229 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+// Narrowed storage through the VectorIndexIf stack -- the path a VectorLSM chunk takes. What
+// matters is reading stored records back: iteration (how compaction consumes source chunks) and
+// Distance (which callers reach with full-precision vectors).
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <set>
+
+#include "yb/ann_methods/hnswlib_wrapper.h"
+
+#include "yb/hnsw/hnsw_block_cache.h"
+#include "yb/hnsw/vector_index_test_base.h"
+
+#include "yb/util/size_literals.h"
+#include "yb/util/status_log.h"
+#include "yb/util/test_util.h"
+
+#include "yb/vector_index/coordinate_codec.h"
+#include "yb/vector_index/vector_index_if.h"
+
+namespace yb::ann_methods {
+
+using vector_index::FactoryMode;
+using vector_index::HNSWOptions;
+using vector_index::StoreVectorPayload;
+using vector_index::VectorId;
+using vector_index::VectorIndexIfPtr;
+using vector_index::VectorStorageKind;
+
+using DistanceResult = float;
+using IndexPtr = VectorIndexIfPtr<FloatVector, DistanceResult>;
+
+class YbHnswStorageWrapperTest : public hnsw::VectorIndexTestBase {
+ protected:
+  size_t BlockCacheCapacity() override {
+    return 256_MB;
+  }
+
+  HNSWOptions Options(VectorStorageKind storage_kind) const {
+    HNSWOptions options;
+    options.dimensions = dimensions_;
+    options.num_neighbors_per_vertex = 16;
+    options.num_neighbors_per_vertex_base = 32;
+    options.ef_construction = 100;
+    options.storage_kind = storage_kind;
+    return options;
+  }
+
+  // Reopens the way a restart would: a fresh traits-factory instance that only saw the file.
+  IndexPtr BuildAndReload(VectorStorageKind storage_kind, const std::string& name) {
+    auto options = Options(storage_kind);
+    auto traits = CHECK_RESULT((CreateHnswlibIndexTraits<FloatVector, DistanceResult>(
+        block_cache_, options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)));
+
+    // These tests cover the coordinate encodings, not payloads.
+    auto mutable_index = traits->Create(FactoryMode::kCreate, StoreVectorPayload::kFalse);
+    CHECK_OK(mutable_index->Reserve(
+        vectors_.size(), 1, 1, rocksdb::Cache::ReservationMode::kAlways));
+    for (size_t i = 0; i != vectors_.size(); ++i) {
+      CHECK_OK(mutable_index->Insert(ids_[i], vectors_[i], Slice()));
+    }
+
+    const auto path = GetTestPath(name);
+    // Drop SaveToFile's return and go through the load factory, covering restart not flush.
+    CHECK_RESULT(mutable_index->SaveToFile(path));
+
+    auto loaded = traits->Create(FactoryMode::kLoad, StoreVectorPayload::kFalse);
+    CHECK_OK(loaded->LoadFromFile(path, 1));
+    return loaded;
+  }
+
+  void GenerateVectors(size_t count) {
+    vectors_ = RandomVectors(count);
+    ids_.clear();
+    ids_.reserve(count);
+    for (size_t i = 0; i != count; ++i) {
+      ids_.push_back(VectorId::GenerateRandom());
+    }
+  }
+
+  vector_index::SearchOptions MakeSearchOptions(size_t max_results, size_t ef = 64) const {
+    return vector_index::SearchOptions {
+      .max_num_results = max_results,
+      .ef = ef,
+    };
+  }
+
+  std::vector<hnsw::Vector> vectors_;
+  std::vector<VectorId> ids_;
+  MemTrackerPtr mem_tracker_ =
+      MemTracker::GetRootTracker()->FindOrCreateTracker(1_GB, "yb_hnsw_storage_test");
+};
+
+// MergingIterator reads every source chunk through this on every compaction, and reading
+// float32-wide from a float16 record would run off the end of each one.
+TEST_F(YbHnswStorageWrapperTest, IterationDecodesNarrowedRecords) {
+  constexpr size_t kNumVectors = 500;
+  dimensions_ = 24;
+  GenerateVectors(kNumVectors);
+
+  for (auto storage_kind : {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16}) {
+    auto index = BuildAndReload(storage_kind, Format("iter_$0.yb_hnsw", storage_kind));
+    ASSERT_EQ(index->Size(), kNumVectors) << storage_kind;
+
+    std::map<VectorId, hnsw::Vector> seen;
+    for (const auto& entry : *index) {
+      ASSERT_EQ(entry.vector.size(), dimensions_) << storage_kind;
+      ASSERT_TRUE(seen.emplace(entry.vector_id, entry.vector).second)
+          << "duplicate id from iteration: " << entry.vector_id << ", " << storage_kind;
+    }
+    ASSERT_EQ(seen.size(), kNumVectors) << storage_kind;
+
+    // The invariant that keeps compaction from degrading an index over time.
+    for (size_t i = 0; i != kNumVectors; ++i) {
+      auto it = seen.find(ids_[i]);
+      ASSERT_NE(it, seen.end()) << "missing id " << ids_[i] << ", " << storage_kind;
+
+      std::vector<std::byte> narrowed(
+          vector_index::CoordinateBytes(storage_kind, dimensions_));
+      vector_index::NarrowCoordinates(
+          storage_kind, vectors_[i].data(), dimensions_, narrowed.data());
+      hnsw::Vector expected(dimensions_);
+      vector_index::WidenCoordinates(
+          storage_kind, narrowed.data(), dimensions_, expected.data());
+
+      ASSERT_EQ(expected, it->second) << "vector " << i << ", " << storage_kind;
+    }
+  }
+}
+
+// Re-narrowing iteration's output must reproduce the same bytes, or precision drifts per merge.
+TEST_F(YbHnswStorageWrapperTest, CompactionRoundTripIsStable) {
+  dimensions_ = 32;
+  GenerateVectors(400);
+
+  auto index = BuildAndReload(VectorStorageKind::kFloat16, "roundtrip.yb_hnsw");
+
+  auto narrow = [this](const hnsw::Vector& vector) {
+    std::vector<std::byte> out(
+        vector_index::CoordinateBytes(VectorStorageKind::kFloat16, dimensions_));
+    vector_index::NarrowCoordinates(
+        VectorStorageKind::kFloat16, vector.data(), dimensions_, out.data());
+    return out;
+  };
+
+  for (const auto& entry : *index) {
+    // entry.vector came out of a float16 record, so narrowing it again must be a no-op.
+    std::vector<std::byte> widened_then_narrowed = narrow(entry.vector);
+    hnsw::Vector again(dimensions_);
+    vector_index::WidenCoordinates(
+        VectorStorageKind::kFloat16, widened_then_narrowed.data(), dimensions_, again.data());
+    ASSERT_EQ(entry.vector, again) << entry.vector_id;
+  }
+}
+
+// Distance() takes full-precision vectors but the metric decodes stored records, so it must
+// narrow its arguments or it compares float32 bytes with a float16 metric.
+TEST_F(YbHnswStorageWrapperTest, DistanceNarrowsFullPrecisionArguments) {
+  dimensions_ = 16;
+  GenerateVectors(200);
+
+  auto f32 = BuildAndReload(VectorStorageKind::kFloat32, "dist_f32.yb_hnsw");
+  auto f16 = BuildAndReload(VectorStorageKind::kFloat16, "dist_f16.yb_hnsw");
+
+  for (size_t i = 0; i != 50; ++i) {
+    const auto& lhs = vectors_[i];
+    const auto& rhs = vectors_[(i + 37) % vectors_.size()];
+
+    const auto exact = f32->Distance(lhs, rhs);
+    const auto narrowed = f16->Distance(lhs, rhs);
+
+    ASSERT_TRUE(std::isfinite(narrowed)) << "pair " << i;
+    ASSERT_GT(exact, 0.0f) << "pair " << i;
+    ASSERT_LE(std::fabs(narrowed - exact) / exact, 0.01) << "pair " << i;
+
+    // A vector against itself is exactly zero under either encoding.
+    ASSERT_EQ(f16->Distance(lhs, lhs), 0.0f) << "pair " << i;
+  }
+}
+
+// End to end: the loaded index answers searches and top results still agree with full precision.
+TEST_F(YbHnswStorageWrapperTest, SearchAgreesWithFullPrecision) {
+  constexpr size_t kNumVectors = 4000;
+  constexpr size_t kNumQueries = 200;
+  constexpr size_t kMaxResults = 10;
+
+  dimensions_ = 64;
+  GenerateVectors(kNumVectors);
+
+  auto f32 = BuildAndReload(VectorStorageKind::kFloat32, "search_f32.yb_hnsw");
+  auto f16 = BuildAndReload(VectorStorageKind::kFloat16, "search_f16.yb_hnsw");
+
+  size_t common = 0;
+  for (size_t i = 0; i != kNumQueries; ++i) {
+    auto query = RandomVector();
+    auto from_f32 = ASSERT_RESULT(f32->Search(query, MakeSearchOptions(kMaxResults)));
+    auto from_f16 = ASSERT_RESULT(f16->Search(query, MakeSearchOptions(kMaxResults)));
+    ASSERT_EQ(from_f32.size(), kMaxResults);
+    ASSERT_EQ(from_f16.size(), kMaxResults);
+
+    std::set<VectorId> f32_ids;
+    for (const auto& entry : from_f32) {
+      f32_ids.insert(entry.vector_id);
+    }
+    for (const auto& entry : from_f16) {
+      common += f32_ids.contains(entry.vector_id);
+      ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+    }
+  }
+
+  const double overlap = static_cast<double>(common) / (kNumQueries * kMaxResults);
+  LOG(INFO) << "float16 top-" << kMaxResults << " overlap with float32: " << overlap;
+  ASSERT_GE(overlap, 0.9);
+}
+
+}  // namespace yb::ann_methods

--- a/src/yb/ann_methods/yb_hnsw_wrapper.cc
+++ b/src/yb/ann_methods/yb_hnsw_wrapper.cc
@@ -19,6 +19,7 @@
 #include "yb/util/scope_exit.h"
 #include "yb/util/status_format.h"
 
+#include "yb/vector_index/coordinate_codec.h"
 #include "yb/vector_index/index_wrapper_base.h"
 
 namespace yb::ann_methods {
@@ -28,6 +29,7 @@ namespace {
 using vector_index::IndexableVectorType;
 using vector_index::VectorId;
 using vector_index::ValidDistanceResultType;
+using vector_index::VectorStorageKind;
 
 template<IndexableVectorType Vector>
 class YbHnswIterator : public AbstractIterator<vector_index::VectorIndexIteratorEntry<Vector>> {
@@ -36,7 +38,7 @@ class YbHnswIterator : public AbstractIterator<vector_index::VectorIndexIterator
   using Base = AbstractIterator<ValueType>;
 
   YbHnswIterator(const hnsw::YbHnsw& hnsw, size_t index)
-      : cache_scope_(cache_, hnsw), dimensions_(hnsw.header().dimensions), index_(index) {
+      : cache_scope_(cache_, hnsw), header_(hnsw.header()), index_(index) {
   }
 
   void Next() override {
@@ -44,13 +46,16 @@ class YbHnswIterator : public AbstractIterator<vector_index::VectorIndexIterator
   }
 
   ValueType Dereference() const override {
-    const auto* coordinates = cache_.CoordinatesPtr(index_);
     ValueType result;
     auto [vector_id, payload] = cache_.GetVectorIdAndPayload(index_);
     result.vector_id = vector_id;
-    result.vector.resize(dimensions_);
-    memcpy(result.vector.data(), coordinates, dimensions_ * sizeof(typename Vector::value_type));
     result.payload = payload;
+    result.vector.resize(header_.dimensions);
+    // Records may be narrower than Vector::value_type, so this decodes rather than copies; a
+    // memcpy would walk past the end of each record.
+    vector_index::WidenCoordinates(
+        header_.storage_kind, cache_.CoordinatesPtr(index_), header_.dimensions,
+        result.vector.data());
     return result;
   }
 
@@ -62,7 +67,7 @@ class YbHnswIterator : public AbstractIterator<vector_index::VectorIndexIterator
  private:
   mutable hnsw::SearchCache cache_;
   hnsw::SearchCacheScope cache_scope_;
-  const size_t dimensions_;
+  const hnsw::Header& header_;
   size_t index_;
 };
 
@@ -92,9 +97,12 @@ class YbHnswIndex :
 
   Status Import(
       const hnsw::HnswlibIndex<DistanceResult>& index, const std::string& path,
-      const vector_index::VectorPayloadMap* payloads) {
-    VLOG_WITH_FUNC(3) << "index: " << index.cur_element_count << ", path: " << path;
-    return index_.Import(index, path, payloads);
+      const vector_index::VectorPayloadMap* payloads,
+      VectorStorageKind storage_kind) {
+    VLOG_WITH_FUNC(3)
+        << "index: " << index.cur_element_count << ", path: " << path
+        << ", storage_kind: " << storage_kind;
+    return index_.Import(index, path, payloads, storage_kind);
   }
 
   std::unique_ptr<AbstractIterator<vector_index::VectorIndexIteratorEntry<Vector>>> BeginImpl()
@@ -133,8 +141,21 @@ class YbHnswIndex :
   }
 
   DistanceResult Distance(const Vector& lhs, const Vector& rhs) const override {
-    return index_.Distance(
-        pointer_cast<const std::byte*>(lhs.data()), pointer_cast<const std::byte*>(rhs.data()));
+    const auto& header = index_.header();
+    if (header.storage_kind == VectorStorageKind::kFloat32) {
+      return index_.Distance(
+          pointer_cast<const std::byte*>(lhs.data()), pointer_cast<const std::byte*>(rhs.data()));
+    }
+    // The metric decodes this file's encoding, so full-precision arguments must go through the
+    // same narrowing the stored records did. Cold path (SearchExact and tests), so a scratch
+    // allocation per call is fine.
+    const auto bytes = vector_index::CoordinateBytes(header.storage_kind, header.dimensions);
+    std::vector<std::byte> buffer(bytes * 2);
+    vector_index::NarrowCoordinates(
+        header.storage_kind, lhs.data(), header.dimensions, buffer.data());
+    vector_index::NarrowCoordinates(
+        header.storage_kind, rhs.data(), header.dimensions, buffer.data() + bytes);
+    return index_.Distance(buffer.data(), buffer.data() + bytes);
   }
 
   Result<Vector> GetVector(VectorId vector_id) const override {
@@ -182,14 +203,25 @@ class YbHnswIndex :
   mutable LockFreeStack<SearchContextHolder> search_contexts_;
 };
 
+// Builds metrics from `options` for whichever encoding YbHnsw asks about: what Import is about
+// to write, or what Init read from a file's footer.
+hnsw::YbHnsw::MetricFactory MakeMetricFactory(const vector_index::HNSWOptions& options) {
+  return [options](size_t dimensions, VectorStorageKind storage_kind) {
+    return std::make_unique<hnsw::UsearchMetric>(
+        options.CreateStoredMetric(dimensions, storage_kind));
+  };
+}
+
 } // namespace
 
 template <class Vector, class DistanceResult>
 Result<vector_index::VectorIndexIfPtr<Vector, DistanceResult>> ImportYbHnsw(
     const unum::usearch::index_dense_gt<vector_index::VectorId>& index, const std::string& path,
     const hnsw::BlockCachePtr& block_cache, const vector_index::VectorPayloadMap* payloads) {
+  // The usearch index owns its own float32 metric; narrowed storage is not wired through this
+  // backend, so the chunk is written and served at full precision.
   auto result = std::make_shared<YbHnswIndex<Vector, DistanceResult>>(
-      std::make_unique<hnsw::UsearchMetric>(index.metric()), block_cache);
+      index.metric(), block_cache);
   RETURN_NOT_OK(result->Import(index, path, payloads));
   return result;
 }
@@ -200,8 +232,9 @@ Result<vector_index::VectorIndexIfPtr<Vector, DistanceResult>> ImportYbHnsw(
     const hnsw::BlockCachePtr& block_cache, const vector_index::HNSWOptions& options,
     const vector_index::VectorPayloadMap* payloads) {
   auto result = std::make_shared<YbHnswIndex<Vector, DistanceResult>>(
-      std::make_unique<hnsw::UsearchMetric>(options.CreateMetric<Vector>()), block_cache);
-  RETURN_NOT_OK(result->Import(index, path, payloads));
+      MakeMetricFactory(options), block_cache);
+  RETURN_NOT_OK(
+      result->Import(index, path, payloads, options.storage_kind));
   return result;
 }
 
@@ -220,7 +253,7 @@ template <class Vector, class DistanceResult>
 vector_index::VectorIndexIfPtr<Vector, DistanceResult> CreateYbHnsw(
     const hnsw::BlockCachePtr& block_cache, const vector_index::HNSWOptions& options) {
   return std::make_shared<YbHnswIndex<Vector, DistanceResult>>(
-      std::make_unique<hnsw::UsearchMetric>(options.CreateMetric<Vector>()), block_cache);
+      MakeMetricFactory(options), block_cache);
 }
 
 template

--- a/src/yb/common/common.proto
+++ b/src/yb/common/common.proto
@@ -141,11 +141,23 @@ enum HnswBackend {
   YB_HNSW_HNSWLIB = 3;
 };
 
+// Encoding of the coordinates a served vector index chunk stores on disk. Graph construction
+// always runs at full precision regardless.
+enum VectorStorageType {
+  STORAGE_FLOAT32 = 0;
+  STORAGE_FLOAT16 = 1;
+}
+
 message HnswIndexOptionsPB {
   optional uint32 m = 1;
   optional uint32 m0 = 2;
   optional uint32 ef_construction = 3;
   optional HnswBackend backend = 4;
+
+  // Fixed at CREATE INDEX. Chunks record their own encoding, so this only governs chunks
+  // written from now on; keeping it in the catalog is what makes every replica of an index
+  // agree instead of following each tserver's local flags.
+  optional VectorStorageType storage_type = 5 [ default = STORAGE_FLOAT32 ];
 }
 
 message PgVectorIdxOptionsPB {

--- a/src/yb/docdb/doc_vector_index.cc
+++ b/src/yb/docdb/doc_vector_index.cc
@@ -100,6 +100,16 @@ vector_index::DistanceKind ConvertDistanceKind(PgVectorDistanceType dist_type) {
   FATAL_INVALID_ENUM_VALUE(PgVectorDistanceType, dist_type);
 }
 
+vector_index::VectorStorageKind ConvertStorageKind(VectorStorageType storage_type) {
+  switch (storage_type) {
+    case VectorStorageType::STORAGE_FLOAT32:
+      return vector_index::VectorStorageKind::kFloat32;
+    case VectorStorageType::STORAGE_FLOAT16:
+      return vector_index::VectorStorageKind::kFloat16;
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageType, storage_type);
+}
+
 vector_index::HNSWOptions ConvertToHnswOptions(const PgVectorIdxOptionsPB& options) {
   return {
     .dimensions = options.dimensions(),
@@ -107,6 +117,7 @@ vector_index::HNSWOptions ConvertToHnswOptions(const PgVectorIdxOptionsPB& optio
     .num_neighbors_per_vertex_base = options.hnsw().m0(),
     .ef_construction = options.hnsw().ef_construction(),
     .distance_kind = ConvertDistanceKind(options.dist_type()),
+    .storage_kind = ConvertStorageKind(options.hnsw().storage_type()),
   };
 }
 

--- a/src/yb/hnsw/hnsw-test.cc
+++ b/src/yb/hnsw/hnsw-test.cc
@@ -11,12 +11,20 @@
 // under the License.
 //
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <set>
+
 #include "yb/hnsw/hnsw.h"
 #include "yb/hnsw/hnsw_block_cache.h"
 #include "yb/hnsw/vector_index_test_base.h"
 
 #include "yb/rocksdb/cache.h"
 
+#include "yb/util/env.h"
+#include "yb/util/flags.h"
 #include "yb/util/metrics.h"
 #include "yb/util/random_util.h"
 #include "yb/util/size_literals.h"
@@ -25,13 +33,17 @@
 #include "yb/util/tsan_util.h"
 
 #include "yb/vector_index/vector_index_fwd.h"
+#include "yb/vector_index/coordinate_codec.h"
 #include "yb/vector_index/distance.h"
+#include "yb/vector_index/hnsw_options.h"
 #include "yb/vector_index/usearch_include_wrapper_internal.h"
 #include "yb/vector_index/vector_index_if.h"
 #include "yb/vector_index/vector_payload_map.h"
 
 using namespace std::chrono_literals;
 using namespace yb::size_literals;
+
+DECLARE_bool(yb_hnsw_prefetch_neighbors);
 
 METRIC_DEFINE_entity(table);
 
@@ -216,6 +228,333 @@ TEST_F(YbHnswTest, Cache) {
 
 TEST_F(YbHnswTest, ConcurrentCache) {
   TestRandom(true, 4);
+}
+
+// Batching neighbour resolution must be an optimisation only: same results, and no block the
+// serial loop would not have taken. Resolving an address before the visited filter would Take()
+// blocks the search does not need, showing up as a higher cache_query delta. The deltas also pin
+// down SearchCache::Release's batched counters: one query, and on a resident index one hit, per
+// block.
+TEST_F(YbHnswTest, PrefetchMatchesSerialResolution) {
+  constexpr size_t kNumVectors = 4096;
+  constexpr size_t kNumSearches = 32;
+  constexpr size_t kMaxResults = 20;
+
+  google::FlagSaver flag_saver;
+
+  auto query_vectors = PrepareRandom(/* load= */ true, kNumVectors, kNumSearches);
+  auto options = MakeSearchOptions(kMaxResults);
+  const auto& query_counter = *block_cache_->metrics().query;
+  const auto& hit_counter = *block_cache_->metrics().hit;
+
+  for (const auto& query_vector : query_vectors) {
+    // Warm up so both measured searches find every block resident and their deltas compare.
+    yb_hnsw_->Search(query_vector.data(), options, context_);
+
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_yb_hnsw_prefetch_neighbors) = false;
+    auto queries_before = query_counter.value();
+    auto hits_before = hit_counter.value();
+    auto expected = yb_hnsw_->Search(query_vector.data(), options, context_);
+    auto serial_takes = query_counter.value() - queries_before;
+    ASSERT_GT(serial_takes, 0);
+    ASSERT_EQ(hit_counter.value() - hits_before, serial_takes);
+
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_yb_hnsw_prefetch_neighbors) = true;
+    queries_before = query_counter.value();
+    hits_before = hit_counter.value();
+    auto actual = yb_hnsw_->Search(query_vector.data(), options, context_);
+    ASSERT_EQ(query_counter.value() - queries_before, serial_takes);
+    ASSERT_EQ(hit_counter.value() - hits_before, serial_takes);
+    ASSERT_EQ(AsString(expected), AsString(actual));
+  }
+}
+
+// ------------------------------------------------------------------------------------------------
+// Narrowed coordinate storage
+// ------------------------------------------------------------------------------------------------
+
+using vector_index::VectorStorageKind;
+
+namespace {
+
+// MakeFooter writes the version byte first; the footer's length is the file's last 8 bytes.
+Result<uint8_t> ReadFooterVersion(Env& env, const std::string& path) {
+  std::unique_ptr<RandomAccessFile> file;
+  RETURN_NOT_OK(env.NewRandomAccessFile(path, &file));
+  auto file_size = VERIFY_RESULT(file->Size());
+
+  std::array<uint8_t, sizeof(uint64_t)> size_buffer;
+  Slice size_slice;
+  RETURN_NOT_OK(file->Read(
+      file_size - size_buffer.size(), size_buffer.size(), &size_slice, size_buffer.data()));
+  auto footer_size = LittleEndian::Load64(size_slice.data());
+
+  uint8_t version = 0;
+  Slice version_slice;
+  RETURN_NOT_OK(file->Read(file_size - footer_size, 1, &version_slice, &version));
+  return version;
+}
+
+size_t CountCommon(const YbHnsw::SearchResult& lhs, const YbHnsw::SearchResult& rhs) {
+  std::set<vector_index::VectorId> ids;
+  for (const auto& entry : lhs) {
+    ids.insert(entry.vector_id);
+  }
+  size_t result = 0;
+  for (const auto& entry : rhs) {
+    result += ids.contains(entry.vector_id);
+  }
+  return result;
+}
+
+}  // namespace
+
+// The hnswlib -> YbHnsw import path is the one narrowed storage is wired through.
+class YbHnswStorageTest : public VectorIndexTestBase {
+ protected:
+  using HnswlibImpl = HnswlibIndex<YbHnsw::DistanceType>;
+
+  void BuildHnswlibIndex(size_t num_vectors) {
+    space_ = std::make_unique<hnswlib::L2Space>(dimensions_);
+    hnswlib_index_ = std::make_unique<HnswlibImpl>(
+        space_.get(), num_vectors, /* M= */ 16, /* ef_construction= */ 100);
+    vectors_.reserve(num_vectors);
+    ids_.reserve(num_vectors);
+    for (size_t i = 0; i != num_vectors; ++i) {
+      vectors_.push_back(RandomVector());
+      ids_.push_back(vector_index::VectorId::GenerateRandom());
+      hnswlib_index_->addPoint(vectors_.back().data(), ids_.back());
+    }
+  }
+
+  const Vector& VectorForId(const vector_index::VectorId& id) const {
+    auto it = std::find(ids_.begin(), ids_.end(), id);
+    CHECK(it != ids_.end()) << "unknown vector id: " << id;
+    return vectors_[it - ids_.begin()];
+  }
+
+  // What MakeResult computes: the float16 metric over float16 copies of both sides.
+  YbHnsw::DistanceType Float16Distance(const Vector& lhs, const Vector& rhs) const {
+    vector_index::HNSWOptions options;
+    options.dimensions = dimensions_;
+    options.distance_kind = vector_index::DistanceKind::kL2Squared;
+    UsearchMetric metric(
+        options.CreateStoredMetric(dimensions_, VectorStorageKind::kFloat16));
+    const auto bytes = vector_index::CoordinateBytes(VectorStorageKind::kFloat16, dimensions_);
+    std::vector<std::byte> buffer(bytes * 2);
+    vector_index::NarrowCoordinates(
+        VectorStorageKind::kFloat16, lhs.data(), dimensions_, buffer.data());
+    vector_index::NarrowCoordinates(
+        VectorStorageKind::kFloat16, rhs.data(), dimensions_, buffer.data() + bytes);
+    return metric.Distance(buffer.data(), buffer.data() + bytes);
+  }
+
+  // The production metric factory path, so a wrong storage-kind-to-scalar-kind mapping shows here.
+  YbHnsw::MetricFactory MakeMetricFactory() const {
+    vector_index::HNSWOptions options;
+    options.dimensions = dimensions_;
+    options.distance_kind = vector_index::DistanceKind::kL2Squared;
+    return [options](size_t dimensions, VectorStorageKind storage_kind) {
+      return std::make_unique<UsearchMetric>(
+          options.CreateStoredMetric(dimensions, storage_kind));
+    };
+  }
+
+  // With `reload`, the returned instance only ever saw the file -- i.e. a tserver restart.
+  Result<std::unique_ptr<YbHnsw>> Import(
+      VectorStorageKind storage_kind, const std::string& name, bool reload = false) {
+    auto path = GetTestPath(name);
+    auto result = std::make_unique<YbHnsw>(MakeMetricFactory(), block_cache_);
+    // No payloads: keeps the 16-byte aux entry per vector this fixture's expectations assume.
+    RETURN_NOT_OK(result->Import(
+        *hnswlib_index_, path, /* payloads= */ nullptr, storage_kind));
+    if (reload) {
+      result = std::make_unique<YbHnsw>(MakeMetricFactory(), block_cache_);
+      RETURN_NOT_OK(result->Init(path));
+    }
+    return result;
+  }
+
+  vector_index::SearchOptions MakeSearchOptions(size_t max_results, size_t ef = 64) const {
+    return vector_index::SearchOptions {
+      .max_num_results = max_results,
+      .ef = ef,
+      .filter = AcceptAllVectors(),
+    };
+  }
+
+  std::unique_ptr<hnswlib::SpaceInterface<YbHnsw::DistanceType>> space_;
+  std::unique_ptr<HnswlibImpl> hnswlib_index_;
+  std::vector<Vector> vectors_;
+  std::vector<vector_index::VectorId> ids_;
+  YbHnswSearchContext context_;
+};
+
+// float32 must keep producing byte-identical version-1 footers, or existing deployments' files
+// stop being readable by the previous release.
+TEST_F(YbHnswStorageTest, Float32KeepsFooterVersionOne) {
+  BuildHnswlibIndex(200);
+
+  ASSERT_OK(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  ASSERT_EQ(ASSERT_RESULT(ReadFooterVersion(*Env::Default(), GetTestPath("f32.yb_hnsw"))), 1);
+
+  ASSERT_OK(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+  ASSERT_EQ(ASSERT_RESULT(ReadFooterVersion(*Env::Default(), GetTestPath("f16.yb_hnsw"))), 2);
+
+}
+
+TEST_F(YbHnswStorageTest, HeaderReflectsStorageKind) {
+  // Enough vectors that neither encoding fits one block: InitVectorDataAmountPerBlock derives
+  // records-per-block from the count and only then clamps, so a one-block index makes the
+  // records-per-block assertion below vacuous.
+  BuildHnswlibIndex(5000);
+
+  auto f32 = ASSERT_RESULT(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  auto f16 = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+
+  ASSERT_EQ(f32->header().storage_kind, VectorStorageKind::kFloat32);
+  ASSERT_EQ(f16->header().storage_kind, VectorStorageKind::kFloat16);
+  ASSERT_EQ(f32->header().dimensions, dimensions_);
+  ASSERT_EQ(f16->header().dimensions, dimensions_);
+
+  // Only the coordinates shrink; the record header does not.
+  const auto record_overhead = f32->header().vector_data_size - dimensions_ * sizeof(float);
+  ASSERT_EQ(f16->header().vector_data_size, record_overhead + dimensions_ * sizeof(uint16_t));
+
+  // Not twice as many at 8 dimensions: only the coordinates halve, and the header is a large
+  // share of the record.
+  ASSERT_GT(f16->header().vector_data_amount_per_block,
+            f32->header().vector_data_amount_per_block);
+
+  // Both still clamped to a block, which is what makes the comparison above meaningful.
+  ASSERT_LE(
+      f32->header().vector_data_amount_per_block * f32->header().vector_data_size,
+      f32->header().max_block_size);
+  ASSERT_LE(
+      f16->header().vector_data_amount_per_block * f16->header().vector_data_size,
+      f16->header().max_block_size);
+}
+
+// The encoding must come from the file, not from caller configuration: a stale setting is
+// otherwise undetectable, decoding records at the wrong width into plausible-looking garbage.
+TEST_F(YbHnswStorageTest, InitTakesStorageKindFromTheFile) {
+  BuildHnswlibIndex(200);
+  ASSERT_OK(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+
+  YbHnsw reopened(MakeMetricFactory(), block_cache_);
+  ASSERT_OK(reopened.Init(GetTestPath("f16.yb_hnsw")));
+  ASSERT_EQ(reopened.header().storage_kind, VectorStorageKind::kFloat16);
+
+  // And it still answers correctly, i.e. the metric it built matches the records.
+  auto results = reopened.Search(
+      vectors_.front().data(), MakeSearchOptions(1, /* ef= */ 200), context_);
+  ASSERT_EQ(results.size(), 1);
+  ASSERT_EQ(results.front().distance, 0.0f);
+}
+
+// Writer and query path share one conversion, so a vector used as its own query must come back
+// at distance zero. First thing to break if they diverge.
+TEST_F(YbHnswStorageTest, SelfDistanceIsZero) {
+  BuildHnswlibIndex(500);
+
+  for (auto storage_kind : {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16}) {
+    auto index = ASSERT_RESULT(Import(storage_kind, Format("$0.yb_hnsw", storage_kind)));
+    for (size_t i = 0; i != 20; ++i) {
+      const auto& query = vectors_[i * (vectors_.size() / 20)];
+      // A generous ef makes finding the exact match certain, so a failure is the codec.
+      auto results = index->Search(query.data(), MakeSearchOptions(1, /* ef= */ 200), context_);
+      ASSERT_EQ(results.size(), 1) << storage_kind;
+      ASSERT_EQ(results.front().distance, 0.0f)
+          << "storage_kind: " << storage_kind << ", vector: " << i;
+    }
+  }
+}
+
+// Pins what narrowing costs. Loose threshold: uniform random low-dimension vectors reorder more
+// easily than real embeddings, their neighbours sitting at nearly identical distances.
+TEST_F(YbHnswStorageTest, Float16KeepsRecall) {
+  constexpr size_t kNumVectors = 4000;
+  constexpr size_t kNumQueries = 200;
+  constexpr size_t kMaxResults = 10;
+  constexpr double kMinOverlap = 0.9;
+
+  dimensions_ = 64;
+  BuildHnswlibIndex(kNumVectors);
+
+  auto f32 = ASSERT_RESULT(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  auto f16 = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+
+  size_t common = 0;
+  double worst_distance_error = 0;
+  for (size_t i = 0; i != kNumQueries; ++i) {
+    auto query = RandomVector();
+    auto f32_results = f32->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    auto f16_results = f16->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    ASSERT_EQ(f32_results.size(), f16_results.size());
+    common += CountCommon(f32_results, f16_results);
+
+    // Top-1 distances should agree closely even when the identities differ.
+    worst_distance_error = std::max<double>(
+        worst_distance_error,
+        std::fabs(f32_results.front().distance - f16_results.front().distance) /
+            std::max(f32_results.front().distance, 1e-6f));
+  }
+
+  const double overlap = static_cast<double>(common) / (kNumQueries * kMaxResults);
+  LOG(INFO) << "float16 top-" << kMaxResults << " overlap with float32: " << overlap
+            << ", worst relative top-1 distance error: " << worst_distance_error;
+  ASSERT_GE(overlap, kMinOverlap);
+  ASSERT_LE(worst_distance_error, 0.05);
+}
+
+// Compaction re-reads served files, so a reopened index must survive the same searches.
+TEST_F(YbHnswStorageTest, Float16SurvivesReload) {
+  constexpr size_t kMaxResults = 10;
+  dimensions_ = 32;
+  BuildHnswlibIndex(2000);
+
+  auto fresh = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "a.yb_hnsw"));
+  auto reloaded = ASSERT_RESULT(
+      Import(VectorStorageKind::kFloat16, "b.yb_hnsw", /* reload= */ true));
+
+  for (size_t i = 0; i != 100; ++i) {
+    auto query = RandomVector();
+    auto from_fresh = fresh->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    auto from_reloaded = reloaded->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    ASSERT_EQ(from_fresh.size(), from_reloaded.size());
+    for (size_t j = 0; j != from_fresh.size(); ++j) {
+      ASSERT_EQ(AsString(from_fresh[j]), AsString(from_reloaded[j]));
+    }
+  }
+}
+
+// One inf coordinate makes every distance to that vector NaN, and NaN comparisons quietly
+// corrupt the search heaps.
+TEST_F(YbHnswStorageTest, OutOfRangeCoordinatesStayFinite) {
+  dimensions_ = 8;
+  space_ = std::make_unique<hnswlib::L2Space>(dimensions_);
+  hnswlib_index_ = std::make_unique<HnswlibImpl>(
+      space_.get(), 64, /* M= */ 16, /* ef_construction= */ 100);
+
+  for (size_t i = 0; i != 32; ++i) {
+    auto vector = RandomVector();
+    if (i % 8 == 0) {
+      // Outside fp16 but inside float32, so the graph is still built from finite distances.
+      vector[i % dimensions_] = 1e6f;
+      vector[(i + 1) % dimensions_] = -1e6f;
+    }
+    vectors_.push_back(vector);
+    hnswlib_index_->addPoint(vector.data(), vector_index::VectorId::GenerateRandom());
+  }
+
+  auto index = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "clamped.yb_hnsw"));
+  for (size_t i = 0; i != 16; ++i) {
+    auto results = index->Search(RandomVector().data(), MakeSearchOptions(10), context_);
+    ASSERT_FALSE(results.empty());
+    for (const auto& entry : results) {
+      ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+    }
+  }
 }
 
 }  // namespace yb::hnsw

--- a/src/yb/hnsw/hnsw.cc
+++ b/src/yb/hnsw/hnsw.cc
@@ -13,6 +13,10 @@
 
 #include "yb/hnsw/hnsw.h"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 #include "usearch/index.hpp"
 
 #include "yb/hnsw/block_writer.h"
@@ -20,11 +24,15 @@
 
 #include "yb/util/cast.h"
 #include "yb/util/env.h"
+#include "yb/util/flag_validators.h"
 #include "yb/util/flags.h"
+#include "yb/util/metrics.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/size_literals.h"
+#include "yb/util/status_format.h"
 #include "yb/util/status_log.h"
 
+#include "yb/vector_index/coordinate_codec.h"
 #include "yb/vector_index/vector_index_if.h"
 #include "yb/vector_index/vector_payload_map.h"
 
@@ -35,6 +43,13 @@ DEFINE_RUNTIME_uint64(yb_hnsw_max_block_size, 64_KB,
 
 DEFINE_RUNTIME_bool(yb_hnsw_keep_new_blocks_in_cache, false,
     "Whether to keep new generated blocks in cache after YbHnsw index is built.");
+
+DEFINE_RUNTIME_bool(yb_hnsw_prefetch_neighbors, true,
+    "Whether a base layer search resolves and prefetches the record addresses of a node's "
+    "unvisited neighbours as a batch before computing any of their distances. Both settings "
+    "visit the same vectors and return the same results; batching only overlaps the cache "
+    "misses. Turn it off on an index small enough to sit in cache, where the prefetches are "
+    "pure overhead.");
 
 #define YB_MISALIGNED_STORE(ptr, type, field, value) \
   MisalignedAssign<decltype(type::field)>(ptr, offsetof(type, field), value)
@@ -69,6 +84,8 @@ class YbHnswIndexAdapter {
 
   virtual int16_t NodeLevel(size_t index) = 0;
   virtual vector_index::VectorId NodeKey(size_t index) = 0;
+  // Writes this node's coordinates into `out` in the encoding MakeHeader() declared. Must fill
+  // exactly vector_data_size - sizeof(VectorData) bytes.
   virtual void NodeCoordinates(size_t index, void* out) = 0;
   virtual NeighborsType Neighbors(size_t index, size_t level) = 0;
   virtual NeighborsType NeighborsBase(size_t index) = 0;
@@ -83,6 +100,9 @@ class YbHnswIndexAdapter {
     return payloads_->Get(index);
   }
 
+  // Coordinates NodeCoordinates() had to clamp. Zero for adapters that do not narrow.
+  virtual size_t NumClampedCoordinates() const { return 0; }
+
   virtual ~YbHnswIndexAdapter() = default;
 
  private:
@@ -90,6 +110,28 @@ class YbHnswIndexAdapter {
 };
 
 namespace {
+
+size_t RecordCoordinateBytes(const Header& header) {
+  return vector_index::CoordinateBytes(header.storage_kind, header.dimensions);
+}
+
+// Checks a header parsed from a file against itself, before anything reads a record through it.
+// A vector_data_size disagreeing with the encoding is otherwise silent: it reads past every
+// record into the next.
+Status ValidateHeader(const Header& header) {
+  // Range-checked before anything switches on it: CoordinateBytes ends in
+  // FATAL_INVALID_ENUM_VALUE, so a single corrupt footer byte would abort the process instead of
+  // failing this one file. The enum is contiguous from zero.
+  SCHECK_LT(
+      static_cast<size_t>(std::to_underlying(header.storage_kind)),
+      vector_index::kElementsInVectorStorageKind, Corruption,
+      Format("YbHnsw chunk has an unknown storage kind: $0", header));
+
+  SCHECK_EQ(
+      header.vector_data_size, sizeof(YbHnswVectorData) + RecordCoordinateBytes(header),
+      Corruption, Format("YbHnsw record size disagrees with its encoding: $0", header));
+  return Status::OK();
+}
 
 using VectorData = YbHnswVectorData;
 
@@ -135,6 +177,9 @@ class YbHnswBuilder {
 
   Result<std::pair<FileBlockCachePtr, Header>> Build() {
     header_ = inspector_.MakeHeader();
+    // ValidateHeader()'s invariant, on write: a mismatch means the adapter's MakeHeader and
+    // NodeCoordinates disagree about the record layout, producing an unreadable file.
+    DCHECK_EQ(header_.vector_data_size, sizeof(VectorData) + RecordCoordinateBytes(header_));
     PrepareVectors();
     VLOG_WITH_FUNC(4) << "Size: " << inspector_.Size() << ", header: " << header_.ToString();
 
@@ -149,6 +194,10 @@ class YbHnswBuilder {
     RETURN_NOT_OK(out_->Close());
     out_.reset();
     RETURN_NOT_OK(block_cache_.env().RenameFile(tmp_path, path_));
+    LOG_IF(WARNING, inspector_.NumClampedCoordinates() != 0)
+        << "YbHnsw " << path_ << ": clamped " << inspector_.NumClampedCoordinates()
+        << " coordinate(s) that this chunk's encoding cannot represent (storage_kind: "
+        << header_.storage_kind << "); searches involving those vectors will be less accurate";
     std::unique_ptr<RandomAccessFile> file;
     RETURN_NOT_OK(block_cache_.env().NewRandomAccessFile(path_, &file));
     auto file_block_cache = std::make_unique<FileBlockCache>(
@@ -474,11 +523,25 @@ SearchCacheScope::SearchCacheScope(SearchCache& cache, const YbHnsw& hnsw) : cac
   cache.Bind(hnsw.header_, *hnsw.file_block_cache_);
 }
 
-YbHnsw::YbHnsw(MetricPtr&& metric, BlockCachePtr block_cache)
-    : metric_(std::move(metric)), block_cache_(std::move(block_cache)) {
+YbHnsw::YbHnsw(const UsearchMetric::Impl& metric, BlockCachePtr block_cache)
+    : YbHnsw(
+          [metric](size_t, vector_index::VectorStorageKind storage_kind) -> MetricPtr {
+            LOG_IF(DFATAL, storage_kind != vector_index::VectorStorageKind::kFloat32)
+                << "Fixed float32 metric cannot decode " << storage_kind << " records";
+            return std::make_unique<UsearchMetric>(metric);
+          },
+          std::move(block_cache)) {
+}
+
+YbHnsw::YbHnsw(MetricFactory metric_factory, BlockCachePtr block_cache)
+    : metric_factory_(std::move(metric_factory)), block_cache_(std::move(block_cache)) {
 }
 
 YbHnsw::~YbHnsw() = default;
+
+void YbHnsw::InitMetrics() {
+  metric_ = metric_factory_(header_.dimensions, header_.storage_kind);
+}
 
 Status YbHnsw::Import(
     const unum::usearch::index_dense_gt<vector_index::VectorId>& index, const std::string& path,
@@ -486,6 +549,7 @@ Status YbHnsw::Import(
   YbHnswUsearchIndexAdapter inspector(index, payloads);
   YbHnswBuilder builder(inspector, *block_cache_, path);
   std::tie(file_block_cache_, header_) = VERIFY_RESULT(builder.Build());
+  InitMetrics();
   return Status::OK();
 }
 
@@ -493,8 +557,10 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
  public:
   YbHnswHnswlibIndexAdapter(
       std::reference_wrapper<const HnswlibIndex<YbHnsw::DistanceType>> index,
-      const vector_index::VectorPayloadMap* payloads)
-      : YbHnswIndexAdapter(payloads), index_(index) {}
+      const vector_index::VectorPayloadMap* payloads,
+      vector_index::VectorStorageKind storage_kind)
+      : YbHnswIndexAdapter(payloads), index_(index), storage_kind_(storage_kind),
+        dimensions_(index.get().data_size_ / sizeof(YbHnswBuilder::CoordinateType)) {}
 
   size_t Size() override {
     return index_.getCurrentElementCount();
@@ -507,8 +573,10 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
   Header MakeHeader() override {
     Header result;
     result.max_block_size = FLAGS_yb_hnsw_max_block_size;
-    result.dimensions = index_.data_size_ / sizeof(YbHnswBuilder::CoordinateType);
-    result.vector_data_size = index_.data_size_ + sizeof(VectorData);
+    result.dimensions = dimensions_;
+    result.storage_kind = storage_kind_;
+    result.vector_data_size =
+        vector_index::CoordinateBytes(storage_kind_, dimensions_) + sizeof(VectorData);
     InitVectorDataAmountPerBlock(result, index_.getCurrentElementCount());
     result.max_level = index_.getMaxLevel();
     result.config.connectivity_base = index_.maxM_;
@@ -529,7 +597,19 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
   }
 
   void NodeCoordinates(size_t index, void* out) override {
-    memcpy(out, index_.getDataByInternalId(CastIndex(index)), index_.data_size_);
+    const auto* coordinates =
+        pointer_cast<const YbHnswBuilder::CoordinateType*>(
+            index_.getDataByInternalId(CastIndex(index)));
+    if (storage_kind_ == vector_index::VectorStorageKind::kFloat32) {
+      memcpy(out, coordinates, index_.data_size_);
+    } else {
+      vector_index::NarrowCoordinates(
+          storage_kind_, coordinates, dimensions_, out, &num_clamped_);
+    }
+  }
+
+  size_t NumClampedCoordinates() const override {
+    return num_clamped_;
   }
 
   NeighborsType Neighbors(size_t index, size_t level) override {
@@ -553,15 +633,20 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
   }
 
   const HnswlibIndex<YbHnsw::DistanceType>& index_;
+  const vector_index::VectorStorageKind storage_kind_;
+  const size_t dimensions_;
+  size_t num_clamped_ = 0;
 };
 
 Status YbHnsw::Import(
     const HnswlibIndex<DistanceType>& index,
     const std::string& path,
-    const vector_index::VectorPayloadMap* payloads) {
-  YbHnswHnswlibIndexAdapter inspector(index, payloads);
+    const vector_index::VectorPayloadMap* payloads,
+    vector_index::VectorStorageKind storage_kind) {
+  YbHnswHnswlibIndexAdapter inspector(index, payloads, storage_kind);
   YbHnswBuilder builder(inspector, *block_cache_, path);
   std::tie(file_block_cache_, header_) = VERIFY_RESULT(builder.Build());
+  InitMetrics();
   return Status::OK();
 }
 
@@ -570,6 +655,8 @@ Status YbHnsw::Init(const std::string& path) {
   RETURN_NOT_OK(block_cache_->env().NewRandomAccessFile(path, &file));
   file_block_cache_ = std::make_unique<FileBlockCache>(*block_cache_, std::move(file));
   header_ = VERIFY_RESULT(file_block_cache_->Load());
+  RETURN_NOT_OK(ValidateHeader(header_));
+  InitMetrics();
   return Status::OK();
 }
 
@@ -583,6 +670,19 @@ YbHnsw::SearchResult YbHnsw::Search(
       query_vector, context.search_cache);
   SearchInBaseLayer(query_vector, best_vector, best_dist, options, context);
   return MakeResult(options.max_num_results, context);
+}
+
+YbHnsw::SearchResult YbHnsw::Search(
+    const CoordinateType* query_vector, const vector_index::SearchOptions& options,
+    YbHnswSearchContext& context) const {
+  if (header_.storage_kind == vector_index::VectorStorageKind::kFloat32) {
+    return Search(pointer_cast<const std::byte*>(query_vector), options, context);
+  }
+  auto& buffer = context.narrowed_query;
+  buffer.resize(vector_index::CoordinateBytes(header_.storage_kind, header_.dimensions));
+  vector_index::NarrowCoordinates(
+      header_.storage_kind, query_vector, header_.dimensions, buffer.data());
+  return Search(buffer.data(), options, context);
 }
 
 YbHnsw::SearchResult YbHnsw::MakeResult(size_t max_results, YbHnswSearchContext& context) const {
@@ -659,11 +759,10 @@ void YbHnsw::SearchInBaseLayer(
     auto neighbors = cache.GetNeighborsInBaseLayer(vector);
     visited.reserve(visited.size() + std::ranges::size(neighbors));
 
-    for (auto neighbor : neighbors) {
-      if (visited.set(neighbor)) {
-        continue;
-      }
-      auto neighbor_dist = Distance(query_vector, neighbor, cache);
+    // Distance and heap update for one unvisited neighbour. Both loop shapes below invoke this
+    // in neighbour order, so best_dist evolves identically and the two produce the same results.
+    auto visit = [&](VectorNo neighbor, const std::byte* coordinates) {
+      auto neighbor_dist = Distance(query_vector, coordinates);
 
       if (top.size() < top_limit || extra_top.size() < extra_top_limit ||
           neighbor_dist < best_dist) {
@@ -687,28 +786,58 @@ void YbHnsw::SearchInBaseLayer(
           best_dist = extra_top.empty() ? top.top().first : extra_top.top();
         }
       }
+    };
+
+    if (!FLAGS_yb_hnsw_prefetch_neighbors) {
+      for (auto neighbor : neighbors) {
+        if (visited.set(neighbor)) {
+          continue;
+        }
+        visit(neighbor, cache.CoordinatesPtr(neighbor));
+      }
+      continue;
+    }
+
+    // A record's address is pure arithmetic on the neighbour id, but the CPU cannot speculate
+    // through blocks_[index] and then through the record itself, so both loads stall. Filtering
+    // and resolving the whole neighbour batch before computing any distance lets those misses
+    // overlap each other, and gives the prefetches the length of the batch's distance
+    // computations to land -- more slack than a one-ahead cursor, which matters for the short
+    // int8 kernel.
+    //
+    // The visited filter must stay first: resolving addresses for already-visited neighbours
+    // would Take() blocks the search does not need, inflating used_blocks_ and Release().
+    auto& unvisited = context.unvisited;
+    unvisited.clear();
+    for (auto it = neighbors.begin(), end = neighbors.end(); it != end; ++it) {
+      auto neighbor = *it;
+      if (visited.set(neighbor)) {
+        continue;
+      }
+      if (auto next_it = it + 1; next_it != end) {
+        cache.PrefetchVectorHeaderBlock(*next_it);
+      }
+      auto* coordinates = cache.CoordinatesPtr(neighbor);
+      __builtin_prefetch(coordinates);
+      unvisited.emplace_back(neighbor, coordinates);
+    }
+
+    // Resolved addresses stay valid across visit(): the search holds a reference on every block
+    // it took, which keeps CachedBlock::Unload from freeing the contents until Release().
+    for (auto [neighbor, coordinates] : unvisited) {
+      visit(neighbor, coordinates);
     }
   }
 }
 
 YbHnsw::DistanceType YbHnsw::Distance(const std::byte* lhs, const std::byte* rhs) const {
+  DCHECK(metric_) << "Distance requested before Init/Import";
   return metric_->Distance(lhs, rhs);
 }
 
 YbHnsw::DistanceType YbHnsw::Distance(
     const std::byte* lhs, size_t vector, SearchCache& cache) const {
   return Distance(lhs, cache.CoordinatesPtr(vector));
-}
-
-boost::iterator_range<MisalignedPtr<const YbHnsw::CoordinateType>> YbHnsw::MakeCoordinates(
-    const std::byte* ptr) const {
-  auto start = MisalignedPtr<const CoordinateType>(ptr);
-  return boost::make_iterator_range(start, start + header_.dimensions);
-}
-
-boost::iterator_range<MisalignedPtr<const YbHnsw::CoordinateType>> YbHnsw::Coordinates(
-    size_t vector, SearchCache& cache) const {
-  return MakeCoordinates(cache.CoordinatesPtr(vector));
 }
 
 const Header& YbHnsw::header() const {
@@ -720,7 +849,10 @@ const std::byte* SearchCache::Data(size_t index) {
   if (block) {
     return block;
   }
-  auto data = CHECK_RESULT(file_block_cache_->Take(index));
+  bool was_hit = false;
+  auto data = CHECK_RESULT(file_block_cache_->Take(index, &was_hit));
+  ++takes_;
+  hits_ += was_hit;
   used_blocks_.push_back(index);
   return block = data;
 }
@@ -733,6 +865,16 @@ void SearchCache::Bind(std::reference_wrapper<const Header> header, FileBlockCac
 }
 
 void SearchCache::Release() {
+  // One metrics update per search rather than one per block taken: a query touches roughly as
+  // many blocks as it visits vectors, and Take() is the only site that feeds these counters, so
+  // the totals are unchanged and only the update granularity is coarser.
+  if (takes_) {
+    auto& metrics = file_block_cache_->metrics();
+    metrics.query->IncrementBy(takes_);
+    metrics.hit->IncrementBy(hits_);
+    takes_ = 0;
+    hits_ = 0;
+  }
   for (auto block : used_blocks_) {
     blocks_[block] = nullptr;
     file_block_cache_->Release(block);
@@ -807,6 +949,11 @@ std::pair<vector_index::VectorId, Slice> SearchCache::GetVectorIdAndPayload(size
 
 const std::byte* SearchCache::CoordinatesPtr(size_t vector) {
   return VectorHeader(vector).raw() + offsetof(VectorData, coordinates);
+}
+
+void SearchCache::PrefetchVectorHeaderBlock(size_t vector) {
+  __builtin_prefetch(&blocks_[
+      header_->vector_data_block + vector / header_->vector_data_amount_per_block]);
 }
 
 HnswDistanceType UsearchMetric::Distance(

--- a/src/yb/hnsw/hnsw.h
+++ b/src/yb/hnsw/hnsw.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <functional>
 #include <queue>
 
 #include <boost/range/iterator_range.hpp>
@@ -59,6 +60,11 @@ class SearchCache {
   std::pair<vector_index::VectorId, Slice> GetVectorIdAndPayload(size_t vector);
   const std::byte* CoordinatesPtr(size_t vector);
 
+  // Prefetches the blocks_ slot that VectorHeader(vector) will load. The slot index is pure
+  // arithmetic on the vector id, so it can be issued ahead of time, while the data-dependent
+  // load of the slot itself is something the CPU cannot speculate through.
+  void PrefetchVectorHeaderBlock(size_t vector);
+
  private:
   Slice GetVectorDataSlice(size_t vector);
   const std::byte* BlockPtr(
@@ -68,6 +74,10 @@ class SearchCache {
   FileBlockCache* file_block_cache_ = nullptr;
   std::vector<const std::byte*> blocks_;
   std::vector<size_t> used_blocks_;
+
+  // Block cache query/hit counts for the current search, flushed to the metrics in Release().
+  size_t takes_ = 0;
+  size_t hits_ = 0;
 };
 
 class SearchCacheScope {
@@ -107,6 +117,15 @@ struct YbHnswSearchContext {
   ExtraTop extra_top;
   NextQueue next;
   SearchCache search_cache;
+
+  // Query narrowed to the file's storage encoding. Grown once per pooled context and reused;
+  // unused when the file stores float32.
+  std::vector<std::byte> narrowed_query;
+
+  // Neighbours of the current node that passed the visited filter, with their record addresses
+  // already resolved. Reused across calls; bounded by the neighbour count, i.e. by
+  // config.connectivity_base.
+  std::vector<std::pair<VectorNo, const std::byte*>> unvisited;
 };
 
 class YbHnswMetric {
@@ -135,11 +154,17 @@ class YbHnsw {
   using MetricPtr = std::unique_ptr<Metric>;
   using SearchResult = std::vector<vector_index::VectorWithDistance<DistanceType>>;
 
-  YbHnsw(const UsearchMetric::Impl& metric, BlockCachePtr block_cache)
-      : YbHnsw(std::make_unique<UsearchMetric>(metric), block_cache) {
-  }
+  // Builds the metric for a dimension count and coordinate encoding. The metric decodes stored
+  // records, so it must agree with how they were written: Init() passes the encoding from the
+  // file's own footer, never caller-supplied configuration, which can drift from what the chunk
+  // actually contains.
+  using MetricFactory =
+      std::function<MetricPtr(size_t dimensions, vector_index::VectorStorageKind storage_kind)>;
 
-  YbHnsw(MetricPtr&& metric, BlockCachePtr block_cache);
+  // Convenience constructor for a fixed float32 metric.
+  YbHnsw(const UsearchMetric::Impl& metric, BlockCachePtr block_cache);
+
+  YbHnsw(MetricFactory metric_factory, BlockCachePtr block_cache);
   ~YbHnsw();
 
   // Imports specified index to YbHnsw structure, also storing this structure to disk.
@@ -150,22 +175,25 @@ class YbHnsw {
     const vector_index::VectorPayloadMap* payloads);
   Status Import(
     const HnswlibIndex<DistanceType>& index, const std::string& path,
-    const vector_index::VectorPayloadMap* payloads);
+    const vector_index::VectorPayloadMap* payloads,
+    vector_index::VectorStorageKind storage_kind = vector_index::VectorStorageKind::kFloat32);
 
   // Initialize YbHnsw from specified file, using block_cache to cache blocks.
   Status Init(const std::string& path);
 
+  // Searches with a query already in this file's storage encoding.
   SearchResult Search(
       const std::byte* query_vector, const vector_index::SearchOptions& options,
       YbHnswSearchContext& context) const;
 
+  // Narrows the query through the same conversion the stored records went through, then
+  // delegates to the overload above.
   SearchResult Search(
       const CoordinateType* query_vector, const vector_index::SearchOptions& options,
-      YbHnswSearchContext& context) const {
-    return Search(
-        pointer_cast<const std::byte*>(query_vector), options, context);
-  }
+      YbHnswSearchContext& context) const;
 
+  // Distance between two records in this file's storage encoding. Full-precision callers must
+  // narrow first -- see NarrowCoordinates.
   DistanceType Distance(const std::byte* lhs, const std::byte* rhs) const;
 
   const Header& header() const;
@@ -181,13 +209,13 @@ class YbHnsw {
   SearchResult MakeResult(size_t max_results, YbHnswSearchContext& context) const;
 
   DistanceType Distance(const std::byte* lhs, size_t vector, SearchCache& cache) const;
-  boost::iterator_range<MisalignedPtr<const CoordinateType>> MakeCoordinates(
-      const std::byte* ptr) const;
-  boost::iterator_range<MisalignedPtr<const CoordinateType>> Coordinates(
-      size_t vector, SearchCache& cache) const;
 
-  MetricPtr metric_;
+  // Builds metric_ from header_, which must already be populated.
+  void InitMetrics();
+
+  const MetricFactory metric_factory_;
   const BlockCachePtr block_cache_;
+  MetricPtr metric_;
 
   Header header_;
   FileBlockCachePtr file_block_cache_;

--- a/src/yb/hnsw/hnsw_block_cache.cc
+++ b/src/yb/hnsw/hnsw_block_cache.cc
@@ -13,12 +13,16 @@
 
 #include "yb/hnsw/hnsw_block_cache.h"
 
+#include <cstring>
+#include <type_traits>
+
 #include <boost/intrusive/list.hpp>
 
 #include "yb/hnsw/block_writer.h"
 #include "yb/rocksdb/cache.h"
 
 #include "yb/util/crc.h"
+#include "yb/util/format.h"
 #include "yb/util/metrics.h"
 #include "yb/util/size_literals.h"
 #include "yb/util/unique_lock.h"
@@ -63,6 +67,21 @@ namespace yb::hnsw {
 
 namespace {
 
+// Version 1: original layout.
+// Version 2: appends Header::storage_kind.
+//
+// The writer picks the lowest version that can represent the header, so a float32 index still
+// produces a byte-identical version-1 file readable by binaries that predate narrowed storage.
+// A version-2 file is not, so float16 is a one-way step for the chunks written while it is on.
+constexpr uint8_t kSerializationVersionV1 = 1;
+constexpr uint8_t kSerializationVersionV2 = 2;
+constexpr uint8_t kMaxSupportedSerializationVersion = kSerializationVersionV2;
+
+uint8_t SerializationVersionFor(const Header& header) {
+  return header.storage_kind == vector_index::VectorStorageKind::kFloat32
+      ? kSerializationVersionV1 : kSerializationVersionV2;
+}
+
 template <class Type, class Value, class Writer>
 concept HasAppend = requires(Writer& writer) {
   writer.template Append<Type>(std::declval<Value>());
@@ -74,9 +93,17 @@ concept HasRead = requires(Reader& reader) {
 };
 
 template <class Type, class Value, class Writer>
-requires(HasAppend<Type, Value, Writer>)
+requires(!std::is_enum_v<Value> && HasAppend<Type, Value, Writer>)
 void ConvertField(const Value& value, Writer& writer) {
   writer.template Append<Type>(value);
+}
+
+// Scoped enums do not convert implicitly, so they need their own overloads to serialize as
+// their underlying integer.
+template <class Type, class Value, class Writer>
+requires(std::is_enum_v<Value> && HasAppend<Type, Type, Writer>)
+void ConvertField(const Value& value, Writer& writer) {
+  writer.template Append<Type>(static_cast<Type>(value));
 }
 
 template <class Converter, class Type>
@@ -100,9 +127,15 @@ void ConvertVector(size_t version, const Vector& vector, Writer& writer) {
 }
 
 template <class Type, class Value, class Reader>
-requires(HasRead<Type, Reader>)
+requires(!std::is_enum_v<Value> && HasRead<Type, Reader>)
 void ConvertField(Value& value, Reader& reader) {
   value = reader.template Read<Type>();
+}
+
+template <class Type, class Value, class Reader>
+requires(std::is_enum_v<Value> && HasRead<Type, Reader>)
+void ConvertField(Value& value, Reader& reader) {
+  value = static_cast<Value>(reader.template Read<Type>());
 }
 
 template <class Vector, class Reader>
@@ -133,6 +166,11 @@ void Convert(size_t version, RefForConverter<Converter, Header> header, Converte
   ConvertField<uint64_t>(header.vector_data_block, serializer);
   ConvertField<uint64_t>(header.vector_data_amount_per_block, serializer);
   ConvertVector(version, header.layers, serializer);
+  if (version >= kSerializationVersionV2) {
+    ConvertField<uint8_t>(header.storage_kind, serializer);
+  }
+  // Anything appended here must be consumed by this function: FileBlockCache::Load derives the
+  // block count from the bytes the header converter leaves behind.
 }
 
 class WriteCounter {
@@ -150,16 +188,14 @@ class WriteCounter {
   size_t value_ = 0;
 };
 
-constexpr size_t kSerializationVersion = 1;
-
 template <class Out, class... Args>
-void Serialize(const Out& out, Args&&... args) {
-  Convert(kSerializationVersion, out, std::forward<Args&&>(args)...);
+void Serialize(uint8_t version, const Out& out, Args&&... args) {
+  Convert(version, out, std::forward<Args&&>(args)...);
 }
 
-size_t SerializedSize(const Header& header) {
+size_t SerializedSize(uint8_t version, const Header& header) {
   WriteCounter counter;
-  Convert(kSerializationVersion, header, counter);
+  Convert(version, header, counter);
   return counter.value();
 }
 
@@ -197,7 +233,7 @@ BlockCacheMetrics::BlockCacheMetrics(const MetricEntityPtr& entity)
       evict(METRIC_vector_index_cache_evict.Instantiate(entity)),
       remove(METRIC_vector_index_cache_remove.Instantiate(entity)),
       read_us(METRIC_vector_index_cache_read_us.Instantiate(entity)),
-      take_wait_us(METRIC_vector_index_cache_read_us.Instantiate(entity)) {
+      take_wait_us(METRIC_vector_index_cache_take_wait_us.Instantiate(entity)) {
 }
 
 struct CachedBlock {
@@ -236,13 +272,21 @@ struct CachedBlock {
     }
   }
 
-  Result<const std::byte*> Take(RandomAccessFile& file) {
-    cache->metrics().query->Increment();
-
+  // The cache_query/cache_hit counters are not touched here: they are reported through was_hit
+  // and accumulated by the caller, because at thousands of Take() calls per search the
+  // increments themselves showed up on the hot path.
+  Result<const std::byte*> Take(RandomAccessFile& file, bool* was_hit) {
+    // Written before any early return: both miss paths below would otherwise leave it untouched,
+    // making the counters depend on the caller having pre-initialized it.
+    if (was_hit) {
+      *was_hit = false;
+    }
     UniqueLock lock(mutex);
     ++use_count;
     if (content.data) {
-      cache->metrics().hit->Increment();
+      if (was_hit) {
+        *was_hit = true;
+      }
       auto result = content.data.get();
       auto need_handle = !handle && use_count == 1;
       lock.unlock();
@@ -333,14 +377,15 @@ struct CachedBlock {
 };
 
 DataBlock FileBlockCacheBuilder::MakeFooter(const Header& header) const {
+  const auto version = SerializationVersionFor(header);
   DataBlock buffer(
     sizeof(uint8_t) +
-    SerializedSize(header) + sizeof(uint64_t) * blocks_.size() +
+    SerializedSize(version, header) + sizeof(uint64_t) * blocks_.size() +
     sizeof(uint32_t) + // CRC32
     sizeof(uint64_t)); // Size
   BlockWriter writer(buffer);
-  writer.Append<uint8_t>(kSerializationVersion);
-  Serialize(header, writer);
+  writer.Append<uint8_t>(version);
+  Serialize(version, header, writer);
   uint64_t sum = 0;
   for (const auto& block : blocks_) {
     sum += block.size;
@@ -409,7 +454,12 @@ Result<Header> FileBlockCache::Load() {
   RSTATUS_DCHECK_EQ(expected_crc, found_crc, Corruption, "Wrong footer CRC");
   Header header;
   SliceReader reader(footer_data);
-  size_t version = reader.Read<uint8_t>();
+  // Without this an unknown version is read and ignored, and the extra header fields it carries
+  // are consumed as block offsets.
+  auto version = reader.Read<uint8_t>();
+  SCHECK(
+      version >= kSerializationVersionV1 && version <= kMaxSupportedSerializationVersion,
+      Corruption, Format("Unsupported YbHnsw serialization version: $0", version));
   Deserialize(version, header, reader);
   AllocateBlocks(reader.Left() / sizeof(uint64_t));
   size_t prev_end = 0;
@@ -421,8 +471,12 @@ Result<Header> FileBlockCache::Load() {
   return header;
 }
 
-Result<const std::byte*> FileBlockCache::Take(size_t index) {
-  return blocks_[index].Take(*file_);
+Result<const std::byte*> FileBlockCache::Take(size_t index, bool* was_hit) {
+  return blocks_[index].Take(*file_, was_hit);
+}
+
+BlockCacheMetrics& FileBlockCache::metrics() const {
+  return block_cache_.metrics();
 }
 
 void FileBlockCache::Release(size_t index) {

--- a/src/yb/hnsw/hnsw_block_cache.h
+++ b/src/yb/hnsw/hnsw_block_cache.h
@@ -68,8 +68,15 @@ class FileBlockCache {
     return size_;
   }
 
-  Result<const std::byte*> Take(size_t index);
+  // Takes a reference on a block. When was_hit is non-null it is set to whether the block was
+  // already resident, so the caller can account the cache_query/cache_hit counters itself. The
+  // search path uses this to batch those counters once per search rather than once per block --
+  // see SearchCache::Data. A caller that passes nullptr must account them another way: the
+  // counters have no other update site.
+  Result<const std::byte*> Take(size_t index, bool* was_hit = nullptr);
   void Release(size_t index);
+
+  BlockCacheMetrics& metrics() const;
 
  private:
   void AllocateBlocks(size_t size);

--- a/src/yb/hnsw/types.h
+++ b/src/yb/hnsw/types.h
@@ -18,7 +18,9 @@
 #include "yb/util/logging.h"
 #include "yb/util/tostring.h"
 
+#include "yb/vector_index/coordinate_codec.h"
 #include "yb/vector_index/vector_index_fwd.h"
+#include "yb/vector_index/vector_storage_kind.h"
 
 namespace hnswlib {
 
@@ -80,10 +82,15 @@ struct Header {
   size_t vector_data_amount_per_block;
   std::vector<LayerInfo> layers;
 
+  // Coordinate encoding the graph traversal computes distances on, stored first in each vector
+  // data record. Absent from version-1 footers, which are always float32.
+  vector_index::VectorStorageKind storage_kind = vector_index::VectorStorageKind::kFloat32;
+
   std::string ToString() const {
     return YB_STRUCT_TO_STRING(
         dimensions, vector_data_size, entry, max_level, config, max_block_size,
-        max_vectors_per_non_base_block, vector_data_block, vector_data_amount_per_block, layers);
+        max_vectors_per_non_base_block, vector_data_block, vector_data_amount_per_block, layers,
+        storage_kind);
   }
 };
 

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -640,6 +640,22 @@ DEFINE_validator(vector_index_backend,
 TAG_FLAG(vector_index_backend, hidden);
 TAG_FLAG(vector_index_backend, advanced);
 
+static constexpr char kVectorStorageFloat32[] = "float32";
+static constexpr char kVectorStorageFloat16[] = "float16";
+
+DEFINE_RUNTIME_string(vector_index_storage_coordinate_type, kVectorStorageFloat32,
+    "Coordinate encoding for the on-disk chunks of newly created vector indexes. \"float32\" "
+    "stores full precision. \"float16\" halves the coordinate bytes of every served chunk, so "
+    "roughly twice as much of the index fits in the block cache, at a small recall cost. The "
+    "graph is built at full precision in either case. Recorded per index at creation time, so it "
+    "never changes for an existing index, and chunks written as anything other than float32 "
+    "cannot be read by releases that predate the encoding.");
+
+DEFINE_validator(vector_index_storage_coordinate_type,
+    FLAG_IN_SET_VALIDATOR(kVectorStorageFloat32, kVectorStorageFloat16));
+
+TAG_FLAG(vector_index_storage_coordinate_type, advanced);
+
 DEFINE_RUNTIME_AUTO_bool(enable_table_owned_vector_reverse_mapping, kExternal, false, true,
     "When true, newly created YSQL tables hold vector reverse mapping ownership. "
     "Such tables write vector reverse mappings on row insert/update regardless of "
@@ -4685,6 +4701,12 @@ Status CatalogManager::CreateTable(const CreateTableRequestPB* orig_req,
         vector_index_options.mutable_hnsw()->set_backend(HnswBackend::YB_HNSW_USEARCH);
       } else if (backend == kYbHnswHnswlib) {
         vector_index_options.mutable_hnsw()->set_backend(HnswBackend::YB_HNSW_HNSWLIB);
+      }
+      // Copied, not referenced: the flag is runtime-settable, so holding a reference to its
+      // std::string races with a concurrent set. The backend flag above is read the same way.
+      const auto storage_type = FLAGS_vector_index_storage_coordinate_type;
+      if (storage_type == kVectorStorageFloat16) {
+        vector_index_options.mutable_hnsw()->set_storage_type(VectorStorageType::STORAGE_FLOAT16);
       }
     } else if (!is_pg_table) {
       DCHECK_EQ(index_info.columns().size(), schema.num_columns())

--- a/src/yb/vector_index/CMakeLists.txt
+++ b/src/yb/vector_index/CMakeLists.txt
@@ -29,6 +29,7 @@ ADD_YB_LIBRARY(vector_index_proto
 set(VECTOR_INDEX_SRCS
   ann_validation.cc
   benchmark_data.cc
+  coordinate_codec.cc
   hnsw_options.cc
   hnsw_util.cc
   index_wrapper_base.cc
@@ -58,4 +59,5 @@ add_dependencies(
 set(YB_TEST_LINK_LIBS
     vector_index yb_common_test_util ${YB_MIN_TEST_LIBS})
 
+ADD_YB_TEST(coordinate_codec-test)
 ADD_YB_TEST(hnsw_util-test)

--- a/src/yb/vector_index/coordinate_codec-test.cc
+++ b/src/yb/vector_index/coordinate_codec-test.cc
@@ -1,0 +1,182 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include <cmath>
+#include <limits>
+#include <random>
+#include <vector>
+
+#include "yb/vector_index/coordinate_codec.h"
+
+#include "yb/util/logging.h"
+#include "yb/util/test_util.h"
+
+namespace yb::vector_index {
+
+namespace {
+
+std::vector<std::byte> Narrow(
+    VectorStorageKind kind, const std::vector<float>& in, size_t* clamped = nullptr) {
+  std::vector<std::byte> out(CoordinateBytes(kind, in.size()));
+  NarrowCoordinates(kind, in.data(), in.size(), out.data(), clamped);
+  return out;
+}
+
+std::vector<float> Widen(VectorStorageKind kind, const std::vector<std::byte>& in, size_t dims) {
+  std::vector<float> out(dims);
+  WidenCoordinates(kind, in.data(), dims, out.data());
+  return out;
+}
+
+std::vector<float> RandomVector(size_t dimensions) {
+  std::mt19937_64 rng(42);
+  std::uniform_real_distribution<float> dis(-1.0f, 1.0f);
+  std::vector<float> result(dimensions);
+  for (auto& value : result) {
+    value = dis(rng);
+  }
+  return result;
+}
+
+}  // namespace
+
+class CoordinateCodecTest : public YBTest {
+};
+
+TEST_F(CoordinateCodecTest, SizesMatchScalarWidths) {
+  for (size_t dims : {1, 8, 128, 384, 768, 1536}) {
+    ASSERT_EQ(CoordinateBytes(VectorStorageKind::kFloat32, dims), dims * 4);
+    ASSERT_EQ(CoordinateBytes(VectorStorageKind::kFloat16, dims), dims * 2);
+  }
+}
+
+TEST_F(CoordinateCodecTest, Float32IsIdentity) {
+  std::vector<float> in{-1.5f, 0.0f, 3.25f, 1e20f, -1e-20f};
+  auto widened = Widen(VectorStorageKind::kFloat32, Narrow(VectorStorageKind::kFloat32, in),
+                       in.size());
+  ASSERT_EQ(in, widened);
+}
+
+// Repeated compaction reads chunks back through WidenCoordinates and writes them out through
+// NarrowCoordinates again. If that were not idempotent, precision would drift a little on every
+// compaction until the index no longer resembled the vectors it was built from.
+TEST_F(CoordinateCodecTest, NarrowingIsIdempotent) {
+  constexpr size_t kDims = 4096;
+  std::vector<float> in(kDims);
+  for (size_t i = 0; i != kDims; ++i) {
+    // Sweep sign and eleven orders of magnitude, including the subnormal range.
+    in[i] = static_cast<float>(
+        std::sin(static_cast<double>(i) * 0.37) * std::pow(10.0, (i % 11) - 6));
+  }
+
+  auto once = Narrow(VectorStorageKind::kFloat16, in);
+  auto twice = Narrow(
+      VectorStorageKind::kFloat16, Widen(VectorStorageKind::kFloat16, once, kDims));
+  ASSERT_EQ(once, twice);
+}
+
+// The writer and the query path share this function precisely so that a vector is still at
+// distance zero from itself after narrowing.
+TEST_F(CoordinateCodecTest, SameInputNarrowsToSameBytes) {
+  auto in = RandomVector(1536);
+  ASSERT_EQ(Narrow(VectorStorageKind::kFloat16, in), Narrow(VectorStorageKind::kFloat16, in));
+}
+
+// Two separate bounds, because only the first one is a relative bound. Coordinates below fp16's
+// smallest normal lose relative precision entirely, but their absolute error stays tiny, which
+// is all a squared distance is sensitive to.
+TEST_F(CoordinateCodecTest, Float16ErrorBounds) {
+  constexpr size_t kSamples = 20000;
+  constexpr float kRelativeBound = 4.883e-4f;  // 2^-11
+  constexpr float kAbsoluteBound = 3e-8f;
+  constexpr float kMinNormal = 6.103515625e-05f;  // fp16's smallest normal, the sweep boundary
+
+  double worst_relative = 0;
+  for (size_t i = 0; i <= kSamples; ++i) {
+    const float value = static_cast<float>(
+        kMinNormal * std::pow(6.5e4 / kMinNormal,
+                                     static_cast<double>(i) / kSamples));
+    const auto back = Widen(
+        VectorStorageKind::kFloat16, Narrow(VectorStorageKind::kFloat16, {value}), 1)[0];
+    worst_relative = std::max<double>(worst_relative, std::fabs((back - value) / value));
+  }
+  ASSERT_LE(worst_relative, kRelativeBound) << "relative error over fp16 normals";
+
+  double worst_absolute = 0;
+  for (size_t i = 0; i <= kSamples; ++i) {
+    const float value = static_cast<float>(
+        1e-10 * std::pow(kMinNormal / 1e-10, static_cast<double>(i) / kSamples));
+    const auto back = Widen(
+        VectorStorageKind::kFloat16, Narrow(VectorStorageKind::kFloat16, {value}), 1)[0];
+    worst_absolute = std::max<double>(worst_absolute, std::fabs(back - value));
+  }
+  ASSERT_LE(worst_absolute, kAbsoluteBound) << "absolute error below fp16's smallest normal";
+}
+
+// Without clamping, fp16_ieee_from_fp32_value saturates to infinity, and inf - inf makes every
+// distance to the vector NaN -- which corrupts the ordering of the search heaps silently rather
+// than failing. Same for a NaN coordinate arriving from the table.
+TEST_F(CoordinateCodecTest, ClampsValuesOutsideFloat16Range) {
+  const std::vector<float> in{1e30f, -1e30f, std::numeric_limits<float>::quiet_NaN(),
+                              kMaxFloat16, 65520.0f, 1.0f};
+  size_t clamped = 0;
+  auto back = Widen(
+      VectorStorageKind::kFloat16, Narrow(VectorStorageKind::kFloat16, in, &clamped), in.size());
+
+  for (size_t i = 0; i != back.size(); ++i) {
+    ASSERT_TRUE(std::isfinite(back[i])) << "coordinate " << i << " = " << back[i];
+  }
+  ASSERT_EQ(back[0], kMaxFloat16);
+  ASSERT_EQ(back[1], -kMaxFloat16);
+  ASSERT_EQ(back[2], 0.0f);
+  ASSERT_EQ(back[3], kMaxFloat16);
+  ASSERT_EQ(back[4], kMaxFloat16);
+  ASSERT_EQ(back[5], 1.0f);
+
+  // 1e30, -1e30, NaN and 65520 are all outside the representable range; 65504 and 1.0 are not.
+  ASSERT_EQ(clamped, size_t{4});
+
+  size_t none = 0;
+  Narrow(VectorStorageKind::kFloat16, {0.0f, 1.0f, -1.0f, kMaxFloat16}, &none);
+  ASSERT_EQ(none, size_t{0});
+}
+
+// The clamp counter accumulates so a caller can total it across a whole index build.
+TEST_F(CoordinateCodecTest, ClampCounterAccumulates) {
+  size_t clamped = 0;
+  Narrow(VectorStorageKind::kFloat16, {1e30f}, &clamped);
+  Narrow(VectorStorageKind::kFloat16, {1e30f, 1e30f}, &clamped);
+  ASSERT_EQ(clamped, size_t{3});
+}
+
+// Coordinates land at unaligned offsets inside a YbHnsw record (20 bytes in, with a stride that
+// is not a multiple of 4), so neither side of the codec may assume alignment.
+TEST_F(CoordinateCodecTest, HandlesUnalignedBuffers) {
+  constexpr size_t kDims = 37;
+  auto in = RandomVector(kDims);
+
+  for (size_t offset = 0; offset != 4; ++offset) {
+    for (auto kind : {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16}) {
+      std::vector<std::byte> buffer(CoordinateBytes(kind, kDims) + offset);
+      NarrowCoordinates(kind, in.data(), kDims, buffer.data() + offset);
+
+      std::vector<float> back(kDims);
+      WidenCoordinates(kind, buffer.data() + offset, kDims, back.data());
+
+      ASSERT_EQ(Widen(kind, Narrow(kind, in), kDims), back)
+          << "kind: " << kind << ", offset: " << offset;
+    }
+  }
+}
+
+}  // namespace yb::vector_index

--- a/src/yb/vector_index/coordinate_codec.cc
+++ b/src/yb/vector_index/coordinate_codec.cc
@@ -1,0 +1,96 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/vector_index/coordinate_codec.h"
+
+#include <cmath>
+#include <cstring>
+
+#include "fp16/fp16.h"
+
+#include "yb/util/logging.h"
+
+namespace yb::vector_index {
+
+namespace {
+
+// Records sit at whatever offset the surrounding layout gives them (YbHnsw coordinates start 20
+// bytes into a record whose stride is not a multiple of 4), so every access goes through memcpy
+// rather than a typed load.
+uint16_t LoadU16(const void* src, size_t index) {
+  uint16_t result;
+  memcpy(&result, static_cast<const std::byte*>(src) + index * sizeof(uint16_t), sizeof(result));
+  return result;
+}
+
+void StoreU16(void* dst, size_t index, uint16_t value) {
+  memcpy(static_cast<std::byte*>(dst) + index * sizeof(uint16_t), &value, sizeof(value));
+}
+
+}  // namespace
+
+size_t CoordinateBytes(VectorStorageKind kind, size_t dimensions) {
+  switch (kind) {
+    case VectorStorageKind::kFloat32:
+      return dimensions * sizeof(float);
+    case VectorStorageKind::kFloat16:
+      return dimensions * sizeof(uint16_t);
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageKind, kind);
+}
+
+void NarrowCoordinates(
+    VectorStorageKind kind, const float* src, size_t dimensions, void* dst,
+    size_t* num_clamped) {
+  switch (kind) {
+    case VectorStorageKind::kFloat32:
+      memcpy(dst, src, dimensions * sizeof(float));
+      return;
+    case VectorStorageKind::kFloat16: {
+      size_t clamped = 0;
+      for (size_t i = 0; i != dimensions; ++i) {
+        auto value = src[i];
+        // NaN fails both comparisons, so it takes the same branch as an out-of-range magnitude.
+        // TODO(vector_index): vectorize with _mm256_cvtps_ph. The scalar conversion costs ~8us
+        // per query at 1536 dimensions, once per chunk per search.
+        if (PREDICT_FALSE(!(value >= -kMaxFloat16 && value <= kMaxFloat16))) {
+          ++clamped;
+          value = std::isnan(value) ? 0.0f : std::copysign(kMaxFloat16, value);
+        }
+        StoreU16(dst, i, fp16_ieee_from_fp32_value(value));
+      }
+      if (num_clamped) {
+        *num_clamped += clamped;
+      }
+      return;
+    }
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageKind, kind);
+}
+
+void WidenCoordinates(
+    VectorStorageKind kind, const void* src, size_t dimensions, float* dst) {
+  switch (kind) {
+    case VectorStorageKind::kFloat32:
+      memcpy(dst, src, dimensions * sizeof(float));
+      return;
+    case VectorStorageKind::kFloat16:
+      for (size_t i = 0; i != dimensions; ++i) {
+        dst[i] = fp16_ieee_to_fp32_value(LoadU16(src, i));
+      }
+      return;
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageKind, kind);
+}
+
+}  // namespace yb::vector_index

--- a/src/yb/vector_index/coordinate_codec.h
+++ b/src/yb/vector_index/coordinate_codec.h
@@ -1,0 +1,49 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+// Conversion between full-precision coordinates and the narrowed encodings a served vector
+// index stores on disk (VectorStorageKind).
+//
+// Both directions live here and nothing else narrows coordinates: writer and query path must
+// round identically, or a vector stops being at distance zero from itself.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "yb/vector_index/vector_storage_kind.h"
+
+namespace yb::vector_index {
+
+// Largest finite value in IEEE 754 binary16, used as the clamp threshold.
+constexpr float kMaxFloat16 = 65504.0f;
+
+// Bytes occupied by `dimensions` coordinates stored as `kind`.
+size_t CoordinateBytes(VectorStorageKind kind, size_t dimensions);
+
+// Narrows `dimensions` float32 coordinates from `src` into `dst` in the `kind` encoding. `dst`
+// must have room for CoordinateBytes(kind, dimensions) bytes and need not be aligned.
+//
+// Unrepresentable values are clamped to the encoding's finite extremes and NaN becomes zero;
+// `num_clamped`, when non-null, counts them. Clamping rather than saturating matters: an infinite
+// coordinate makes every distance to that vector NaN, silently corrupting the heaps' ordering.
+void NarrowCoordinates(
+    VectorStorageKind kind, const float* src, size_t dimensions, void* dst,
+    size_t* num_clamped = nullptr);
+
+// Widens `dimensions` coordinates in the `kind` encoding at `src` back to float32 in `dst`.
+// `src` need not be aligned. Exact for both encodings.
+void WidenCoordinates(
+    VectorStorageKind kind, const void* src, size_t dimensions, float* dst);
+
+}  // namespace yb::vector_index

--- a/src/yb/vector_index/hnsw_options.cc
+++ b/src/yb/vector_index/hnsw_options.cc
@@ -50,6 +50,16 @@ scalar_kind_t ConvertCoordinateKind(CoordinateKind coordinate_kind) {
   FATAL_INVALID_ENUM_VALUE(CoordinateKind, coordinate_kind);
 }
 
+scalar_kind_t ScalarKindFromStorageKind(VectorStorageKind storage_kind) {
+  switch (storage_kind) {
+    case VectorStorageKind::kFloat32:
+      return scalar_kind_t::f32_k;
+    case VectorStorageKind::kFloat16:
+      return scalar_kind_t::f16_k;
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageKind, storage_kind);
+}
+
 } // namespace
 
 std::string HNSWOptions::ToString() const {
@@ -61,11 +71,12 @@ std::string HNSWOptions::ToString() const {
       num_neighbors_per_vertex_base,
       max_neighbors_per_vertex_base,
       ef_construction,
-      robust_prune_alpha);
+      robust_prune_alpha,
+      storage_kind);
 }
 
 template <class Vector>
-unum::usearch::metric_punned_t HNSWOptions::CreateMetric() const {
+unum::usearch::metric_punned_t HNSWOptions::CreateBuildMetric() const {
   return unum::usearch::metric_punned_t(
       dimensions,
       MetricKindFromDistanceType(distance_kind),
@@ -73,6 +84,14 @@ unum::usearch::metric_punned_t HNSWOptions::CreateMetric() const {
 }
 
 template
-unum::usearch::metric_punned_t HNSWOptions::CreateMetric<FloatVector>() const;
+unum::usearch::metric_punned_t HNSWOptions::CreateBuildMetric<FloatVector>() const;
+
+unum::usearch::metric_punned_t HNSWOptions::CreateStoredMetric(
+    size_t dimensions_arg, VectorStorageKind storage_kind_arg) const {
+  return unum::usearch::metric_punned_t(
+      dimensions_arg,
+      MetricKindFromDistanceType(distance_kind),
+      ScalarKindFromStorageKind(storage_kind_arg));
+}
 
 }  // namespace yb::vector_index

--- a/src/yb/vector_index/hnsw_options.h
+++ b/src/yb/vector_index/hnsw_options.h
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "yb/vector_index/distance.h"
+#include "yb/vector_index/vector_storage_kind.h"
 
 namespace unum::usearch {
 class metric_punned_t;
@@ -61,9 +62,20 @@ struct HNSWOptions {
 
   DistanceKind distance_kind = DistanceKind::kL2Squared;
 
+  // Encoding for coordinates written into immutable, file-backed chunks. Graph construction is
+  // unaffected: it always runs at the index's in-memory coordinate type.
+  VectorStorageKind storage_kind = VectorStorageKind::kFloat32;
+
   std::string ToString() const;
+
+  // Metric over Vector::value_type, the in-memory type the graph is built at.
   template <class Vector>
-  unum::usearch::metric_punned_t CreateMetric() const;
+  unum::usearch::metric_punned_t CreateBuildMetric() const;
+
+  // Metric over stored records. Takes the encoding explicitly rather than reading storage_kind,
+  // because YbHnsw::Init must use what the file it just opened records, not what this says now.
+  unum::usearch::metric_punned_t CreateStoredMetric(
+      size_t dimensions, VectorStorageKind storage_kind) const;
 };
 
 }  // namespace yb::vector_index

--- a/src/yb/vector_index/vector_storage_kind.h
+++ b/src/yb/vector_index/vector_storage_kind.h
@@ -1,0 +1,28 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <cstdint>
+
+#include "yb/util/enums.h"
+
+namespace yb::vector_index {
+
+// On-disk encoding of a served vector index's coordinates. Separate from CoordinateKind: the
+// graph is built at full precision and this narrows only the copy in the immutable chunk.
+//
+// Serialized as uint8 in the footer: kFloat32 must stay 0, as version-1 footers lack the field.
+YB_DEFINE_TYPED_ENUM(VectorStorageKind, uint8_t, (kFloat32)(kFloat16));
+
+}  // namespace yb::vector_index

--- a/src/yb/yql/pgwrapper/pg_vector_index-test.cc
+++ b/src/yb/yql/pgwrapper/pg_vector_index-test.cc
@@ -11,7 +11,10 @@
 // under the License.
 //
 
+#include <cmath>
+#include <map>
 #include <queue>
+#include <set>
 
 #include "yb/client/client_error.h"
 #include "yb/client/client_fwd.h"
@@ -94,6 +97,7 @@ DECLARE_int64(db_block_size_bytes);
 DECLARE_int64(db_write_buffer_size);
 DECLARE_int64(tablet_force_split_threshold_bytes);
 DECLARE_string(vector_index_backend);
+DECLARE_string(vector_index_storage_coordinate_type);
 DECLARE_uint64(post_split_compaction_input_size_threshold_bytes);
 DECLARE_bool(vector_index_allow_parallel_compactions);
 DECLARE_int32(vector_index_files_number_compaction_trigger);
@@ -101,6 +105,7 @@ DECLARE_uint32(vector_index_compaction_chunk_max_mem_store_size_percentage);
 DECLARE_uint32(vector_index_concurrent_reads);
 DECLARE_uint32(vector_index_concurrent_writes);
 DECLARE_uint32(vector_index_num_compactions_limit);
+DECLARE_uint32(vector_index_rerank_overfetch_factor);
 DECLARE_uint64(vector_index_compaction_chunk_max_mem_store_size_mb);
 DECLARE_uint64(vector_index_initial_chunk_size);
 DECLARE_uint64(vector_index_max_insert_tasks);
@@ -4684,6 +4689,222 @@ TEST_P(PgVectorIndexTest, StatusResolutionDuringBootstrapBackfill) {
 
   // Reaching here without the tserver crashing means the fix holds.
   threads.Stop();
+}
+
+////////////////////////////////////////////////////////
+// Narrowed coordinate storage (float16)
+////////////////////////////////////////////////////////
+
+// Shared by the narrowed-storage fixtures below, each of which names one encoding, so the same
+// suite runs against all of them. The graph is still built at full precision, so what these cover
+// is whether narrowed records survive flush, restart, compaction and the query path.
+class PgVectorIndexNarrowStorageTest : public PgVectorIndexTestBase {
+ protected:
+  virtual std::string StorageCoordinateType() const = 0;
+
+  bool IsColocated() const override { return false; }
+  VectorIndexEngine Engine() const override { return VectorIndexEngine::kYbHnswHnswlib; }
+  PackingMode GetPackingMode() const override { return PackingMode::kV1; }
+
+  void SetUp() override {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_storage_coordinate_type) =
+        StorageCoordinateType();
+    PgVectorIndexTestBase::SetUp();
+    // The base fixture forces brute-force search; these tests want the real graph walk over
+    // narrowed records.
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_vector_index_exact) = false;
+  }
+
+  // Ids of the `limit` nearest rows by exact float32 distance, computed from the vectors the test
+  // inserted rather than from anything the index stored.
+  std::vector<int64_t> ExactNearest(const FloatVector& query_vector, size_t limit) {
+    unum::usearch::metric_punned_t metric(
+        dimensions_, UsearchMetricKind(), unum::usearch::scalar_kind_t::f32_k);
+    std::vector<int64_t> ids(vectors_.size());
+    std::generate(ids.begin(), ids.end(), [n{0LL}]() mutable { return n++; });
+    std::sort(ids.begin(), ids.end(), [&](int64_t lhs, int64_t rhs) {
+      return metric(VectorToBytePtr(query_vector), VectorToBytePtr(vectors_[lhs])) <
+             metric(VectorToBytePtr(query_vector), VectorToBytePtr(vectors_[rhs]));
+    });
+    ids.resize(std::min(ids.size(), limit));
+    return ids;
+  }
+
+  // Fraction of the exact top-`limit` that the index actually returned, averaged over
+  // `iterations` random queries.
+  Result<double> MeasureRecall(PGConn& conn, size_t limit, size_t iterations) {
+    size_t found = 0;
+    for (size_t i = 0; i != iterations; ++i) {
+      auto query_vector = RandomVector();
+      auto rows = VERIFY_RESULT(conn.FetchRows<int64_t>(
+          "SELECT id FROM test" + IndexQuerySuffix(query_vector, limit)));
+      auto expected = ExactNearest(query_vector, limit);
+      std::set<int64_t> expected_set(expected.begin(), expected.end());
+      for (auto id : rows) {
+        found += expected_set.contains(id);
+      }
+    }
+    return static_cast<double>(found) / (limit * iterations);
+  }
+
+  // Storage type recorded on every vector index this cluster is serving.
+  std::map<VectorStorageType, size_t> StorageTypeCounts() {
+    std::map<VectorStorageType, size_t> counts;
+    for (const auto& peer : ListTabletPeersWithVectorIndexes(cluster_.get())) {
+      auto tablet = CHECK_RESULT(peer->shared_tablet());
+      auto indexes = tablet->vector_indexes().List();
+      CHECK(indexes);
+      for (const auto& index : *indexes) {
+        ++counts[index->options().hnsw().storage_type()];
+      }
+    }
+    return counts;
+  }
+};
+
+class PgVectorIndexFloat16Test : public PgVectorIndexNarrowStorageTest {
+ protected:
+  std::string StorageCoordinateType() const override { return "float16"; }
+};
+
+// The encoding is fixed per index at creation time so every replica agrees on it. A tserver-local
+// setting would let replicas of the same tablet disagree about the accuracy of their answers.
+TEST_F(PgVectorIndexFloat16Test, StorageTypeIsRecordedInTheCatalog) {
+  auto conn = ASSERT_RESULT(MakeIndex());
+
+  size_t checked = 0;
+  for (const auto& peer : ListTabletPeersWithVectorIndexes(cluster_.get())) {
+    auto tablet = ASSERT_RESULT(peer->shared_tablet());
+    auto indexes = tablet->vector_indexes().List();
+    ASSERT_TRUE(indexes);
+    for (const auto& index : *indexes) {
+      ASSERT_EQ(index->options().hnsw().storage_type(), VectorStorageType::STORAGE_FLOAT16);
+      ++checked;
+    }
+  }
+  ASSERT_GT(checked, 0);
+}
+
+// Narrowing changes which rows come back, not the distances the user sees: ybvectorgettuple
+// leaves xs_orderbyvals unset and xs_recheckorderby false, so the executor evaluates `<->` over
+// the full-precision heap value. They are not even the same quantity -- `<->` is sqrt(L2 squared)
+// where the index ranks on L2 squared -- so a leaked index distance fails this by a wide margin.
+TEST_F(PgVectorIndexFloat16Test, ReportedDistancesStayFullPrecision) {
+  constexpr size_t kNumRows = 500;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+
+  // Mirrors pgvector's l2_distance: float32 accumulation, then sqrt in double.
+  auto exact_l2_distance = [](const FloatVector& lhs, const FloatVector& rhs) {
+    float squared = 0.0f;
+    for (size_t i = 0; i != lhs.size(); ++i) {
+      const float diff = lhs[i] - rhs[i];
+      squared += diff * diff;
+    }
+    return std::sqrt(static_cast<double>(squared));
+  };
+
+  for (size_t i = 0; i != 10; ++i) {
+    auto query_vector = RandomVector();
+    auto rows = ASSERT_RESULT((conn.FetchRows<int64_t, double>(Format(
+        "SELECT id, $0 FROM test$1",
+        DistanceToQuery(query_vector), IndexQuerySuffix(query_vector, kLimit)))));
+    ASSERT_FALSE(rows.empty());
+
+    for (const auto& [id, reported] : rows) {
+      const auto exact = exact_l2_distance(query_vector, vectors_[id]);
+      // 1e-5 sits two orders of magnitude above float32 accumulation noise and two below the
+      // ~5e-4 relative error of a float16 distance, so it tells the two apart.
+      ASSERT_LE(std::fabs(reported - exact), 1e-5 * std::max<double>(exact, 1.0))
+          << "id: " << id << ", reported: " << reported << ", exact: " << exact;
+    }
+  }
+}
+
+TEST_F(PgVectorIndexFloat16Test, Recall) {
+  constexpr size_t kNumRows = 2000;
+  constexpr size_t kLimit = 10;
+  constexpr size_t kIterations = 20;
+
+  dimensions_ = 32;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+
+  auto recall = ASSERT_RESULT(MeasureRecall(conn, kLimit, kIterations));
+  LOG(INFO) << "float16 recall@" << kLimit << ": " << recall;
+  ASSERT_GE(recall, 0.8);
+}
+
+// Flush turns the mutable chunk into a narrowed file, and restart reopens it through
+// YbHnsw::Init -- the path where the metric has to be rebuilt from the file's own footer.
+TEST_F(PgVectorIndexFloat16Test, SurvivesFlushAndRestart) {
+  constexpr size_t kNumRows = 1000;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+  ASSERT_OK(cluster_->FlushTablets());
+
+  auto before = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  ASSERT_OK(RestartCluster());
+  conn = ASSERT_RESULT(Connect());
+
+  auto after = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+  LOG(INFO) << "recall before restart: " << before << ", after: " << after;
+  ASSERT_GE(after, 0.8);
+}
+
+// Compaction reads source chunks back through YbHnswIterator, which has to decode narrowed
+// records rather than copy float32-wide out of them. Re-narrowing what it read is idempotent, so
+// recall should not decay across compactions either.
+TEST_F(PgVectorIndexFloat16Test, SurvivesCompaction) {
+  constexpr size_t kRowsPerChunk = 300;
+  constexpr size_t kNumChunks = 4;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndex(dimensions_));
+  for (size_t chunk = 0; chunk != kNumChunks; ++chunk) {
+    ASSERT_OK(InsertRandomRows(conn, kRowsPerChunk));
+    ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+    ASSERT_OK(cluster_->FlushTablets());
+  }
+
+  auto before = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  ASSERT_OK(cluster_->CompactTablets());
+  auto after = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  LOG(INFO) << "recall before compaction: " << before << ", after: " << after;
+  ASSERT_GE(after, 0.8);
+}
+
+// A float16 index has to coexist with a float32 one in the same cluster: the encoding is a
+// per-index property, and each chunk records its own.
+TEST_F(PgVectorIndexFloat16Test, CoexistsWithFloat32Index) {
+  constexpr size_t kNumRows = 500;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_storage_coordinate_type) = "float32";
+  ASSERT_OK(conn.Execute(
+      "CREATE INDEX vi_f32 ON test USING ybhnsw (embedding vector_l2_ops) WITH (m=16)"));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 60s * kTimeMultiplier));
+  ASSERT_OK(cluster_->FlushTablets());
+
+  auto counts = StorageTypeCounts();
+  LOG(INFO) << "indexes by storage type: " << AsString(counts);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_FLOAT16], 0);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_FLOAT32], 0);
+
+  ASSERT_GE(ASSERT_RESULT(MeasureRecall(conn, kLimit, 10)), 0.8);
 }
 
 }  // namespace yb::pgwrapper


### PR DESCRIPTION
## Summary

A DocDB vector index (`ybhnsw`) stored every served coordinate as float32, so a 768-dimension
chunk spent 3072 bytes per record on coordinates and a graph traversal read all of them on every
distance evaluation. At 1M vectors that exceeds what the block cache holds, and the traversal is
the hot path: it touches thousands of records per query.

This adds `float16` as an on-disk encoding for the coordinates of an immutable chunk, selected per
index at `CREATE INDEX` and recorded in the chunk footer. The HNSW graph is still built at full
float32 precision; only the copy written into the chunk is narrowed.

`coordinate_codec.{h,cc}` owns both directions and nothing else narrows coordinates: writer and
query path must round identically, or a vector stops being at distance zero from itself and the
graph's neighbour choices stop agreeing with the distances used to search it.

## Index size and memory footprint

Measured for 1M vectors at 768 dimensions (single-node `ef_search=200` run):

| encoding | record | index size | vs `float32` | records per fixed cache budget |
|---|---|---|---|---|
| `float32` | 3092 B | 3.19 GB | 1.00x | 1.00x |
| `float16` | 1556 B | **1.65 GB** | **0.52x** | **1.99x** |

A 48% smaller index, and the same block cache keeps ~2x as many vectors resident -- which matters
more than the disk saving, since a float32 index of this size does not fit a typical cache and the
traversal is what pays for the misses.

The saving follows from the record layout alone: 1M records account for 3.09 GB at `float32` and
1.56 GB at `float16`, leaving ~0.10 GB of neighbour lists and aux entries that do not shrink, and
1.56 + 0.10 = 1.65 GB is exactly what was measured. That is also why the file ratio is 0.52x
rather than 0.50x.

## Throughput

VectorDBBench `Performance768D1M` (Cohere, cosine), `k=100`, 30 clients, versus `float32` at the
same `ef_search`:

| setup | ef | recall delta | throughput |
|---|---|---|---|
| RF3 | 100 | +0.14% | +17.0% |
| RF3 | 200 | +0.06% | +12.5% |
| RF1 | 100 | +0.05% | +17.0% |
| RF1 | 200 | -0.02% | +20.6% |

Recall moves by at most 0.14% in either direction across all four cells, which is what makes the
encoding safe to consider as a default.

Throughput gains less than the halved byte count suggests, for two reasons. The `*_f16_haswell`
kernels widen each coordinate to fp32 and accumulate there, so halving the bytes does not halve
the work. And fitting `speedup = 1/((1-f) + f/c)` gives **f ~ 0.3**: only about 30% of end-to-end
query time scales with coordinate bytes at all, the rest being tablet fan-out, fetching `LIMIT`
rows per query, neighbour-list reads that no encoding shrinks, and YSQL/RPC overhead. That puts a
ceiling near 1.43x on what any coordinate encoding can buy here.

## Also in this change

Two search hot path changes, independent of which encoding an index uses:

- The base layer search resolves a node's unvisited neighbour record addresses as a batch and
  prefetches them before computing any distance, so the two dependent cache misses per visit
  overlap. Both loop shapes call one `visit` lambda in neighbour order, so results are identical.
  **As measured this is neutral, so it is not a claimed gain** -- the `float32` rows isolate it
  and straddle zero (+4.9%/+2.1% RF3, -3.4%/-4.9% RF1). It is behind a runtime flag so the two
  shapes can be A/B'd in one process.
- `cache_query`/`cache_hit` were incremented inside `CachedBlock::Take`, which a query calls
  thousands of times. `Take` now reports residency through an out-parameter and `SearchCache`
  flushes once per search. Totals unchanged.
- `BlockCacheMetrics` instantiated `take_wait_us` from the `cache_read_us` prototype, so that
  metric reported read latency under a second name.

## Flags

- `--vector_index_storage_coordinate_type` (**master**, runtime-settable): `float32` (default) or
  `float16`. Read at `CREATE INDEX` and stamped into the index's catalog entry, so it is fixed for
  that index's life and identical on every replica rather than following each tserver's local
  flags.

Design doc: `architecture/design/docdb-vector-index-narrowed-storage.md`

An `int8` encoding with a float16 rerank tier builds on this and is stacked on top of it as a
separate PR.

## Upgrade/Rollback safety

**Proto change:** `common.proto` adds `enum VectorStorageType` and
`HnswIndexOptionsPB.storage_type` (field 5, `default = STORAGE_FLOAT32`).

**Upgrade is a no-op unless an operator opts in.** The new master flag defaults to `float32`, so
a freshly upgraded cluster stamps `STORAGE_FLOAT32` (the proto default, which is also the zero
value) and writes byte-identical **version-1** chunk footers. Nothing about an existing index or
its files changes.

**Rollback is safe while the flag is untouched, and one-way for chunks written after it is set.**
The chunk footer is versioned: `float32` emits version 1, `float16` version 2. A binary predating
this change cannot read version 2 -- its `FileBlockCache::Load` has no version gate and would
consume the appended `storage_kind` byte as part of a block offset. So:

- Rolled back with the flag never set: no version-2 chunks exist; nothing to do.
- Rolled back after the flag was set: indexes created while it was set keep their encoding in the
  catalog, and their chunks are unreadable by the older binary. **Those indexes must be dropped
  and rebuilt before rolling back.** Clearing the flag stops new chunks from using the encoding
  but does not rewrite existing ones.

**Mixed-version window:** an older tserver ignores unknown field 5 and would build `float32`
chunks for an index whose catalog entry says `float16`, while an upgraded tserver builds
`float16` chunks for the same index. Every chunk records its own encoding, so a new binary reads
both correctly and this is not a correctness problem -- but it yields an index with
mixed-encoding chunks and therefore mixed recall. **Do not set the flag until the rolling upgrade
is complete on every node.**

This change adds a version gate on read (`SCHECK` on the footer version, plus a `ValidateHeader`
self-consistency check on the parsed header, including a range check on the encoding enum so a
corrupt byte fails the one file rather than aborting the process), so a binary carrying this
change fails a chunk it cannot interpret with `Corruption` rather than misreading it.

## Test plan

Jenkins: all

New tests:

- [x] `coordinate_codec-test` -- round-trip error bounds (a relative bound above fp16's smallest
      normal and an absolute one below it), clamping of unrepresentable values and NaN,
      determinism of narrowing, unaligned source and destination buffers.
- [x] `hnsw-test` -- that the prefetching and serial neighbour loops visit the same blocks and
      return identical results, so the flag cannot change an answer; that a `float32` index still
      produces a version-1 footer byte for byte and `float16` a version-2 one; that the encoding
      is taken from the file rather than from caller configuration; that a vector used as its own
      query comes back at distance zero; that the header reflects the encoding and records-per-
      block rises as the record shrinks.
- [x] `yb_hnsw_storage-test` -- iteration and `Distance` through the `VectorIndexIf` stack, and
      that re-narrowing what iteration yields is idempotent, so repeated compaction cannot drift
      a vector.
- [ ] `pg_vector_index-test` -- the suite against `float16` end-to-end through flush, restart,
      compaction and the query path; that the distance the user sees is unaffected by the storage
      encoding.

Ran locally, macOS arm64 debug -- all pass: `coordinate_codec-test`, `hnsw-test`,
`yb_hnsw_storage-test`.

`pg_vector_index-test` compiles but does not run on this host: it needs `127.0.0.x` loopback
aliases, which macOS does not configure by default (every case fails at `Error binding socket to
127.0.0.2 ... Can't assign requested address`). CI is its first execution.

Benchmarks: VectorDBBench `Performance768D1M` at RF1 and RF3, `ef_search` 100 and 200 -- results
in the Summary and in the design doc.
