### PR TITLE
[#33804] DocDB: int8 coordinate storage with a float16 rerank tier

### DIFF
--- a/architecture/design/docdb-vector-index-narrowed-storage.md
+++ b/architecture/design/docdb-vector-index-narrowed-storage.md
@@ -1,0 +1,154 @@
+# Vector index narrowed coordinate storage
+
+A DocDB vector index (`ybhnsw`) can store the coordinates of a served chunk as `float16` rather
+than `float32`. The HNSW graph is always built at full `float32` precision -- only the copy
+written into the immutable chunk file is narrowed.
+
+`float32` is the default and writes version-1 chunks, so an index that does not opt in is
+unaffected.
+
+## Record layout
+
+`VectorStorageKind` names the encoding. Per vector at 768 dimensions:
+
+| encoding | coordinates | record | vs `float32` | bytes per distance |
+|---|---|---|---|---|
+| `float32` | 3072 | 3092 | 1.00x | 3072 |
+| `float16` | 1536 | 1556 | 0.50x | 1536 |
+
+The 20-byte overhead is the per-vector `YbHnswVectorData` header.
+
+`coordinate_codec.{h,cc}` owns both directions and nothing else narrows coordinates: writer and
+query path must round identically, or a vector stops being at distance zero from itself and the
+graph's neighbour choices stop agreeing with the distances used to search it.
+
+## Measured
+
+VectorDBBench `Performance768D1M` (Cohere, cosine), `k=100`, 30 clients, versus `float32` at the
+same `ef_search`:
+
+| setup | ef | recall delta | throughput |
+|---|---|---|---|
+| RF3 | 100 | +0.14% | +17.0% |
+| RF3 | 200 | +0.06% | +12.5% |
+| RF1 | 100 | +0.05% | +17.0% |
+| RF1 | 200 | -0.02% | +20.6% |
+
+Recall moves by at most 0.14% in either direction across all four cells, which is what makes the
+encoding safe to consider as a default.
+
+Throughput gains less than the halved byte count suggests, for two reasons. The `*_f16_haswell`
+kernels widen each coordinate to fp32 and accumulate there, so halving the bytes does not halve
+the work. And fitting `speedup = 1/((1-f) + f/c)` across these cells, `c` being the coordinate-byte
+ratio, gives **f ~ 0.3**: only about 30% of end-to-end query time scales with coordinate bytes.
+The rest is tablet fan-out, resolving and fetching `LIMIT` rows per query, neighbour-list reads
+that no encoding shrinks, and YSQL/RPC overhead. That puts a ceiling near 1.43x on what any
+coordinate encoding can buy here.
+
+## Index size and memory footprint
+
+Halving the coordinate bytes halves what the index costs on disk and in the block cache. Measured
+file sizes for 1M vectors at 768 dimensions (from a single-node `ef_search=200` run, not the
+RF1/RF3 runs above):
+
+| encoding | record | vs `float32` | index size | records per fixed cache budget |
+|---|---|---|---|---|
+| `float32` | 3092 | 1.00x | 3.19 GB | 1.00x |
+| `float16` | 1556 | 0.50x | **1.65 GB** | **1.99x** |
+
+The file ratio is 0.52x rather than 0.50x because the graph and aux data do not shrink. That is
+the whole of the discrepancy: 1M records account for 3.09 GB at `float32` and 1.56 GB at
+`float16`, leaving ~0.10 GB of neighbour lists and aux entries unchanged, and 1.56 + 0.10 = 1.65 GB
+is what was measured. So the on-disk saving is predicted by the record layout alone -- there is no
+second effect to account for.
+
+The block cache holds records, so the same budget keeps ~2x as many vectors resident. That matters
+more than the disk saving: at 1M x 768d a `float32` index does not fit a typical cache, and the
+traversal is what pays for the misses.
+
+## Chunk format
+
+Each chunk records its own encoding in its footer, under a serialization version:
+
+| version | contents |
+|---|---|
+| 1 | base layout; always `float32` |
+| 2 | adds `Header::storage_kind` |
+
+The writer emits the lowest version that can represent the header, which keeps a `float32` index
+at version 1. `Load` rejects a version outside the supported range rather than reading the fields
+it knows and consuming the remainder as block offsets, and `ValidateHeader` then checks the parsed
+header against itself before any record is read through it: a `vector_data_size` disagreeing with
+the encoding would read past every record into the next, and an out-of-range encoding enum would
+reach `FATAL_INVALID_ENUM_VALUE` and abort the process rather than failing the one file.
+
+## Search hot path
+
+Two changes here are independent of which encoding an index uses.
+
+**Neighbour prefetch** (`yb_hnsw_prefetch_neighbors`, default on). Visiting a neighbour costs two
+dependent cache misses the CPU cannot speculate through: `blocks_[index]`, then the record it
+points at. The loop filters a node's neighbours through the visited set, resolves all their
+record addresses and prefetches each, before computing any distance, so the misses overlap. Both
+loop shapes call one `visit` lambda in neighbour order, so results are identical --
+`PrefetchMatchesSerialResolution` asserts that, including equal cache query and hit counts. The
+visited filter must stay first, or resolving addresses for already-visited neighbours would
+`Take()` blocks the search does not need. **Measured neutral** (see Caveats); the flag allows
+A/B in one process.
+
+**Batched cache counters.** `cache_query`/`cache_hit` are accumulated in `SearchCache` and
+flushed once per search rather than incremented inside `CachedBlock::Take`, which a query calls
+thousands of times. `Take` reports residency through a `was_hit` out-parameter; a caller passing
+`nullptr` gets no accounting, as the header states.
+
+## Enabling the encoding
+
+A **master** flag chooses the encoding, stamped into the index's catalog entry at `CREATE INDEX`.
+It is therefore fixed for the life of that index and identical on every replica, rather than
+following each tserver's local flags.
+
+```bash
+# On every yb-master. Runtime-settable; no restart needed.
+--vector_index_storage_coordinate_type=float16   # or float32 (default)
+```
+
+An index keeps the encoding it was created with, so the flag's value at query time says nothing
+about an index created earlier. To see what an index got, read `vector_data_size` from the index
+flush log line: `20 + 4*d` for `float32`, `20 + 2*d` for `float16`.
+
+### Downgrade
+
+Selecting `float16` is one-way for the chunks written while it is selected: a version-2 chunk is
+unreadable by a binary that only understands version 1. Clearing the flag stops new chunks from
+using the encoding but does not rewrite existing ones, and an index created while it was set
+keeps its encoding in the catalog. Moving such a cluster to a binary without the encoding
+requires those indexes be dropped and rebuilt.
+
+## SIMD kernels
+
+x86-64 builds at `-march=ivybridge`, so no AVX-512 family enables itself from its `-march` macro
+and `usearch_include_wrapper_internal.h` forces the SimSIMD targets the encoding needs:
+`HASWELL` and `SKYLAKE`. Forcing a target is safe -- each kernel carries its own target attribute
+so it compiles under the Ivy Bridge baseline, and `simsimd_capabilities()` dispatches on CPUID, so
+a kernel the host cannot run is never called.
+
+`float16` distances use the 256-bit `*_f16_haswell` kernels, which widen each coordinate to fp32
+and accumulate there. The `#define`s reach only translation units including
+`usearch_include_wrapper_internal.h`, directly or through `hnsw.h`: 5 production files, all
+vector-index code, plus 4 tests. `hnsw.h` is included by no other header, so nothing in
+`tserver`, `master`, `rocksdb` or `postgres` is reached. Vector indexes are YSQL-only, so none of
+this can reach a YCQL workload.
+
+## Caveats
+
+- **No sanitizer coverage of the SIMD kernels.** SimSIMD is disabled under ASAN and TSAN, whose
+  builds exercise usearch's scalar metric instead. The wide intrinsic loads largely evade
+  instrumentation, so a bad read inside one faults or is missed rather than reported.
+- **One workload.** Every number above is Cohere 768d/1M, `k=100`, 30 clients, read-only. The
+  dispatch split, the 30% byte-proportional fraction, and the balance between bytes moved and
+  kernel cost will differ on another host, at another dimension count, at a different `LIMIT`, or
+  under a mixed read/write load.
+- **Latency is unmeasured.** The table reports recall and throughput only.
+- **The prefetch is not earning its place.** Isolated at `float32` it straddles zero
+  (+4.9%/+2.1% RF3, -3.4%/-4.9% RF1). It should either be shown to pay on some workload or be
+  turned off.

--- a/architecture/design/docdb-vector-index-narrowed-storage.md
+++ b/architecture/design/docdb-vector-index-narrowed-storage.md
@@ -1,22 +1,27 @@
 # Vector index narrowed coordinate storage
 
-A DocDB vector index (`ybhnsw`) can store the coordinates of a served chunk as `float16` rather
-than `float32`. The HNSW graph is always built at full `float32` precision -- only the copy
-written into the immutable chunk file is narrowed.
+A DocDB vector index (`ybhnsw`) can store the coordinates of a served chunk in a narrower
+encoding than `float32`: either `float16`, or `int8` paired with a `float16` rerank tier. The
+HNSW graph is always built at full `float32` precision -- only the copies written into the
+immutable chunk file are narrowed.
 
 `float32` is the default and writes version-1 chunks, so an index that does not opt in is
 unaffected.
 
 ## Record layout
 
-`VectorStorageKind` names the encoding. Per vector at 768 dimensions:
+`VectorStorageKind` names the traversal encoding, `RerankStorageKind` the optional second copy.
+Per vector at 768 dimensions:
 
-| encoding | coordinates | record | vs `float32` | bytes per distance |
-|---|---|---|---|---|
-| `float32` | 3072 | 3092 | 1.00x | 3072 |
-| `float16` | 1536 | 1556 | 0.50x | 1536 |
+| encoding | traversal | rerank | record | vs `float32` | bytes per distance |
+|---|---|---|---|---|---|
+| `float32` | 3072 | -- | 3092 | 1.00x | 3072 |
+| `float16` | 1536 | -- | 1556 | 0.50x | 1536 |
+| `int8` | 768 | 1536 | 2324 | 0.75x | **768** |
 
-The 20-byte overhead is the per-vector `YbHnswVectorData` header.
+The 20-byte overhead is the per-vector `YbHnswVectorData` header. A traversal touches thousands
+of records per query while the rerank tier reads only the retained candidates, so `int8` spends
+0.75x the disk to make the hot path read a quarter of the bytes.
 
 `coordinate_codec.{h,cc}` owns both directions and nothing else narrows coordinates: writer and
 query path must round identically, or a vector stops being at distance zero from itself and the
@@ -27,23 +32,75 @@ graph's neighbour choices stop agreeing with the distances used to search it.
 VectorDBBench `Performance768D1M` (Cohere, cosine), `k=100`, 30 clients, versus `float32` at the
 same `ef_search`:
 
-| setup | ef | recall delta | throughput |
-|---|---|---|---|
-| RF3 | 100 | +0.14% | +17.0% |
-| RF3 | 200 | +0.06% | +12.5% |
-| RF1 | 100 | +0.05% | +17.0% |
-| RF1 | 200 | -0.02% | +20.6% |
+| setup | ef | encoding | recall delta | throughput |
+|---|---|---|---|---|
+| RF3 | 200 | `float16` | +0.06% | +12.5% |
+| RF3 | 200 | `int8`, overfetch 1 | +0.01% | **+39.8%** |
+| RF1 | 200 | `float16` | -0.02% | +20.6% |
+| RF1 | 200 | `int8`, overfetch 2 | +0.01% | **+32.8%** |
 
-Recall moves by at most 0.14% in either direction across all four cells, which is what makes the
-encoding safe to consider as a default.
+Fitting `speedup = 1/((1-f) + f/c)` across eight recall-matched cells, `c` being the
+coordinate-byte ratio, gives **f = 0.30 +/- 0.06**: only ~30% of end-to-end query time scales
+with coordinate bytes. The ceiling for any coordinate encoding is therefore `1/(1-0.30)` =
+**1.43x**, and `int8` reaches ~93% of it. The rest is tablet fan-out, resolving and fetching
+`LIMIT` rows per query, neighbour-list reads that no encoding shrinks, and YSQL/RPC overhead.
+This is why nothing narrower than `int8` is worth adding: `int4` would buy roughly 3%.
 
-Throughput gains less than the halved byte count suggests, for two reasons. The `*_f16_haswell`
-kernels widen each coordinate to fp32 and accumulate there, so halving the bytes does not halve
-the work. And fitting `speedup = 1/((1-f) + f/c)` across these cells, `c` being the coordinate-byte
-ratio, gives **f ~ 0.3**: only about 30% of end-to-end query time scales with coordinate bytes.
-The rest is tablet fan-out, resolving and fetching `LIMIT` rows per query, neighbour-list reads
-that no encoding shrinks, and YSQL/RPC overhead. That puts a ceiling near 1.43x on what any
-coordinate encoding can buy here.
+## Index size and memory footprint
+
+The two encodings move footprint in opposite directions, which is the main reason to pick one over
+the other. Measured file sizes for 1M vectors at 768 dimensions (from a single-node
+`ef_search=200` run, not the RF1/RF3 runs above):
+
+| encoding | record | vs `float32` | index size | records per fixed cache budget | bytes touched per visit |
+|---|---|---|---|---|---|
+| `float32` | 3092 | 1.00x | 3.19 GB | 1.00x | 3092 |
+| `float16` | 1556 | 0.50x | **1.65 GB** | **1.99x** | 1556 |
+| `int8` + rerank | 2324 | 0.75x | 2.42 GB | 1.33x | **788** |
+
+`float16` is the capacity option: it halves the index and keeps ~2x as many vectors resident in the
+same block cache, at identical recall. `int8` is the throughput option: its record is *larger*
+than `float16`'s, because the rerank copy costs more than the narrowed traversal copy saves, so it
+shrinks the index only 24% -- but a traversal reads just the header and traversal coordinates, so
+what the hot path touches drops to **0.25x**. The rerank copy is read only for the retained
+candidates.
+
+Both file sizes follow from the record layout alone. 1M records account for 3.09 / 1.56 / 2.32 GB,
+leaving ~0.10 GB of neighbour lists and aux entries that no encoding shrinks; adding that back
+gives 1.65 GB and 2.42 GB, which is what was measured to the last digit. There is no second effect
+to account for, and the ratios hold at any vector count where records dominate the file.
+
+## The rerank tier, and why `ef` is not the knob
+
+`int8` quantizes each coordinate to a per-chunk step, costing several points of recall@k.
+**Raising `ef` does not recover it** -- a search retains `max_num_results` entries ranked by that
+same quantized distance, so widening the candidate set does not improve the final selection.
+
+What recovers it is retaining more candidates than requested and rescoring them at `float16`
+before they leave the chunk. `MakeResult` is the only point at which distances cross the chunk
+boundary, so it is also the only point at which they must be in the metric's own units for
+VectorLSM to merge them against other chunks.
+
+The candidate budget is `max(ef_search, LIMIT, factor * LIMIT)`. While `factor * LIMIT <=
+ef_search` the over-fetch is free, since the search already retains that many candidates. Above
+it the budget becomes `factor * LIMIT` and `ef_search` goes inert below that -- at the default
+factor of 2 with `LIMIT 100`, an `ef_search` of 100 and of 200 run the identical search. Either
+set the factor to 1 and let `ef_search` control depth, or raise `ef_search` past
+`factor * LIMIT`. The RF3 numbers above use factor 1; RF1 needs factor 2, which costs it 1.1
+recall points at factor 1, so this is a per-deployment choice.
+
+## Per-chunk quantization scale
+
+`int8` uses a symmetric scale, `max|coordinate| / 127`, derived from the chunk's own coordinates
+and recorded in its footer. Scoping it to the chunk keeps it a pure function of data already in
+hand -- no sampling, no configuration, nothing to recalibrate as an index grows -- at the cost
+that two chunks of one index hold different scales. A query must therefore be quantized against
+the scale of the chunk it is compared against, never a freshly computed one.
+
+This is also why compaction reads the **rerank** copy rather than decoding the traversal
+coordinates. A merged chunk derives a new scale, so decoding `int8` would feed already-quantized
+values into a fresh quantization and lose a little more on every merge. The `float16` copy
+round-trips exactly, making a vector a fixed point across arbitrarily many compactions.
 
 ## Index size and memory footprint
 
@@ -74,17 +131,19 @@ Each chunk records its own encoding in its footer, under a serialization version
 |---|---|
 | 1 | base layout; always `float32` |
 | 2 | adds `Header::storage_kind` |
+| 3 | adds `Header::rerank_kind` and `Header::quantization_scale` |
 
 The writer emits the lowest version that can represent the header, which keeps a `float32` index
-at version 1. `Load` rejects a version outside the supported range rather than reading the fields
-it knows and consuming the remainder as block offsets, and `ValidateHeader` then checks the parsed
-header against itself before any record is read through it: a `vector_data_size` disagreeing with
-the encoding would read past every record into the next, and an out-of-range encoding enum would
-reach `FATAL_INVALID_ENUM_VALUE` and abort the process rather than failing the one file.
+at version 1. `Load` rejects a version outside 1..3 rather than reading the fields it knows and
+consuming the remainder as block offsets, and `ValidateHeader` then checks the parsed header
+against itself before any record is read through it: a `vector_data_size` disagreeing with the
+encodings would read past every record into the next, an unusable scale would decode coordinates
+to zero or infinity, and an out-of-range encoding enum would reach `FATAL_INVALID_ENUM_VALUE` and
+abort the process rather than failing the one file.
 
 ## Search hot path
 
-Two changes here are independent of which encoding an index uses.
+Two changes are independent of which encoding an index uses.
 
 **Neighbour prefetch** (`yb_hnsw_prefetch_neighbors`, default on). Visiting a neighbour costs two
 dependent cache misses the CPU cannot speculate through: `blocks_[index]`, then the record it
@@ -101,7 +160,7 @@ flushed once per search rather than incremented inside `CachedBlock::Take`, whic
 thousands of times. `Take` reports residency through a `was_hit` out-parameter; a caller passing
 `nullptr` gets no accounting, as the header states.
 
-## Enabling the encoding
+## Enabling an encoding
 
 A **master** flag chooses the encoding, stamped into the index's catalog entry at `CREATE INDEX`.
 It is therefore fixed for the life of that index and identical on every replica, rather than
@@ -109,35 +168,45 @@ following each tserver's local flags.
 
 ```bash
 # On every yb-master. Runtime-settable; no restart needed.
---vector_index_storage_coordinate_type=float16   # or float32 (default)
+--vector_index_storage_coordinate_type=int8      # or float16, or float32 (default)
+
+# On every yb-tserver. 1 disables the over-fetch. Valid range 1-64.
+--vector_index_rerank_overfetch_factor=2         # default
 ```
 
 An index keeps the encoding it was created with, so the flag's value at query time says nothing
 about an index created earlier. To see what an index got, read `vector_data_size` from the index
-flush log line: `20 + 4*d` for `float32`, `20 + 2*d` for `float16`.
+flush log line: `20 + 4*d` for `float32`, `20 + 2*d` for `float16`, `20 + 3*d` for `int8`.
 
 ### Downgrade
 
-Selecting `float16` is one-way for the chunks written while it is selected: a version-2 chunk is
-unreadable by a binary that only understands version 1. Clearing the flag stops new chunks from
-using the encoding but does not rewrite existing ones, and an index created while it was set
-keeps its encoding in the catalog. Moving such a cluster to a binary without the encoding
-requires those indexes be dropped and rebuilt.
+Selecting a narrow encoding is one-way for the chunks written while it is selected. A version-2
+or version-3 chunk is unreadable by a binary that only understands version 1. Clearing the flag
+stops new chunks from using the encoding but does not rewrite existing ones, and an index created
+while it was set keeps its encoding in the catalog. Moving such a cluster to a binary without
+these encodings requires those indexes be dropped and rebuilt.
 
 ## SIMD kernels
 
 x86-64 builds at `-march=ivybridge`, so no AVX-512 family enables itself from its `-march` macro
-and `usearch_include_wrapper_internal.h` forces the SimSIMD targets the encoding needs:
-`HASWELL` and `SKYLAKE`. Forcing a target is safe -- each kernel carries its own target attribute
-so it compiles under the Ivy Bridge baseline, and `simsimd_capabilities()` dispatches on CPUID, so
-a kernel the host cannot run is never called.
+and `usearch_include_wrapper_internal.h` forces the three SimSIMD targets the encodings need:
+`HASWELL`, `SKYLAKE` and `ICE`. Forcing a target is safe -- each kernel carries its own target
+attribute so it compiles under the Ivy Bridge baseline, and `simsimd_capabilities()` dispatches
+on CPUID, so a kernel the host cannot run is never called.
 
-`float16` distances use the 256-bit `*_f16_haswell` kernels, which widen each coordinate to fp32
-and accumulate there. The `#define`s reach only translation units including
-`usearch_include_wrapper_internal.h`, directly or through `hnsw.h`: 5 production files, all
-vector-index code, plus 4 tests. `hnsw.h` is included by no other header, so nothing in
-`tserver`, `master`, `rocksdb` or `postgres` is reached. Vector indexes are YSQL-only, so none of
-this can reach a YCQL workload.
+`ICE` is what the narrowed encodings depend on: SimSIMD has no `*_i8_skylake`, so without it the
+`int8` ladder drops from AVX-512 straight to the 256-bit Haswell kernels while `float32` keeps a
+512-bit one. `cos/l2sq/dot_i8_ice` accumulate into `int32` exactly as the Haswell kernels do, so
+they are bit-identical and cost no accuracy. `float16` distances use the 256-bit `*_f16_haswell`
+kernels, which widen each coordinate to fp32 and accumulate there -- which is why `float16` buys
+less throughput than its byte count suggests.
+
+The `#define`s reach only translation units including `usearch_include_wrapper_internal.h`,
+directly or through `hnsw.h`: 5 production files, all vector-index code, plus 4 tests. `hnsw.h` is
+included by no other header, so nothing in `tserver`, `master`, `rocksdb` or `postgres` is
+reached. Vector indexes are YSQL-only, so none of this can reach a YCQL workload. `int32`
+accumulator headroom for `int8` is 8.3x: saturation needs `d > 133,144` against a
+`VECTOR_MAX_DIM` of 16,000.
 
 ## Caveats
 
@@ -152,3 +221,5 @@ this can reach a YCQL workload.
 - **The prefetch is not earning its place.** Isolated at `float32` it straddles zero
   (+4.9%/+2.1% RF3, -3.4%/-4.9% RF1). It should either be shown to pay on some workload or be
   turned off.
+- **The `int32` overflow bound is implicit.** The 8.3x headroom follows from `VECTOR_MAX_DIM`; no
+  assertion ties them together, so raising that limit past ~133,000 needs it rechecked.

--- a/src/yb/ann_methods/CMakeLists.txt
+++ b/src/yb/ann_methods/CMakeLists.txt
@@ -42,4 +42,5 @@ set(YB_TEST_LINK_LIBS ann_methods ann_methods_test_proto yrpc hnsw_test_util ${Y
 
 ADD_YB_TEST(index_merge-test)
 ADD_YB_TEST(vector_index_perf-test)
+ADD_YB_TEST(yb_hnsw_storage-test)
 ADD_YB_TEST(vector_lsm-test)

--- a/src/yb/ann_methods/usearch_wrapper.cc
+++ b/src/yb/ann_methods/usearch_wrapper.cc
@@ -137,7 +137,7 @@ class UsearchIndex :
         block_cache_(block_cache),
         dimensions_(options.dimensions),
         distance_kind_(options.distance_kind),
-        metric_(options.CreateMetric<Vector>()),
+        metric_(options.CreateBuildMetric<Vector>()),
         backend_(backend),
         index_(IndexImpl::make(metric_, CreateIndexDenseConfig(options))) {
     CHECK_GT(dimensions_, 0);
@@ -374,7 +374,7 @@ class UsearchIndexTraits :
       const MemTrackerPtr& mem_tracker)
       : block_cache_(block_cache), options_(options), backend_(backend),
         mem_tracker_(mem_tracker),
-        metric_(options.CreateMetric<Vector>()) {
+        metric_(options.CreateBuildMetric<Vector>()) {
     LOG_IF(DFATAL, backend != HnswBackend::USEARCH && backend != HnswBackend::YB_HNSW_USEARCH) <<
         "Invalid backend for usearch index: " << HnswBackend_Name(backend);
   }

--- a/src/yb/ann_methods/vector_index_perf-test.cc
+++ b/src/yb/ann_methods/vector_index_perf-test.cc
@@ -17,6 +17,7 @@
 #include "yb/ann_methods/hnswlib_wrapper.h"
 #include "yb/ann_methods/usearch_wrapper.h"
 
+#include "yb/util/env.h"
 #include "yb/util/size_literals.h"
 
 namespace yb::ann_methods {
@@ -44,6 +45,11 @@ class VectorIndexPerfTest : public hnsw::VectorIndexTestBase {
     vector_index::HNSWOptions options = {
       .dimensions = dimensions_,
     };
+    // Same options apart from the on-disk encoding, so the graph built in RAM is identical and
+    // the set isolates what narrowing the served records costs.
+    auto float16_options = options;
+    float16_options.storage_kind = vector_index::VectorStorageKind::kFloat16;
+
     indexes_.emplace_back(
         "usearch",
         ASSERT_RESULT((CreateUsearchIndexTraits<Vector, DistanceResult>(
@@ -53,6 +59,11 @@ class VectorIndexPerfTest : public hnsw::VectorIndexTestBase {
         "hnswlib",
         ASSERT_RESULT((CreateHnswlibIndexTraits<Vector, DistanceResult>(
             block_cache_, options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)))
+            ->Create(vector_index::FactoryMode::kCreate, vector_index::StoreVectorPayload::kFalse));
+    indexes_.emplace_back(
+        "hnswlib_f16_source",
+        ASSERT_RESULT((CreateHnswlibIndexTraits<Vector, DistanceResult>(
+            block_cache_, float16_options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)))
             ->Create(vector_index::FactoryMode::kCreate, vector_index::StoreVectorPayload::kFalse));
     for (const auto& [_, index] : indexes_) {
       ASSERT_OK(index->Reserve(
@@ -66,11 +77,20 @@ class VectorIndexPerfTest : public hnsw::VectorIndexTestBase {
 
     indexes_.emplace_back(
         "yb_hnsw",
-        ASSERT_RESULT(indexes_.front().second->SaveToFile(GetTestPath("0.yb_hnsw"))));
+        ASSERT_RESULT(indexes_[0].second->SaveToFile(GetTestPath("0.yb_hnsw"))));
 
     indexes_.emplace_back(
         "yb_hnsw_hnswlib",
         ASSERT_RESULT(indexes_[1].second->SaveToFile(GetTestPath("1.yb_hnsw"))));
+
+    indexes_.emplace_back(
+        "yb_hnsw_hnswlib_f16",
+        ASSERT_RESULT(indexes_[2].second->SaveToFile(GetTestPath("2.yb_hnsw"))));
+
+    for (const auto& name : {"1.yb_hnsw", "2.yb_hnsw"}) {
+      LOG(INFO) << name << " size: "
+                << ASSERT_RESULT(Env::Default()->GetFileSize(GetTestPath(name)));
+    }
   }
 
   void InsertRandomVector(Vector& holder) {

--- a/src/yb/ann_methods/vector_index_perf-test.cc
+++ b/src/yb/ann_methods/vector_index_perf-test.cc
@@ -49,6 +49,9 @@ class VectorIndexPerfTest : public hnsw::VectorIndexTestBase {
     // the set isolates what narrowing the served records costs.
     auto float16_options = options;
     float16_options.storage_kind = vector_index::VectorStorageKind::kFloat16;
+    auto int8_options = options;
+    int8_options.storage_kind = vector_index::VectorStorageKind::kInt8;
+    int8_options.rerank_kind = vector_index::RerankStorageKind::kFloat16;
 
     indexes_.emplace_back(
         "usearch",
@@ -64,6 +67,11 @@ class VectorIndexPerfTest : public hnsw::VectorIndexTestBase {
         "hnswlib_f16_source",
         ASSERT_RESULT((CreateHnswlibIndexTraits<Vector, DistanceResult>(
             block_cache_, float16_options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)))
+            ->Create(vector_index::FactoryMode::kCreate, vector_index::StoreVectorPayload::kFalse));
+    indexes_.emplace_back(
+        "hnswlib_i8_source",
+        ASSERT_RESULT((CreateHnswlibIndexTraits<Vector, DistanceResult>(
+            block_cache_, int8_options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)))
             ->Create(vector_index::FactoryMode::kCreate, vector_index::StoreVectorPayload::kFalse));
     for (const auto& [_, index] : indexes_) {
       ASSERT_OK(index->Reserve(
@@ -87,7 +95,11 @@ class VectorIndexPerfTest : public hnsw::VectorIndexTestBase {
         "yb_hnsw_hnswlib_f16",
         ASSERT_RESULT(indexes_[2].second->SaveToFile(GetTestPath("2.yb_hnsw"))));
 
-    for (const auto& name : {"1.yb_hnsw", "2.yb_hnsw"}) {
+    indexes_.emplace_back(
+        "yb_hnsw_hnswlib_i8",
+        ASSERT_RESULT(indexes_[3].second->SaveToFile(GetTestPath("3.yb_hnsw"))));
+
+    for (const auto& name : {"1.yb_hnsw", "2.yb_hnsw", "3.yb_hnsw"}) {
       LOG(INFO) << name << " size: "
                 << ASSERT_RESULT(Env::Default()->GetFileSize(GetTestPath(name)));
     }

--- a/src/yb/ann_methods/yb_hnsw_storage-test.cc
+++ b/src/yb/ann_methods/yb_hnsw_storage-test.cc
@@ -35,6 +35,7 @@ namespace yb::ann_methods {
 
 using vector_index::FactoryMode;
 using vector_index::HNSWOptions;
+using vector_index::RerankStorageKind;
 using vector_index::StoreVectorPayload;
 using vector_index::VectorId;
 using vector_index::VectorIndexIfPtr;
@@ -49,19 +50,24 @@ class YbHnswStorageWrapperTest : public hnsw::VectorIndexTestBase {
     return 256_MB;
   }
 
-  HNSWOptions Options(VectorStorageKind storage_kind) const {
+  HNSWOptions Options(
+      VectorStorageKind storage_kind,
+      RerankStorageKind rerank_kind = RerankStorageKind::kNone) const {
     HNSWOptions options;
     options.dimensions = dimensions_;
     options.num_neighbors_per_vertex = 16;
     options.num_neighbors_per_vertex_base = 32;
     options.ef_construction = 100;
     options.storage_kind = storage_kind;
+    options.rerank_kind = rerank_kind;
     return options;
   }
 
   // Reopens the way a restart would: a fresh traits-factory instance that only saw the file.
-  IndexPtr BuildAndReload(VectorStorageKind storage_kind, const std::string& name) {
-    auto options = Options(storage_kind);
+  IndexPtr BuildAndReload(
+      VectorStorageKind storage_kind, const std::string& name,
+      RerankStorageKind rerank_kind = RerankStorageKind::kNone) {
+    auto options = Options(storage_kind, rerank_kind);
     auto traits = CHECK_RESULT((CreateHnswlibIndexTraits<FloatVector, DistanceResult>(
         block_cache_, options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)));
 
@@ -89,6 +95,11 @@ class YbHnswStorageWrapperTest : public hnsw::VectorIndexTestBase {
     for (size_t i = 0; i != count; ++i) {
       ids_.push_back(VectorId::GenerateRandom());
     }
+  }
+
+  // The shipping int8 configuration.
+  IndexPtr BuildAndReloadInt8(const std::string& name) {
+    return BuildAndReload(VectorStorageKind::kInt8, name, RerankStorageKind::kFloat16);
   }
 
   vector_index::SearchOptions MakeSearchOptions(size_t max_results, size_t ef = 64) const {
@@ -224,6 +235,226 @@ TEST_F(YbHnswStorageWrapperTest, SearchAgreesWithFullPrecision) {
   const double overlap = static_cast<double>(common) / (kNumQueries * kMaxResults);
   LOG(INFO) << "float16 top-" << kMaxResults << " overlap with float32: " << overlap;
   ASSERT_GE(overlap, 0.9);
+}
+
+
+// The hazard the two-tier record exists to avoid: a merged chunk derives its own scale, so
+// decoding int8 would feed already-quantized values into a fresh quantization and lose more on
+// every merge. The rerank copy round-trips exactly.
+TEST_F(YbHnswStorageWrapperTest, IterationReadsTheRerankCopy) {
+  constexpr size_t kNumVectors = 500;
+  dimensions_ = 24;
+  GenerateVectors(kNumVectors);
+
+  auto index = BuildAndReloadInt8("iter_i8.yb_hnsw");
+  ASSERT_EQ(index->Size(), kNumVectors);
+
+  size_t count = 0;
+  double worst_error = 0;
+  for (const auto& entry : *index) {
+    ASSERT_EQ(entry.vector.size(), dimensions_);
+    auto it = std::find(ids_.begin(), ids_.end(), entry.vector_id);
+    ASSERT_NE(it, ids_.end()) << "unknown id from iteration: " << entry.vector_id;
+    const auto& original = vectors_[it - ids_.begin()];
+
+    // Exact float16 equality, not a tolerance: an int8 decode would be off by up to half a
+    // quantization step, orders of magnitude more.
+    std::vector<std::byte> narrowed(
+        vector_index::CoordinateBytes(VectorStorageKind::kFloat16, dimensions_));
+    vector_index::NarrowCoordinates(
+        VectorStorageKind::kFloat16, original.data(), dimensions_, narrowed.data());
+    hnsw::Vector expected(dimensions_);
+    vector_index::WidenCoordinates(
+        VectorStorageKind::kFloat16, narrowed.data(), dimensions_, expected.data());
+    ASSERT_EQ(expected, entry.vector) << "id " << entry.vector_id;
+
+    for (size_t i = 0; i != dimensions_; ++i) {
+      worst_error = std::max<double>(worst_error, std::fabs(entry.vector[i] - original[i]));
+    }
+    ++count;
+  }
+  ASSERT_EQ(count, kNumVectors);
+  LOG(INFO) << "worst absolute coordinate error from iteration: " << worst_error;
+}
+
+// Feeding iteration's output back through a fresh chunk models a merge; repeating it would
+// expose compounding error.
+TEST_F(YbHnswStorageWrapperTest, Int8SurvivesRepeatedCompaction) {
+  constexpr size_t kNumVectors = 300;
+  constexpr size_t kGenerations = 4;
+  dimensions_ = 32;
+  GenerateVectors(kNumVectors);
+
+  std::map<VectorId, hnsw::Vector> previous;
+  for (size_t generation = 0; generation != kGenerations; ++generation) {
+    auto index = BuildAndReloadInt8(Format("gen_$0.yb_hnsw", generation));
+
+    std::map<VectorId, hnsw::Vector> current;
+    for (const auto& entry : *index) {
+      ASSERT_TRUE(current.emplace(entry.vector_id, entry.vector).second) << entry.vector_id;
+    }
+    ASSERT_EQ(current.size(), kNumVectors);
+
+    if (generation != 0) {
+      // Bit-identical across generations is the fixed point. Per id so a failure names the
+      // vector that drifted rather than dumping the chunk.
+      for (const auto& [vector_id, vector] : current) {
+        auto it = previous.find(vector_id);
+        ASSERT_NE(it, previous.end()) << "generation " << generation << " lost " << vector_id;
+        ASSERT_EQ(vector, it->second)
+            << "generation " << generation << " drifted for " << vector_id;
+      }
+    }
+    previous = std::move(current);
+
+    // Built from stored records rather than the originals, as a real compaction does.
+    for (size_t i = 0; i != kNumVectors; ++i) {
+      vectors_[i] = previous[ids_[i]];
+    }
+  }
+}
+
+// Distance() feeds VectorLSM's comparison of in-flight vectors against chunk results, so it must
+// be in the metric's units; the int8 metric returns quantized units, meaningful in one chunk.
+TEST_F(YbHnswStorageWrapperTest, Int8DistanceUsesTheRerankMetric) {
+  dimensions_ = 16;
+  GenerateVectors(200);
+
+  auto f32 = BuildAndReload(VectorStorageKind::kFloat32, "dist_f32.yb_hnsw");
+  auto f16 = BuildAndReload(VectorStorageKind::kFloat16, "dist_f16.yb_hnsw");
+  auto i8 = BuildAndReloadInt8("dist_i8.yb_hnsw");
+
+  for (size_t i = 0; i != 50; ++i) {
+    const auto& lhs = vectors_[i];
+    const auto& rhs = vectors_[(i + 37) % vectors_.size()];
+
+    const auto exact = f32->Distance(lhs, rhs);
+    ASSERT_GT(exact, 0.0f) << "pair " << i;
+
+    // Agrees with float16 to the bit, because that is the metric it uses.
+    ASSERT_EQ(i8->Distance(lhs, rhs), f16->Distance(lhs, rhs)) << "pair " << i;
+    // So within float16's error of full precision, not int8's.
+    ASSERT_LE(std::fabs(i8->Distance(lhs, rhs) - exact) / exact, 0.01) << "pair " << i;
+    ASSERT_EQ(i8->Distance(lhs, lhs), 0.0f) << "pair " << i;
+  }
+}
+
+// Two chunks of one index hold different scales, so a query quantized with a cached or shared
+// scale would decode one of them wrong.
+TEST_F(YbHnswStorageWrapperTest, ScalesDifferAcrossChunks) {
+  constexpr size_t kNumVectors = 300;
+  dimensions_ = 16;
+
+  // Two chunks whose coordinate ranges differ by two orders of magnitude.
+  GenerateVectors(kNumVectors);
+  auto narrow_range = vectors_;
+  auto wide_range = vectors_;
+  for (auto& vector : wide_range) {
+    for (auto& coordinate : vector) {
+      coordinate *= 100.0f;
+    }
+  }
+
+  vectors_ = narrow_range;
+  auto small = BuildAndReloadInt8("scale_small.yb_hnsw");
+  vectors_ = wide_range;
+  auto large = BuildAndReloadInt8("scale_large.yb_hnsw");
+
+  // A query from a chunk's own range finds its exact match at zero only if quantized with that
+  // chunk's scale.
+  for (size_t i = 0; i != 20; ++i) {
+    auto from_small = ASSERT_RESULT(small->Search(narrow_range[i], MakeSearchOptions(1, 200)));
+    ASSERT_EQ(from_small.size(), 1);
+    ASSERT_EQ(from_small.front().distance, 0.0f) << "narrow-range vector " << i;
+
+    auto from_large = ASSERT_RESULT(large->Search(wide_range[i], MakeSearchOptions(1, 200)));
+    ASSERT_EQ(from_large.size(), 1);
+    ASSERT_EQ(from_large.front().distance, 0.0f) << "wide-range vector " << i;
+  }
+
+  // Reranking puts both into the metric's units regardless of scale, so VectorLSM can merge.
+  const auto small_self = small->Distance(narrow_range[0], narrow_range[1]);
+  const auto large_self = large->Distance(wide_range[0], wide_range[1]);
+  // wide_range is narrow_range scaled by 100, so L2 squared is 10000x.
+  ASSERT_LE(std::fabs(large_self / small_self - 10000.0) / 10000.0, 0.01)
+      << "small: " << small_self << ", large: " << large_self;
+}
+
+// Why the encoding is shippable: int8 traversal alone loses recall; reranking recovers it.
+TEST_F(YbHnswStorageWrapperTest, Int8SearchAgreesWithFullPrecision) {
+  constexpr size_t kNumVectors = 4000;
+  constexpr size_t kNumQueries = 200;
+  constexpr size_t kMaxResults = 10;
+
+  dimensions_ = 64;
+  GenerateVectors(kNumVectors);
+
+  auto f32 = BuildAndReload(VectorStorageKind::kFloat32, "search_f32.yb_hnsw");
+  auto f16 = BuildAndReload(VectorStorageKind::kFloat16, "search_f16.yb_hnsw");
+  auto i8 = BuildAndReloadInt8("search_i8.yb_hnsw");
+  auto i8_bare = BuildAndReload(VectorStorageKind::kInt8, "search_i8_bare.yb_hnsw");
+
+  size_t common_f16 = 0, common_i8 = 0, common_bare = 0;
+  for (size_t i = 0; i != kNumQueries; ++i) {
+    auto query = RandomVector();
+    auto options = MakeSearchOptions(kMaxResults);
+    auto from_f32 = ASSERT_RESULT(f32->Search(query, options));
+    ASSERT_EQ(from_f32.size(), kMaxResults);
+
+    std::set<VectorId> f32_ids;
+    for (const auto& entry : from_f32) {
+      f32_ids.insert(entry.vector_id);
+    }
+
+    for (auto [index, common] : std::initializer_list<std::pair<IndexPtr*, size_t*>>{
+             {&f16, &common_f16}, {&i8, &common_i8}, {&i8_bare, &common_bare}}) {
+      auto results = ASSERT_RESULT((*index)->Search(query, options));
+      ASSERT_EQ(results.size(), kMaxResults);
+      for (const auto& entry : results) {
+        *common += f32_ids.contains(entry.vector_id);
+        ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+      }
+    }
+  }
+
+  const double denominator = kNumQueries * kMaxResults;
+  const double f16_overlap = common_f16 / denominator;
+  const double i8_overlap = common_i8 / denominator;
+  const double bare_overlap = common_bare / denominator;
+  LOG(INFO) << "top-" << kMaxResults << " overlap with float32: float16 " << f16_overlap
+            << ", int8 + float16 rerank " << i8_overlap << ", int8 alone " << bare_overlap;
+
+  ASSERT_GE(f16_overlap, 0.9);
+  // float16 is the ceiling. That the rerank ran is asserted below by the distance's units, not
+  // by a recall gap against `bare`, which depends on the data.
+  ASSERT_GE(i8_overlap, f16_overlap - 0.02);
+
+  // Proves the rerank ran: each distance must be exactly what the float16 index gives, which is
+  // what MakeResult computes. Without the tier the quantized distance is reported.
+  std::map<VectorId, size_t> index_by_id;
+  for (size_t i = 0; i != ids_.size(); ++i) {
+    index_by_id.emplace(ids_[i], i);
+  }
+  for (size_t i = 0; i != 20; ++i) {
+    auto query = RandomVector();
+    auto options = MakeSearchOptions(kMaxResults);
+    auto reranked = ASSERT_RESULT(i8->Search(query, options));
+    auto quantized = ASSERT_RESULT(i8_bare->Search(query, options));
+    ASSERT_EQ(reranked.size(), kMaxResults);
+    ASSERT_EQ(quantized.size(), kMaxResults);
+
+    for (const auto& entry : reranked) {
+      auto it = index_by_id.find(entry.vector_id);
+      ASSERT_NE(it, index_by_id.end()) << entry;
+      ASSERT_EQ(entry.distance, f16->Distance(query, vectors_[it->second]))
+          << "reported distance is not the float16 metric's: " << entry;
+    }
+    const auto& nearest = quantized.front();
+    auto it = index_by_id.find(nearest.vector_id);
+    ASSERT_NE(it, index_by_id.end()) << nearest;
+    ASSERT_NE(nearest.distance, f16->Distance(query, vectors_[it->second]))
+        << "un-reranked search reported a float16 distance: " << nearest;
+  }
 }
 
 }  // namespace yb::ann_methods

--- a/src/yb/ann_methods/yb_hnsw_storage-test.cc
+++ b/src/yb/ann_methods/yb_hnsw_storage-test.cc
@@ -1,0 +1,229 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+// Narrowed storage through the VectorIndexIf stack -- the path a VectorLSM chunk takes. What
+// matters is reading stored records back: iteration (how compaction consumes source chunks) and
+// Distance (which callers reach with full-precision vectors).
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <set>
+
+#include "yb/ann_methods/hnswlib_wrapper.h"
+
+#include "yb/hnsw/hnsw_block_cache.h"
+#include "yb/hnsw/vector_index_test_base.h"
+
+#include "yb/util/size_literals.h"
+#include "yb/util/status_log.h"
+#include "yb/util/test_util.h"
+
+#include "yb/vector_index/coordinate_codec.h"
+#include "yb/vector_index/vector_index_if.h"
+
+namespace yb::ann_methods {
+
+using vector_index::FactoryMode;
+using vector_index::HNSWOptions;
+using vector_index::StoreVectorPayload;
+using vector_index::VectorId;
+using vector_index::VectorIndexIfPtr;
+using vector_index::VectorStorageKind;
+
+using DistanceResult = float;
+using IndexPtr = VectorIndexIfPtr<FloatVector, DistanceResult>;
+
+class YbHnswStorageWrapperTest : public hnsw::VectorIndexTestBase {
+ protected:
+  size_t BlockCacheCapacity() override {
+    return 256_MB;
+  }
+
+  HNSWOptions Options(VectorStorageKind storage_kind) const {
+    HNSWOptions options;
+    options.dimensions = dimensions_;
+    options.num_neighbors_per_vertex = 16;
+    options.num_neighbors_per_vertex_base = 32;
+    options.ef_construction = 100;
+    options.storage_kind = storage_kind;
+    return options;
+  }
+
+  // Reopens the way a restart would: a fresh traits-factory instance that only saw the file.
+  IndexPtr BuildAndReload(VectorStorageKind storage_kind, const std::string& name) {
+    auto options = Options(storage_kind);
+    auto traits = CHECK_RESULT((CreateHnswlibIndexTraits<FloatVector, DistanceResult>(
+        block_cache_, options, HnswBackend::YB_HNSW_HNSWLIB, mem_tracker_)));
+
+    // These tests cover the coordinate encodings, not payloads.
+    auto mutable_index = traits->Create(FactoryMode::kCreate, StoreVectorPayload::kFalse);
+    CHECK_OK(mutable_index->Reserve(
+        vectors_.size(), 1, 1, rocksdb::Cache::ReservationMode::kAlways));
+    for (size_t i = 0; i != vectors_.size(); ++i) {
+      CHECK_OK(mutable_index->Insert(ids_[i], vectors_[i], Slice()));
+    }
+
+    const auto path = GetTestPath(name);
+    // Drop SaveToFile's return and go through the load factory, covering restart not flush.
+    CHECK_RESULT(mutable_index->SaveToFile(path));
+
+    auto loaded = traits->Create(FactoryMode::kLoad, StoreVectorPayload::kFalse);
+    CHECK_OK(loaded->LoadFromFile(path, 1));
+    return loaded;
+  }
+
+  void GenerateVectors(size_t count) {
+    vectors_ = RandomVectors(count);
+    ids_.clear();
+    ids_.reserve(count);
+    for (size_t i = 0; i != count; ++i) {
+      ids_.push_back(VectorId::GenerateRandom());
+    }
+  }
+
+  vector_index::SearchOptions MakeSearchOptions(size_t max_results, size_t ef = 64) const {
+    return vector_index::SearchOptions {
+      .max_num_results = max_results,
+      .ef = ef,
+    };
+  }
+
+  std::vector<hnsw::Vector> vectors_;
+  std::vector<VectorId> ids_;
+  MemTrackerPtr mem_tracker_ =
+      MemTracker::GetRootTracker()->FindOrCreateTracker(1_GB, "yb_hnsw_storage_test");
+};
+
+// MergingIterator reads every source chunk through this on every compaction, and reading
+// float32-wide from a float16 record would run off the end of each one.
+TEST_F(YbHnswStorageWrapperTest, IterationDecodesNarrowedRecords) {
+  constexpr size_t kNumVectors = 500;
+  dimensions_ = 24;
+  GenerateVectors(kNumVectors);
+
+  for (auto storage_kind : {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16}) {
+    auto index = BuildAndReload(storage_kind, Format("iter_$0.yb_hnsw", storage_kind));
+    ASSERT_EQ(index->Size(), kNumVectors) << storage_kind;
+
+    std::map<VectorId, hnsw::Vector> seen;
+    for (const auto& entry : *index) {
+      ASSERT_EQ(entry.vector.size(), dimensions_) << storage_kind;
+      ASSERT_TRUE(seen.emplace(entry.vector_id, entry.vector).second)
+          << "duplicate id from iteration: " << entry.vector_id << ", " << storage_kind;
+    }
+    ASSERT_EQ(seen.size(), kNumVectors) << storage_kind;
+
+    // The invariant that keeps compaction from degrading an index over time.
+    for (size_t i = 0; i != kNumVectors; ++i) {
+      auto it = seen.find(ids_[i]);
+      ASSERT_NE(it, seen.end()) << "missing id " << ids_[i] << ", " << storage_kind;
+
+      std::vector<std::byte> narrowed(
+          vector_index::CoordinateBytes(storage_kind, dimensions_));
+      vector_index::NarrowCoordinates(
+          storage_kind, vectors_[i].data(), dimensions_, narrowed.data());
+      hnsw::Vector expected(dimensions_);
+      vector_index::WidenCoordinates(
+          storage_kind, narrowed.data(), dimensions_, expected.data());
+
+      ASSERT_EQ(expected, it->second) << "vector " << i << ", " << storage_kind;
+    }
+  }
+}
+
+// Re-narrowing iteration's output must reproduce the same bytes, or precision drifts per merge.
+TEST_F(YbHnswStorageWrapperTest, CompactionRoundTripIsStable) {
+  dimensions_ = 32;
+  GenerateVectors(400);
+
+  auto index = BuildAndReload(VectorStorageKind::kFloat16, "roundtrip.yb_hnsw");
+
+  auto narrow = [this](const hnsw::Vector& vector) {
+    std::vector<std::byte> out(
+        vector_index::CoordinateBytes(VectorStorageKind::kFloat16, dimensions_));
+    vector_index::NarrowCoordinates(
+        VectorStorageKind::kFloat16, vector.data(), dimensions_, out.data());
+    return out;
+  };
+
+  for (const auto& entry : *index) {
+    // entry.vector came out of a float16 record, so narrowing it again must be a no-op.
+    std::vector<std::byte> widened_then_narrowed = narrow(entry.vector);
+    hnsw::Vector again(dimensions_);
+    vector_index::WidenCoordinates(
+        VectorStorageKind::kFloat16, widened_then_narrowed.data(), dimensions_, again.data());
+    ASSERT_EQ(entry.vector, again) << entry.vector_id;
+  }
+}
+
+// Distance() takes full-precision vectors but the metric decodes stored records, so it must
+// narrow its arguments or it compares float32 bytes with a float16 metric.
+TEST_F(YbHnswStorageWrapperTest, DistanceNarrowsFullPrecisionArguments) {
+  dimensions_ = 16;
+  GenerateVectors(200);
+
+  auto f32 = BuildAndReload(VectorStorageKind::kFloat32, "dist_f32.yb_hnsw");
+  auto f16 = BuildAndReload(VectorStorageKind::kFloat16, "dist_f16.yb_hnsw");
+
+  for (size_t i = 0; i != 50; ++i) {
+    const auto& lhs = vectors_[i];
+    const auto& rhs = vectors_[(i + 37) % vectors_.size()];
+
+    const auto exact = f32->Distance(lhs, rhs);
+    const auto narrowed = f16->Distance(lhs, rhs);
+
+    ASSERT_TRUE(std::isfinite(narrowed)) << "pair " << i;
+    ASSERT_GT(exact, 0.0f) << "pair " << i;
+    ASSERT_LE(std::fabs(narrowed - exact) / exact, 0.01) << "pair " << i;
+
+    // A vector against itself is exactly zero under either encoding.
+    ASSERT_EQ(f16->Distance(lhs, lhs), 0.0f) << "pair " << i;
+  }
+}
+
+// End to end: the loaded index answers searches and top results still agree with full precision.
+TEST_F(YbHnswStorageWrapperTest, SearchAgreesWithFullPrecision) {
+  constexpr size_t kNumVectors = 4000;
+  constexpr size_t kNumQueries = 200;
+  constexpr size_t kMaxResults = 10;
+
+  dimensions_ = 64;
+  GenerateVectors(kNumVectors);
+
+  auto f32 = BuildAndReload(VectorStorageKind::kFloat32, "search_f32.yb_hnsw");
+  auto f16 = BuildAndReload(VectorStorageKind::kFloat16, "search_f16.yb_hnsw");
+
+  size_t common = 0;
+  for (size_t i = 0; i != kNumQueries; ++i) {
+    auto query = RandomVector();
+    auto from_f32 = ASSERT_RESULT(f32->Search(query, MakeSearchOptions(kMaxResults)));
+    auto from_f16 = ASSERT_RESULT(f16->Search(query, MakeSearchOptions(kMaxResults)));
+    ASSERT_EQ(from_f32.size(), kMaxResults);
+    ASSERT_EQ(from_f16.size(), kMaxResults);
+
+    std::set<VectorId> f32_ids;
+    for (const auto& entry : from_f32) {
+      f32_ids.insert(entry.vector_id);
+    }
+    for (const auto& entry : from_f16) {
+      common += f32_ids.contains(entry.vector_id);
+      ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+    }
+  }
+
+  const double overlap = static_cast<double>(common) / (kNumQueries * kMaxResults);
+  LOG(INFO) << "float16 top-" << kMaxResults << " overlap with float32: " << overlap;
+  ASSERT_GE(overlap, 0.9);
+}
+
+}  // namespace yb::ann_methods

--- a/src/yb/ann_methods/yb_hnsw_wrapper.cc
+++ b/src/yb/ann_methods/yb_hnsw_wrapper.cc
@@ -19,6 +19,7 @@
 #include "yb/util/scope_exit.h"
 #include "yb/util/status_format.h"
 
+#include "yb/vector_index/coordinate_codec.h"
 #include "yb/vector_index/index_wrapper_base.h"
 
 namespace yb::ann_methods {
@@ -28,6 +29,7 @@ namespace {
 using vector_index::IndexableVectorType;
 using vector_index::VectorId;
 using vector_index::ValidDistanceResultType;
+using vector_index::VectorStorageKind;
 
 template<IndexableVectorType Vector>
 class YbHnswIterator : public AbstractIterator<vector_index::VectorIndexIteratorEntry<Vector>> {
@@ -36,7 +38,7 @@ class YbHnswIterator : public AbstractIterator<vector_index::VectorIndexIterator
   using Base = AbstractIterator<ValueType>;
 
   YbHnswIterator(const hnsw::YbHnsw& hnsw, size_t index)
-      : cache_scope_(cache_, hnsw), dimensions_(hnsw.header().dimensions), index_(index) {
+      : cache_scope_(cache_, hnsw), header_(hnsw.header()), index_(index) {
   }
 
   void Next() override {
@@ -44,13 +46,16 @@ class YbHnswIterator : public AbstractIterator<vector_index::VectorIndexIterator
   }
 
   ValueType Dereference() const override {
-    const auto* coordinates = cache_.CoordinatesPtr(index_);
     ValueType result;
     auto [vector_id, payload] = cache_.GetVectorIdAndPayload(index_);
     result.vector_id = vector_id;
-    result.vector.resize(dimensions_);
-    memcpy(result.vector.data(), coordinates, dimensions_ * sizeof(typename Vector::value_type));
     result.payload = payload;
+    result.vector.resize(header_.dimensions);
+    // Records may be narrower than Vector::value_type, so this decodes rather than copies; a
+    // memcpy would walk past the end of each record.
+    vector_index::WidenCoordinates(
+        header_.storage_kind, cache_.CoordinatesPtr(index_), header_.dimensions,
+        result.vector.data());
     return result;
   }
 
@@ -62,7 +67,7 @@ class YbHnswIterator : public AbstractIterator<vector_index::VectorIndexIterator
  private:
   mutable hnsw::SearchCache cache_;
   hnsw::SearchCacheScope cache_scope_;
-  const size_t dimensions_;
+  const hnsw::Header& header_;
   size_t index_;
 };
 
@@ -92,9 +97,12 @@ class YbHnswIndex :
 
   Status Import(
       const hnsw::HnswlibIndex<DistanceResult>& index, const std::string& path,
-      const vector_index::VectorPayloadMap* payloads) {
-    VLOG_WITH_FUNC(3) << "index: " << index.cur_element_count << ", path: " << path;
-    return index_.Import(index, path, payloads);
+      const vector_index::VectorPayloadMap* payloads,
+      VectorStorageKind storage_kind) {
+    VLOG_WITH_FUNC(3)
+        << "index: " << index.cur_element_count << ", path: " << path
+        << ", storage_kind: " << storage_kind;
+    return index_.Import(index, path, payloads, storage_kind);
   }
 
   std::unique_ptr<AbstractIterator<vector_index::VectorIndexIteratorEntry<Vector>>> BeginImpl()
@@ -133,8 +141,21 @@ class YbHnswIndex :
   }
 
   DistanceResult Distance(const Vector& lhs, const Vector& rhs) const override {
-    return index_.Distance(
-        pointer_cast<const std::byte*>(lhs.data()), pointer_cast<const std::byte*>(rhs.data()));
+    const auto& header = index_.header();
+    if (header.storage_kind == VectorStorageKind::kFloat32) {
+      return index_.Distance(
+          pointer_cast<const std::byte*>(lhs.data()), pointer_cast<const std::byte*>(rhs.data()));
+    }
+    // The metric decodes this file's encoding, so full-precision arguments must go through the
+    // same narrowing the stored records did. Cold path (SearchExact and tests), so a scratch
+    // allocation per call is fine.
+    const auto bytes = vector_index::CoordinateBytes(header.storage_kind, header.dimensions);
+    std::vector<std::byte> buffer(bytes * 2);
+    vector_index::NarrowCoordinates(
+        header.storage_kind, lhs.data(), header.dimensions, buffer.data());
+    vector_index::NarrowCoordinates(
+        header.storage_kind, rhs.data(), header.dimensions, buffer.data() + bytes);
+    return index_.Distance(buffer.data(), buffer.data() + bytes);
   }
 
   Result<Vector> GetVector(VectorId vector_id) const override {
@@ -182,14 +203,25 @@ class YbHnswIndex :
   mutable LockFreeStack<SearchContextHolder> search_contexts_;
 };
 
+// Builds metrics from `options` for whichever encoding YbHnsw asks about: what Import is about
+// to write, or what Init read from a file's footer.
+hnsw::YbHnsw::MetricFactory MakeMetricFactory(const vector_index::HNSWOptions& options) {
+  return [options](size_t dimensions, VectorStorageKind storage_kind) {
+    return std::make_unique<hnsw::UsearchMetric>(
+        options.CreateStoredMetric(dimensions, storage_kind));
+  };
+}
+
 } // namespace
 
 template <class Vector, class DistanceResult>
 Result<vector_index::VectorIndexIfPtr<Vector, DistanceResult>> ImportYbHnsw(
     const unum::usearch::index_dense_gt<vector_index::VectorId>& index, const std::string& path,
     const hnsw::BlockCachePtr& block_cache, const vector_index::VectorPayloadMap* payloads) {
+  // The usearch index owns its own float32 metric; narrowed storage is not wired through this
+  // backend, so the chunk is written and served at full precision.
   auto result = std::make_shared<YbHnswIndex<Vector, DistanceResult>>(
-      std::make_unique<hnsw::UsearchMetric>(index.metric()), block_cache);
+      index.metric(), block_cache);
   RETURN_NOT_OK(result->Import(index, path, payloads));
   return result;
 }
@@ -200,8 +232,9 @@ Result<vector_index::VectorIndexIfPtr<Vector, DistanceResult>> ImportYbHnsw(
     const hnsw::BlockCachePtr& block_cache, const vector_index::HNSWOptions& options,
     const vector_index::VectorPayloadMap* payloads) {
   auto result = std::make_shared<YbHnswIndex<Vector, DistanceResult>>(
-      std::make_unique<hnsw::UsearchMetric>(options.CreateMetric<Vector>()), block_cache);
-  RETURN_NOT_OK(result->Import(index, path, payloads));
+      MakeMetricFactory(options), block_cache);
+  RETURN_NOT_OK(
+      result->Import(index, path, payloads, options.storage_kind));
   return result;
 }
 
@@ -220,7 +253,7 @@ template <class Vector, class DistanceResult>
 vector_index::VectorIndexIfPtr<Vector, DistanceResult> CreateYbHnsw(
     const hnsw::BlockCachePtr& block_cache, const vector_index::HNSWOptions& options) {
   return std::make_shared<YbHnswIndex<Vector, DistanceResult>>(
-      std::make_unique<hnsw::UsearchMetric>(options.CreateMetric<Vector>()), block_cache);
+      MakeMetricFactory(options), block_cache);
 }
 
 template

--- a/src/yb/ann_methods/yb_hnsw_wrapper.cc
+++ b/src/yb/ann_methods/yb_hnsw_wrapper.cc
@@ -53,9 +53,20 @@ class YbHnswIterator : public AbstractIterator<vector_index::VectorIndexIterator
     result.vector.resize(header_.dimensions);
     // Records may be narrower than Vector::value_type, so this decodes rather than copies; a
     // memcpy would walk past the end of each record.
-    vector_index::WidenCoordinates(
-        header_.storage_kind, cache_.CoordinatesPtr(index_), header_.dimensions,
-        result.vector.data());
+    //
+    // Where a rerank copy exists it is the one compaction must read. The traversal encoding may be
+    // quantized against a scale the merged chunk will not reuse, so decoding it would feed
+    // already-quantized values into a fresh quantization and compound the error once per
+    // compaction. The rerank encodings round trip exactly.
+    if (header_.rerank_kind != vector_index::RerankStorageKind::kNone) {
+      vector_index::WidenCoordinates(
+          vector_index::StorageKindForRerank(header_.rerank_kind),
+          cache_.RerankCoordinatesPtr(index_), header_.dimensions, result.vector.data());
+    } else {
+      vector_index::WidenCoordinates(
+          header_.storage_kind, header_.quantization_scale, cache_.CoordinatesPtr(index_),
+          header_.dimensions, result.vector.data());
+    }
     return result;
   }
 
@@ -98,11 +109,11 @@ class YbHnswIndex :
   Status Import(
       const hnsw::HnswlibIndex<DistanceResult>& index, const std::string& path,
       const vector_index::VectorPayloadMap* payloads,
-      VectorStorageKind storage_kind) {
+      VectorStorageKind storage_kind, vector_index::RerankStorageKind rerank_kind) {
     VLOG_WITH_FUNC(3)
         << "index: " << index.cur_element_count << ", path: " << path
-        << ", storage_kind: " << storage_kind;
-    return index_.Import(index, path, payloads, storage_kind);
+        << ", storage_kind: " << storage_kind << ", rerank_kind: " << rerank_kind;
+    return index_.Import(index, path, payloads, storage_kind, rerank_kind);
   }
 
   std::unique_ptr<AbstractIterator<vector_index::VectorIndexIteratorEntry<Vector>>> BeginImpl()
@@ -142,19 +153,42 @@ class YbHnswIndex :
 
   DistanceResult Distance(const Vector& lhs, const Vector& rhs) const override {
     const auto& header = index_.header();
+    // Compared against distances from other chunks -- VectorLSM scores the mutable chunk's
+    // in-flight vectors through it -- so it must be in the metric's own units. That means the
+    // rerank encoding and metric where a tier exists: a quantized traversal distance is only
+    // comparable within its own chunk.
+    //
+    // Cold path (SearchExact and tests), so a scratch allocation per call is fine.
+    if (header.rerank_kind != vector_index::RerankStorageKind::kNone) {
+      const auto kind = vector_index::StorageKindForRerank(header.rerank_kind);
+      if (kind == VectorStorageKind::kFloat32) {
+        return index_.RerankDistance(
+            pointer_cast<const std::byte*>(lhs.data()),
+            pointer_cast<const std::byte*>(rhs.data()));
+      }
+      // No rerank encoding quantizes, so none of them needs the scale.
+      const auto bytes = vector_index::CoordinateBytes(kind, header.dimensions);
+      std::vector<std::byte> buffer(bytes * 2);
+      vector_index::NarrowCoordinates(kind, lhs.data(), header.dimensions, buffer.data());
+      vector_index::NarrowCoordinates(
+          kind, rhs.data(), header.dimensions, buffer.data() + bytes);
+      return index_.RerankDistance(buffer.data(), buffer.data() + bytes);
+    }
+
     if (header.storage_kind == VectorStorageKind::kFloat32) {
       return index_.Distance(
           pointer_cast<const std::byte*>(lhs.data()), pointer_cast<const std::byte*>(rhs.data()));
     }
     // The metric decodes this file's encoding, so full-precision arguments must go through the
-    // same narrowing the stored records did. Cold path (SearchExact and tests), so a scratch
-    // allocation per call is fine.
+    // same narrowing the stored records did.
     const auto bytes = vector_index::CoordinateBytes(header.storage_kind, header.dimensions);
     std::vector<std::byte> buffer(bytes * 2);
     vector_index::NarrowCoordinates(
-        header.storage_kind, lhs.data(), header.dimensions, buffer.data());
+        header.storage_kind, header.quantization_scale, lhs.data(), header.dimensions,
+        buffer.data());
     vector_index::NarrowCoordinates(
-        header.storage_kind, rhs.data(), header.dimensions, buffer.data() + bytes);
+        header.storage_kind, header.quantization_scale, rhs.data(), header.dimensions,
+        buffer.data() + bytes);
     return index_.Distance(buffer.data(), buffer.data() + bytes);
   }
 
@@ -234,7 +268,7 @@ Result<vector_index::VectorIndexIfPtr<Vector, DistanceResult>> ImportYbHnsw(
   auto result = std::make_shared<YbHnswIndex<Vector, DistanceResult>>(
       MakeMetricFactory(options), block_cache);
   RETURN_NOT_OK(
-      result->Import(index, path, payloads, options.storage_kind));
+      result->Import(index, path, payloads, options.storage_kind, options.rerank_kind));
   return result;
 }
 

--- a/src/yb/common/common.proto
+++ b/src/yb/common/common.proto
@@ -141,11 +141,23 @@ enum HnswBackend {
   YB_HNSW_HNSWLIB = 3;
 };
 
+// Encoding of the coordinates a served vector index chunk stores on disk. Graph construction
+// always runs at full precision regardless.
+enum VectorStorageType {
+  STORAGE_FLOAT32 = 0;
+  STORAGE_FLOAT16 = 1;
+}
+
 message HnswIndexOptionsPB {
   optional uint32 m = 1;
   optional uint32 m0 = 2;
   optional uint32 ef_construction = 3;
   optional HnswBackend backend = 4;
+
+  // Fixed at CREATE INDEX. Chunks record their own encoding, so this only governs chunks
+  // written from now on; keeping it in the catalog is what makes every replica of an index
+  // agree instead of following each tserver's local flags.
+  optional VectorStorageType storage_type = 5 [ default = STORAGE_FLOAT32 ];
 }
 
 message PgVectorIdxOptionsPB {

--- a/src/yb/common/common.proto
+++ b/src/yb/common/common.proto
@@ -146,6 +146,9 @@ enum HnswBackend {
 enum VectorStorageType {
   STORAGE_FLOAT32 = 0;
   STORAGE_FLOAT16 = 1;
+  // int8 traversal coordinates plus a float16 rerank copy. Selects the pair, not just the
+  // traversal encoding: int8 alone loses recall no amount of ef recovers.
+  STORAGE_INT8 = 2;
 }
 
 message HnswIndexOptionsPB {

--- a/src/yb/docdb/doc_vector_index.cc
+++ b/src/yb/docdb/doc_vector_index.cc
@@ -106,6 +106,21 @@ vector_index::VectorStorageKind ConvertStorageKind(VectorStorageType storage_typ
       return vector_index::VectorStorageKind::kFloat32;
     case VectorStorageType::STORAGE_FLOAT16:
       return vector_index::VectorStorageKind::kFloat16;
+    case VectorStorageType::STORAGE_INT8:
+      return vector_index::VectorStorageKind::kInt8;
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageType, storage_type);
+}
+
+// The rerank tier is implied by the storage type rather than separately configurable: a quantizing
+// traversal encoding is not usable without one.
+vector_index::RerankStorageKind ConvertRerankKind(VectorStorageType storage_type) {
+  switch (storage_type) {
+    case VectorStorageType::STORAGE_FLOAT32: [[fallthrough]];
+    case VectorStorageType::STORAGE_FLOAT16:
+      return vector_index::RerankStorageKind::kNone;
+    case VectorStorageType::STORAGE_INT8:
+      return vector_index::RerankStorageKind::kFloat16;
   }
   FATAL_INVALID_ENUM_VALUE(VectorStorageType, storage_type);
 }
@@ -118,6 +133,7 @@ vector_index::HNSWOptions ConvertToHnswOptions(const PgVectorIdxOptionsPB& optio
     .ef_construction = options.hnsw().ef_construction(),
     .distance_kind = ConvertDistanceKind(options.dist_type()),
     .storage_kind = ConvertStorageKind(options.hnsw().storage_type()),
+    .rerank_kind = ConvertRerankKind(options.hnsw().storage_type()),
   };
 }
 

--- a/src/yb/docdb/doc_vector_index.cc
+++ b/src/yb/docdb/doc_vector_index.cc
@@ -100,6 +100,16 @@ vector_index::DistanceKind ConvertDistanceKind(PgVectorDistanceType dist_type) {
   FATAL_INVALID_ENUM_VALUE(PgVectorDistanceType, dist_type);
 }
 
+vector_index::VectorStorageKind ConvertStorageKind(VectorStorageType storage_type) {
+  switch (storage_type) {
+    case VectorStorageType::STORAGE_FLOAT32:
+      return vector_index::VectorStorageKind::kFloat32;
+    case VectorStorageType::STORAGE_FLOAT16:
+      return vector_index::VectorStorageKind::kFloat16;
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageType, storage_type);
+}
+
 vector_index::HNSWOptions ConvertToHnswOptions(const PgVectorIdxOptionsPB& options) {
   return {
     .dimensions = options.dimensions(),
@@ -107,6 +117,7 @@ vector_index::HNSWOptions ConvertToHnswOptions(const PgVectorIdxOptionsPB& optio
     .num_neighbors_per_vertex_base = options.hnsw().m0(),
     .ef_construction = options.hnsw().ef_construction(),
     .distance_kind = ConvertDistanceKind(options.dist_type()),
+    .storage_kind = ConvertStorageKind(options.hnsw().storage_type()),
   };
 }
 

--- a/src/yb/hnsw/hnsw-test.cc
+++ b/src/yb/hnsw/hnsw-test.cc
@@ -44,6 +44,7 @@ using namespace std::chrono_literals;
 using namespace yb::size_literals;
 
 DECLARE_bool(yb_hnsw_prefetch_neighbors);
+DECLARE_uint32(vector_index_rerank_overfetch_factor);
 
 METRIC_DEFINE_entity(table);
 
@@ -273,6 +274,7 @@ TEST_F(YbHnswTest, PrefetchMatchesSerialResolution) {
 // Narrowed coordinate storage
 // ------------------------------------------------------------------------------------------------
 
+using vector_index::RerankStorageKind;
 using vector_index::VectorStorageKind;
 
 namespace {
@@ -362,17 +364,23 @@ class YbHnswStorageTest : public VectorIndexTestBase {
 
   // With `reload`, the returned instance only ever saw the file -- i.e. a tserver restart.
   Result<std::unique_ptr<YbHnsw>> Import(
-      VectorStorageKind storage_kind, const std::string& name, bool reload = false) {
+      VectorStorageKind storage_kind, const std::string& name, bool reload = false,
+      RerankStorageKind rerank_kind = RerankStorageKind::kNone) {
     auto path = GetTestPath(name);
     auto result = std::make_unique<YbHnsw>(MakeMetricFactory(), block_cache_);
     // No payloads: keeps the 16-byte aux entry per vector this fixture's expectations assume.
     RETURN_NOT_OK(result->Import(
-        *hnswlib_index_, path, /* payloads= */ nullptr, storage_kind));
+        *hnswlib_index_, path, /* payloads= */ nullptr, storage_kind, rerank_kind));
     if (reload) {
       result = std::make_unique<YbHnsw>(MakeMetricFactory(), block_cache_);
       RETURN_NOT_OK(result->Init(path));
     }
     return result;
+  }
+
+  // The shipping int8 configuration: quantized traversal coordinates with an fp16 rerank copy.
+  Result<std::unique_ptr<YbHnsw>> ImportInt8(const std::string& name, bool reload = false) {
+    return Import(VectorStorageKind::kInt8, name, reload, RerankStorageKind::kFloat16);
   }
 
   vector_index::SearchOptions MakeSearchOptions(size_t max_results, size_t ef = 64) const {
@@ -401,6 +409,9 @@ TEST_F(YbHnswStorageTest, Float32KeepsFooterVersionOne) {
   ASSERT_OK(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
   ASSERT_EQ(ASSERT_RESULT(ReadFooterVersion(*Env::Default(), GetTestPath("f16.yb_hnsw"))), 2);
 
+  // Rerank tier and scale are version 3, so they must not push float16 files past version 2.
+  ASSERT_OK(ImportInt8("i8.yb_hnsw"));
+  ASSERT_EQ(ASSERT_RESULT(ReadFooterVersion(*Env::Default(), GetTestPath("i8.yb_hnsw"))), 3);
 }
 
 TEST_F(YbHnswStorageTest, HeaderReflectsStorageKind) {
@@ -457,8 +468,13 @@ TEST_F(YbHnswStorageTest, InitTakesStorageKindFromTheFile) {
 TEST_F(YbHnswStorageTest, SelfDistanceIsZero) {
   BuildHnswlibIndex(500);
 
-  for (auto storage_kind : {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16}) {
-    auto index = ASSERT_RESULT(Import(storage_kind, Format("$0.yb_hnsw", storage_kind)));
+  for (auto storage_kind :
+       {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16, VectorStorageKind::kInt8}) {
+    // int8 always has a rerank tier and the distance comes from it, so this covers both.
+    auto rerank_kind = storage_kind == VectorStorageKind::kInt8
+        ? RerankStorageKind::kFloat16 : RerankStorageKind::kNone;
+    auto index = ASSERT_RESULT(Import(
+        storage_kind, Format("$0.yb_hnsw", storage_kind), /* reload= */ false, rerank_kind));
     for (size_t i = 0; i != 20; ++i) {
       const auto& query = vectors_[i * (vectors_.size() / 20)];
       // A generous ef makes finding the exact match certain, so a failure is the codec.
@@ -554,6 +570,319 @@ TEST_F(YbHnswStorageTest, OutOfRangeCoordinatesStayFinite) {
     for (const auto& entry : results) {
       ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
     }
+  }
+}
+
+
+// The scale is chunk-local and unrecoverable from anything else in the file, so it has to survive
+// the footer round trip bit for bit -- it is serialized as a bit pattern precisely because a
+// nearly-right scale would decode every record slightly wrong and look like a recall bug.
+TEST_F(YbHnswStorageTest, HeaderRoundTripsScaleAndRerankKind) {
+  BuildHnswlibIndex(200);
+
+  auto fresh = ASSERT_RESULT(ImportInt8("a.yb_hnsw"));
+  auto reloaded = ASSERT_RESULT(ImportInt8("b.yb_hnsw", /* reload= */ true));
+
+  ASSERT_EQ(fresh->header().storage_kind, VectorStorageKind::kInt8);
+  ASSERT_EQ(fresh->header().rerank_kind, RerankStorageKind::kFloat16);
+  ASSERT_GT(fresh->header().quantization_scale, 0.0f);
+
+  ASSERT_EQ(reloaded->header().storage_kind, VectorStorageKind::kInt8);
+  ASSERT_EQ(reloaded->header().rerank_kind, RerankStorageKind::kFloat16);
+  // Exact equality, not a tolerance: the field is serialized as a bit pattern, and a scale that
+  // decodes almost right would make every record slightly wrong and read as a recall bug.
+  ASSERT_EQ(reloaded->header().quantization_scale, fresh->header().quantization_scale);
+
+  // Encodings that do not quantize must not carry a scale, so a stray non-zero value here would
+  // mean the field is being set from something other than the data.
+  auto f16 = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+  ASSERT_EQ(f16->header().rerank_kind, RerankStorageKind::kNone);
+  ASSERT_EQ(f16->header().quantization_scale, 0.0f);
+}
+
+// Both copies live in one record, so vector_data_size is the only stride and the rerank copy is
+// found at a fixed offset inside it. Getting this arithmetic wrong reads the wrong bytes without
+// ever going out of bounds, which is why it is asserted rather than left to the search tests.
+TEST_F(YbHnswStorageTest, RecordLayoutIsInterleaved) {
+  BuildHnswlibIndex(200);
+
+  auto f32 = ASSERT_RESULT(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  auto i8 = ASSERT_RESULT(ImportInt8("i8.yb_hnsw"));
+
+  const auto record_overhead = f32->header().vector_data_size - dimensions_ * sizeof(float);
+  ASSERT_EQ(
+      i8->header().vector_data_size,
+      record_overhead + dimensions_ * sizeof(int8_t) + dimensions_ * sizeof(uint16_t));
+  ASSERT_EQ(i8->header().coordinates_size(), dimensions_ * sizeof(int8_t));
+
+  // 3 bytes per coordinate against float32's 4, so the whole file is smaller even though each
+  // vector is stored twice.
+  ASSERT_LT(i8->header().vector_data_size, f32->header().vector_data_size);
+  ASSERT_LT(
+      ASSERT_RESULT(Env::Default()->GetFileSize(GetTestPath("i8.yb_hnsw"))),
+      ASSERT_RESULT(Env::Default()->GetFileSize(GetTestPath("f32.yb_hnsw"))));
+}
+
+// The point of the design: int8 traversal costs recall, and reranking a modest over-fetch at
+// float16 gets it back. Asserting the un-reranked configuration is measurably worse is not
+// redundant -- without it the test passes just as happily when the rerank tier does nothing,
+// which is what a capped candidate budget produces.
+TEST_F(YbHnswStorageTest, Int8WithRerankMatchesFloat16Recall) {
+  constexpr size_t kNumVectors = 4000;
+  constexpr size_t kNumQueries = 200;
+  constexpr size_t kMaxResults = 10;
+
+  dimensions_ = 64;
+  BuildHnswlibIndex(kNumVectors);
+
+  auto f32 = ASSERT_RESULT(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  auto f16 = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+  auto i8 = ASSERT_RESULT(ImportInt8("i8.yb_hnsw"));
+  auto i8_bare = ASSERT_RESULT(Import(VectorStorageKind::kInt8, "i8_bare.yb_hnsw"));
+
+  std::vector<Vector> queries;
+  for (size_t i = 0; i != kNumQueries; ++i) {
+    queries.push_back(RandomVector());
+  }
+
+  auto measure_overlap = [this, &queries, &f32](YbHnsw& index) {
+    size_t common = 0;
+    for (const auto& query : queries) {
+      auto expected = f32->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+      auto actual = index.Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+      common += CountCommon(expected, actual);
+    }
+    return static_cast<double>(common) / (queries.size() * kMaxResults);
+  };
+
+  const auto f16_overlap = measure_overlap(*f16);
+  const auto i8_overlap = measure_overlap(*i8);
+  const auto bare_overlap = measure_overlap(*i8_bare);
+
+  LOG(INFO) << "top-" << kMaxResults << " overlap with float32: float16 " << f16_overlap
+            << ", int8 + float16 rerank " << i8_overlap << ", int8 alone " << bare_overlap;
+
+  // Reranking cannot beat the encoding it reranks with, so float16's overlap is the ceiling; the
+  // margin absorbs graph non-determinism between the two files. That reranking ran at all is
+  // asserted deterministically below, not by comparing recall.
+  ASSERT_GE(i8_overlap, f16_overlap - 0.02);
+
+  // Deterministic proof the rerank ran: each reported distance must be exactly what the float16
+  // metric gives for that row, since that is what MakeResult computes. The un-reranked index
+  // reports the traversal's quantized distance, larger by 1/scale squared.
+  for (size_t i = 0; i != 20; ++i) {
+    auto query = RandomVector();
+    auto reranked = i8->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    auto quantized = i8_bare->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    ASSERT_EQ(reranked.size(), kMaxResults);
+    ASSERT_EQ(quantized.size(), kMaxResults);
+
+    for (const auto& entry : reranked) {
+      ASSERT_EQ(entry.distance, Float16Distance(query, VectorForId(entry.vector_id)))
+          << "reported distance is not the float16 metric's: " << entry;
+    }
+    // And without a rerank tier it is not, which is what makes the assertion above meaningful.
+    const auto& nearest = quantized.front();
+    ASSERT_NE(nearest.distance, Float16Distance(query, VectorForId(nearest.vector_id)))
+        << "un-reranked search reported a float16 distance: " << nearest;
+  }
+}
+
+// Over-fetching must work when ef <= max_num_results, the case a naive
+// min(max(ef, k), overfetch * k) budget silently breaks: it retains exactly k candidates, so
+// reranking reorders rather than corrects. Size assertions all still pass in that state, so this
+// compares behaviour across over-fetch factors instead.
+TEST_F(YbHnswStorageTest, OverFetchActuallyOverFetches) {
+  constexpr size_t kNumVectors = 4000;
+  constexpr size_t kNumQueries = 100;
+
+  dimensions_ = 64;
+  BuildHnswlibIndex(kNumVectors);
+
+  auto i8 = ASSERT_RESULT(ImportInt8("i8.yb_hnsw"));
+
+  std::vector<Vector> queries;
+  for (size_t i = 0; i != kNumQueries; ++i) {
+    queries.push_back(RandomVector());
+  }
+
+  // ef below, equal to, and above max_num_results, plus the k=1 boundary.
+  for (auto [max_results, ef] : std::initializer_list<std::pair<size_t, size_t>>{
+           {50, 10}, {50, 50}, {10, 64}, {1, 1}, {1, 64}}) {
+    std::vector<std::vector<std::string>> rendered_by_factor;
+    std::vector<double> total_distance_by_factor;
+    for (uint32_t factor : {1, 3}) {
+      google::FlagSaver flag_saver;
+      ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_rerank_overfetch_factor) = factor;
+      std::vector<std::string> rendered;
+      double total_distance = 0;
+      for (const auto& query : queries) {
+        auto actual = i8->Search(query.data(), MakeSearchOptions(max_results, ef), context_);
+        // Over-fetching is internal: the caller still gets exactly what it asked for.
+        ASSERT_EQ(actual.size(), std::min(max_results, kNumVectors))
+            << "max_results: " << max_results << ", ef: " << ef << ", factor: " << factor;
+        for (const auto& entry : actual) {
+          ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+          total_distance += entry.distance;
+        }
+        rendered.push_back(AsString(actual));
+      }
+      rendered_by_factor.push_back(std::move(rendered));
+      total_distance_by_factor.push_back(total_distance);
+    }
+
+    LOG(INFO) << "max_results: " << max_results << ", ef: " << ef
+              << " -- summed distance at factor 1: " << total_distance_by_factor[0]
+              << ", at factor 3: " << total_distance_by_factor[1];
+
+    // Reranking a superset cannot select a worse result, so summed over all queries a larger
+    // retained set must not be farther. Recall is not the assertion: it is not monotone in the
+    // budget, which also moves the traversal's termination bound.
+    ASSERT_LE(total_distance_by_factor[1], total_distance_by_factor[0] * 1.0001)
+        << "retaining more candidates produced farther results: max_results " << max_results
+        << ", ef " << ef;
+
+    // Where the over-fetch pushes the budget past max(ef, k) the search demonstrably does more
+    // work, so the answer has to change somewhere across these queries. Under the capped formula
+    // it would be identical for every one of them, which is the bug.
+    if (3 * max_results > std::max(ef, max_results)) {
+      ASSERT_NE(rendered_by_factor[0], rendered_by_factor[1])
+          << "factor 3 returned exactly what factor 1 did for all " << kNumQueries
+          << " queries, so the candidate budget is not growing: max_results " << max_results
+          << ", ef " << ef;
+    }
+  }
+}
+
+TEST_F(YbHnswStorageTest, Int8SurvivesReload) {
+  constexpr size_t kMaxResults = 10;
+  dimensions_ = 32;
+  BuildHnswlibIndex(2000);
+
+  auto fresh = ASSERT_RESULT(ImportInt8("a.yb_hnsw"));
+  auto reloaded = ASSERT_RESULT(ImportInt8("b.yb_hnsw", /* reload= */ true));
+
+  for (size_t i = 0; i != 100; ++i) {
+    auto query = RandomVector();
+    auto from_fresh = fresh->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    auto from_reloaded = reloaded->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    ASSERT_EQ(from_fresh.size(), from_reloaded.size());
+    for (size_t j = 0; j != from_fresh.size(); ++j) {
+      ASSERT_EQ(AsString(from_fresh[j]), AsString(from_reloaded[j]));
+    }
+  }
+}
+
+// A chunk whose coordinates are all zero would otherwise derive a zero scale, and dividing by it
+// turns every coordinate into an infinity -- which makes every distance NaN rather than failing.
+TEST_F(YbHnswStorageTest, Int8HandlesAnAllZeroChunk) {
+  dimensions_ = 8;
+  space_ = std::make_unique<hnswlib::L2Space>(dimensions_);
+  hnswlib_index_ = std::make_unique<HnswlibImpl>(
+      space_.get(), 64, /* M= */ 16, /* ef_construction= */ 100);
+  for (size_t i = 0; i != 32; ++i) {
+    vectors_.push_back(Vector(dimensions_, 0.0f));
+    hnswlib_index_->addPoint(vectors_.back().data(), vector_index::VectorId::GenerateRandom());
+  }
+
+  auto index = ASSERT_RESULT(ImportInt8("zeros.yb_hnsw"));
+  ASSERT_GT(index->header().quantization_scale, 0.0f);
+
+  auto results = index->Search(vectors_.front().data(), MakeSearchOptions(10), context_);
+  ASSERT_FALSE(results.empty());
+  for (const auto& entry : results) {
+    ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+    ASSERT_EQ(entry.distance, 0.0f) << entry;
+  }
+}
+
+// An infinite coordinate must not set the quantization scale: its reciprocal is zero, which would
+// quantize the whole chunk, well-behaved coordinates included, to zero -- silently destroying the
+// traversal while the reranked distances still look plausible.
+TEST_F(YbHnswStorageTest, Int8ScaleIgnoresNonFiniteCoordinates) {
+  dimensions_ = 8;
+  space_ = std::make_unique<hnswlib::L2Space>(dimensions_);
+  hnswlib_index_ = std::make_unique<HnswlibImpl>(
+      space_.get(), 64, /* M= */ 16, /* ef_construction= */ 100);
+
+  // Every coordinate is well below 4, so the expected scale comes from this and nothing else.
+  float max_finite = 0;
+  for (size_t i = 0; i != 32; ++i) {
+    auto vector = RandomVector();
+    for (auto coordinate : vector) {
+      max_finite = std::max(max_finite, std::fabs(coordinate));
+    }
+    vectors_.push_back(vector);
+    ids_.push_back(vector_index::VectorId::GenerateRandom());
+    hnswlib_index_->addPoint(vectors_.back().data(), ids_.back());
+  }
+
+  // One vector carrying an infinity and a NaN. hnswlib will compute non-finite distances to it
+  // while building, which is fine here: what is under test is the scale the writer derives.
+  auto poisoned = RandomVector();
+  poisoned[0] = std::numeric_limits<float>::infinity();
+  poisoned[1] = -std::numeric_limits<float>::infinity();
+  poisoned[2] = std::numeric_limits<float>::quiet_NaN();
+  vectors_.push_back(poisoned);
+  ids_.push_back(vector_index::VectorId::GenerateRandom());
+  hnswlib_index_->addPoint(vectors_.back().data(), ids_.back());
+
+  auto index = ASSERT_RESULT(ImportInt8("poisoned.yb_hnsw"));
+  const auto scale = index->header().quantization_scale;
+  ASSERT_TRUE(std::isfinite(scale)) << "an infinite coordinate set the scale";
+  ASSERT_GT(scale, 0.0f);
+  // Derived from the finite data alone. Compared against the largest finite magnitude among the
+  // healthy vectors, whose own coordinates are the only ones that should count.
+  ASSERT_LE(std::fabs(scale - max_finite / vector_index::kMaxInt8), 1e-9f)
+      << "scale " << scale << " does not match max finite magnitude " << max_finite;
+
+  // And the healthy vectors still quantize to distinguishable records: each is found at distance
+  // zero from itself, which cannot hold if every coordinate collapsed to the same byte.
+  for (size_t i = 0; i != 10; ++i) {
+    auto results = index->Search(
+        vectors_[i].data(), MakeSearchOptions(1, /* ef= */ 200), context_);
+    ASSERT_EQ(results.size(), 1);
+    ASSERT_EQ(results.front().distance, 0.0f) << "vector " << i;
+  }
+}
+
+// Same clamp hazard as float16, but a different failure: an out-of-range float -> int8_t
+// conversion is undefined behaviour rather than a saturation, so without the clamp the stored
+// byte is whatever the hardware happens to produce.
+TEST_F(YbHnswStorageTest, Int8ClampsOutOfRangeCoordinates) {
+  dimensions_ = 8;
+  space_ = std::make_unique<hnswlib::L2Space>(dimensions_);
+  hnswlib_index_ = std::make_unique<HnswlibImpl>(
+      space_.get(), 64, /* M= */ 16, /* ef_construction= */ 100);
+
+  for (size_t i = 0; i != 32; ++i) {
+    auto vector = RandomVector();
+    // One vector far outside the rest, so the scale it sets leaves every other coordinate in the
+    // bottom few steps of the range -- the outlier case the scale is most sensitive to.
+    if (i == 0) {
+      vector[0] = 1e4f;
+    }
+    vectors_.push_back(vector);
+    hnswlib_index_->addPoint(vector.data(), vector_index::VectorId::GenerateRandom());
+  }
+
+  auto index = ASSERT_RESULT(ImportInt8("outlier.yb_hnsw"));
+  for (size_t i = 0; i != 16; ++i) {
+    auto results = index->Search(RandomVector().data(), MakeSearchOptions(10), context_);
+    ASSERT_FALSE(results.empty());
+    for (const auto& entry : results) {
+      ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+      ASSERT_GE(entry.distance, 0.0f) << entry;
+    }
+  }
+
+  // A query well outside the chunk's range clamps rather than wrapping, and still returns
+  // finite, ordered results.
+  auto far_query = Vector(dimensions_, 1e9f);
+  auto results = index->Search(far_query.data(), MakeSearchOptions(5), context_);
+  ASSERT_FALSE(results.empty());
+  for (const auto& entry : results) {
+    ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
   }
 }
 

--- a/src/yb/hnsw/hnsw-test.cc
+++ b/src/yb/hnsw/hnsw-test.cc
@@ -11,12 +11,20 @@
 // under the License.
 //
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <set>
+
 #include "yb/hnsw/hnsw.h"
 #include "yb/hnsw/hnsw_block_cache.h"
 #include "yb/hnsw/vector_index_test_base.h"
 
 #include "yb/rocksdb/cache.h"
 
+#include "yb/util/env.h"
+#include "yb/util/flags.h"
 #include "yb/util/metrics.h"
 #include "yb/util/random_util.h"
 #include "yb/util/size_literals.h"
@@ -25,13 +33,17 @@
 #include "yb/util/tsan_util.h"
 
 #include "yb/vector_index/vector_index_fwd.h"
+#include "yb/vector_index/coordinate_codec.h"
 #include "yb/vector_index/distance.h"
+#include "yb/vector_index/hnsw_options.h"
 #include "yb/vector_index/usearch_include_wrapper_internal.h"
 #include "yb/vector_index/vector_index_if.h"
 #include "yb/vector_index/vector_payload_map.h"
 
 using namespace std::chrono_literals;
 using namespace yb::size_literals;
+
+DECLARE_bool(yb_hnsw_prefetch_neighbors);
 
 METRIC_DEFINE_entity(table);
 
@@ -216,6 +228,333 @@ TEST_F(YbHnswTest, Cache) {
 
 TEST_F(YbHnswTest, ConcurrentCache) {
   TestRandom(true, 4);
+}
+
+// Batching neighbour resolution must be an optimisation only: same results, and no block the
+// serial loop would not have taken. Resolving an address before the visited filter would Take()
+// blocks the search does not need, showing up as a higher cache_query delta. The deltas also pin
+// down SearchCache::Release's batched counters: one query, and on a resident index one hit, per
+// block.
+TEST_F(YbHnswTest, PrefetchMatchesSerialResolution) {
+  constexpr size_t kNumVectors = 4096;
+  constexpr size_t kNumSearches = 32;
+  constexpr size_t kMaxResults = 20;
+
+  google::FlagSaver flag_saver;
+
+  auto query_vectors = PrepareRandom(/* load= */ true, kNumVectors, kNumSearches);
+  auto options = MakeSearchOptions(kMaxResults);
+  const auto& query_counter = *block_cache_->metrics().query;
+  const auto& hit_counter = *block_cache_->metrics().hit;
+
+  for (const auto& query_vector : query_vectors) {
+    // Warm up so both measured searches find every block resident and their deltas compare.
+    yb_hnsw_->Search(query_vector.data(), options, context_);
+
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_yb_hnsw_prefetch_neighbors) = false;
+    auto queries_before = query_counter.value();
+    auto hits_before = hit_counter.value();
+    auto expected = yb_hnsw_->Search(query_vector.data(), options, context_);
+    auto serial_takes = query_counter.value() - queries_before;
+    ASSERT_GT(serial_takes, 0);
+    ASSERT_EQ(hit_counter.value() - hits_before, serial_takes);
+
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_yb_hnsw_prefetch_neighbors) = true;
+    queries_before = query_counter.value();
+    hits_before = hit_counter.value();
+    auto actual = yb_hnsw_->Search(query_vector.data(), options, context_);
+    ASSERT_EQ(query_counter.value() - queries_before, serial_takes);
+    ASSERT_EQ(hit_counter.value() - hits_before, serial_takes);
+    ASSERT_EQ(AsString(expected), AsString(actual));
+  }
+}
+
+// ------------------------------------------------------------------------------------------------
+// Narrowed coordinate storage
+// ------------------------------------------------------------------------------------------------
+
+using vector_index::VectorStorageKind;
+
+namespace {
+
+// MakeFooter writes the version byte first; the footer's length is the file's last 8 bytes.
+Result<uint8_t> ReadFooterVersion(Env& env, const std::string& path) {
+  std::unique_ptr<RandomAccessFile> file;
+  RETURN_NOT_OK(env.NewRandomAccessFile(path, &file));
+  auto file_size = VERIFY_RESULT(file->Size());
+
+  std::array<uint8_t, sizeof(uint64_t)> size_buffer;
+  Slice size_slice;
+  RETURN_NOT_OK(file->Read(
+      file_size - size_buffer.size(), size_buffer.size(), &size_slice, size_buffer.data()));
+  auto footer_size = LittleEndian::Load64(size_slice.data());
+
+  uint8_t version = 0;
+  Slice version_slice;
+  RETURN_NOT_OK(file->Read(file_size - footer_size, 1, &version_slice, &version));
+  return version;
+}
+
+size_t CountCommon(const YbHnsw::SearchResult& lhs, const YbHnsw::SearchResult& rhs) {
+  std::set<vector_index::VectorId> ids;
+  for (const auto& entry : lhs) {
+    ids.insert(entry.vector_id);
+  }
+  size_t result = 0;
+  for (const auto& entry : rhs) {
+    result += ids.contains(entry.vector_id);
+  }
+  return result;
+}
+
+}  // namespace
+
+// The hnswlib -> YbHnsw import path is the one narrowed storage is wired through.
+class YbHnswStorageTest : public VectorIndexTestBase {
+ protected:
+  using HnswlibImpl = HnswlibIndex<YbHnsw::DistanceType>;
+
+  void BuildHnswlibIndex(size_t num_vectors) {
+    space_ = std::make_unique<hnswlib::L2Space>(dimensions_);
+    hnswlib_index_ = std::make_unique<HnswlibImpl>(
+        space_.get(), num_vectors, /* M= */ 16, /* ef_construction= */ 100);
+    vectors_.reserve(num_vectors);
+    ids_.reserve(num_vectors);
+    for (size_t i = 0; i != num_vectors; ++i) {
+      vectors_.push_back(RandomVector());
+      ids_.push_back(vector_index::VectorId::GenerateRandom());
+      hnswlib_index_->addPoint(vectors_.back().data(), ids_.back());
+    }
+  }
+
+  const Vector& VectorForId(const vector_index::VectorId& id) const {
+    auto it = std::find(ids_.begin(), ids_.end(), id);
+    CHECK(it != ids_.end()) << "unknown vector id: " << id;
+    return vectors_[it - ids_.begin()];
+  }
+
+  // What MakeResult computes: the float16 metric over float16 copies of both sides.
+  YbHnsw::DistanceType Float16Distance(const Vector& lhs, const Vector& rhs) const {
+    vector_index::HNSWOptions options;
+    options.dimensions = dimensions_;
+    options.distance_kind = vector_index::DistanceKind::kL2Squared;
+    UsearchMetric metric(
+        options.CreateStoredMetric(dimensions_, VectorStorageKind::kFloat16));
+    const auto bytes = vector_index::CoordinateBytes(VectorStorageKind::kFloat16, dimensions_);
+    std::vector<std::byte> buffer(bytes * 2);
+    vector_index::NarrowCoordinates(
+        VectorStorageKind::kFloat16, lhs.data(), dimensions_, buffer.data());
+    vector_index::NarrowCoordinates(
+        VectorStorageKind::kFloat16, rhs.data(), dimensions_, buffer.data() + bytes);
+    return metric.Distance(buffer.data(), buffer.data() + bytes);
+  }
+
+  // The production metric factory path, so a wrong storage-kind-to-scalar-kind mapping shows here.
+  YbHnsw::MetricFactory MakeMetricFactory() const {
+    vector_index::HNSWOptions options;
+    options.dimensions = dimensions_;
+    options.distance_kind = vector_index::DistanceKind::kL2Squared;
+    return [options](size_t dimensions, VectorStorageKind storage_kind) {
+      return std::make_unique<UsearchMetric>(
+          options.CreateStoredMetric(dimensions, storage_kind));
+    };
+  }
+
+  // With `reload`, the returned instance only ever saw the file -- i.e. a tserver restart.
+  Result<std::unique_ptr<YbHnsw>> Import(
+      VectorStorageKind storage_kind, const std::string& name, bool reload = false) {
+    auto path = GetTestPath(name);
+    auto result = std::make_unique<YbHnsw>(MakeMetricFactory(), block_cache_);
+    // No payloads: keeps the 16-byte aux entry per vector this fixture's expectations assume.
+    RETURN_NOT_OK(result->Import(
+        *hnswlib_index_, path, /* payloads= */ nullptr, storage_kind));
+    if (reload) {
+      result = std::make_unique<YbHnsw>(MakeMetricFactory(), block_cache_);
+      RETURN_NOT_OK(result->Init(path));
+    }
+    return result;
+  }
+
+  vector_index::SearchOptions MakeSearchOptions(size_t max_results, size_t ef = 64) const {
+    return vector_index::SearchOptions {
+      .max_num_results = max_results,
+      .ef = ef,
+      .filter = AcceptAllVectors(),
+    };
+  }
+
+  std::unique_ptr<hnswlib::SpaceInterface<YbHnsw::DistanceType>> space_;
+  std::unique_ptr<HnswlibImpl> hnswlib_index_;
+  std::vector<Vector> vectors_;
+  std::vector<vector_index::VectorId> ids_;
+  YbHnswSearchContext context_;
+};
+
+// float32 must keep producing byte-identical version-1 footers, or existing deployments' files
+// stop being readable by the previous release.
+TEST_F(YbHnswStorageTest, Float32KeepsFooterVersionOne) {
+  BuildHnswlibIndex(200);
+
+  ASSERT_OK(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  ASSERT_EQ(ASSERT_RESULT(ReadFooterVersion(*Env::Default(), GetTestPath("f32.yb_hnsw"))), 1);
+
+  ASSERT_OK(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+  ASSERT_EQ(ASSERT_RESULT(ReadFooterVersion(*Env::Default(), GetTestPath("f16.yb_hnsw"))), 2);
+
+}
+
+TEST_F(YbHnswStorageTest, HeaderReflectsStorageKind) {
+  // Enough vectors that neither encoding fits one block: InitVectorDataAmountPerBlock derives
+  // records-per-block from the count and only then clamps, so a one-block index makes the
+  // records-per-block assertion below vacuous.
+  BuildHnswlibIndex(5000);
+
+  auto f32 = ASSERT_RESULT(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  auto f16 = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+
+  ASSERT_EQ(f32->header().storage_kind, VectorStorageKind::kFloat32);
+  ASSERT_EQ(f16->header().storage_kind, VectorStorageKind::kFloat16);
+  ASSERT_EQ(f32->header().dimensions, dimensions_);
+  ASSERT_EQ(f16->header().dimensions, dimensions_);
+
+  // Only the coordinates shrink; the record header does not.
+  const auto record_overhead = f32->header().vector_data_size - dimensions_ * sizeof(float);
+  ASSERT_EQ(f16->header().vector_data_size, record_overhead + dimensions_ * sizeof(uint16_t));
+
+  // Not twice as many at 8 dimensions: only the coordinates halve, and the header is a large
+  // share of the record.
+  ASSERT_GT(f16->header().vector_data_amount_per_block,
+            f32->header().vector_data_amount_per_block);
+
+  // Both still clamped to a block, which is what makes the comparison above meaningful.
+  ASSERT_LE(
+      f32->header().vector_data_amount_per_block * f32->header().vector_data_size,
+      f32->header().max_block_size);
+  ASSERT_LE(
+      f16->header().vector_data_amount_per_block * f16->header().vector_data_size,
+      f16->header().max_block_size);
+}
+
+// The encoding must come from the file, not from caller configuration: a stale setting is
+// otherwise undetectable, decoding records at the wrong width into plausible-looking garbage.
+TEST_F(YbHnswStorageTest, InitTakesStorageKindFromTheFile) {
+  BuildHnswlibIndex(200);
+  ASSERT_OK(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+
+  YbHnsw reopened(MakeMetricFactory(), block_cache_);
+  ASSERT_OK(reopened.Init(GetTestPath("f16.yb_hnsw")));
+  ASSERT_EQ(reopened.header().storage_kind, VectorStorageKind::kFloat16);
+
+  // And it still answers correctly, i.e. the metric it built matches the records.
+  auto results = reopened.Search(
+      vectors_.front().data(), MakeSearchOptions(1, /* ef= */ 200), context_);
+  ASSERT_EQ(results.size(), 1);
+  ASSERT_EQ(results.front().distance, 0.0f);
+}
+
+// Writer and query path share one conversion, so a vector used as its own query must come back
+// at distance zero. First thing to break if they diverge.
+TEST_F(YbHnswStorageTest, SelfDistanceIsZero) {
+  BuildHnswlibIndex(500);
+
+  for (auto storage_kind : {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16}) {
+    auto index = ASSERT_RESULT(Import(storage_kind, Format("$0.yb_hnsw", storage_kind)));
+    for (size_t i = 0; i != 20; ++i) {
+      const auto& query = vectors_[i * (vectors_.size() / 20)];
+      // A generous ef makes finding the exact match certain, so a failure is the codec.
+      auto results = index->Search(query.data(), MakeSearchOptions(1, /* ef= */ 200), context_);
+      ASSERT_EQ(results.size(), 1) << storage_kind;
+      ASSERT_EQ(results.front().distance, 0.0f)
+          << "storage_kind: " << storage_kind << ", vector: " << i;
+    }
+  }
+}
+
+// Pins what narrowing costs. Loose threshold: uniform random low-dimension vectors reorder more
+// easily than real embeddings, their neighbours sitting at nearly identical distances.
+TEST_F(YbHnswStorageTest, Float16KeepsRecall) {
+  constexpr size_t kNumVectors = 4000;
+  constexpr size_t kNumQueries = 200;
+  constexpr size_t kMaxResults = 10;
+  constexpr double kMinOverlap = 0.9;
+
+  dimensions_ = 64;
+  BuildHnswlibIndex(kNumVectors);
+
+  auto f32 = ASSERT_RESULT(Import(VectorStorageKind::kFloat32, "f32.yb_hnsw"));
+  auto f16 = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "f16.yb_hnsw"));
+
+  size_t common = 0;
+  double worst_distance_error = 0;
+  for (size_t i = 0; i != kNumQueries; ++i) {
+    auto query = RandomVector();
+    auto f32_results = f32->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    auto f16_results = f16->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    ASSERT_EQ(f32_results.size(), f16_results.size());
+    common += CountCommon(f32_results, f16_results);
+
+    // Top-1 distances should agree closely even when the identities differ.
+    worst_distance_error = std::max<double>(
+        worst_distance_error,
+        std::fabs(f32_results.front().distance - f16_results.front().distance) /
+            std::max(f32_results.front().distance, 1e-6f));
+  }
+
+  const double overlap = static_cast<double>(common) / (kNumQueries * kMaxResults);
+  LOG(INFO) << "float16 top-" << kMaxResults << " overlap with float32: " << overlap
+            << ", worst relative top-1 distance error: " << worst_distance_error;
+  ASSERT_GE(overlap, kMinOverlap);
+  ASSERT_LE(worst_distance_error, 0.05);
+}
+
+// Compaction re-reads served files, so a reopened index must survive the same searches.
+TEST_F(YbHnswStorageTest, Float16SurvivesReload) {
+  constexpr size_t kMaxResults = 10;
+  dimensions_ = 32;
+  BuildHnswlibIndex(2000);
+
+  auto fresh = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "a.yb_hnsw"));
+  auto reloaded = ASSERT_RESULT(
+      Import(VectorStorageKind::kFloat16, "b.yb_hnsw", /* reload= */ true));
+
+  for (size_t i = 0; i != 100; ++i) {
+    auto query = RandomVector();
+    auto from_fresh = fresh->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    auto from_reloaded = reloaded->Search(query.data(), MakeSearchOptions(kMaxResults), context_);
+    ASSERT_EQ(from_fresh.size(), from_reloaded.size());
+    for (size_t j = 0; j != from_fresh.size(); ++j) {
+      ASSERT_EQ(AsString(from_fresh[j]), AsString(from_reloaded[j]));
+    }
+  }
+}
+
+// One inf coordinate makes every distance to that vector NaN, and NaN comparisons quietly
+// corrupt the search heaps.
+TEST_F(YbHnswStorageTest, OutOfRangeCoordinatesStayFinite) {
+  dimensions_ = 8;
+  space_ = std::make_unique<hnswlib::L2Space>(dimensions_);
+  hnswlib_index_ = std::make_unique<HnswlibImpl>(
+      space_.get(), 64, /* M= */ 16, /* ef_construction= */ 100);
+
+  for (size_t i = 0; i != 32; ++i) {
+    auto vector = RandomVector();
+    if (i % 8 == 0) {
+      // Outside fp16 but inside float32, so the graph is still built from finite distances.
+      vector[i % dimensions_] = 1e6f;
+      vector[(i + 1) % dimensions_] = -1e6f;
+    }
+    vectors_.push_back(vector);
+    hnswlib_index_->addPoint(vector.data(), vector_index::VectorId::GenerateRandom());
+  }
+
+  auto index = ASSERT_RESULT(Import(VectorStorageKind::kFloat16, "clamped.yb_hnsw"));
+  for (size_t i = 0; i != 16; ++i) {
+    auto results = index->Search(RandomVector().data(), MakeSearchOptions(10), context_);
+    ASSERT_FALSE(results.empty());
+    for (const auto& entry : results) {
+      ASSERT_TRUE(std::isfinite(entry.distance)) << entry;
+    }
+  }
 }
 
 }  // namespace yb::hnsw

--- a/src/yb/hnsw/hnsw.cc
+++ b/src/yb/hnsw/hnsw.cc
@@ -13,6 +13,10 @@
 
 #include "yb/hnsw/hnsw.h"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 #include "usearch/index.hpp"
 
 #include "yb/hnsw/block_writer.h"
@@ -20,11 +24,15 @@
 
 #include "yb/util/cast.h"
 #include "yb/util/env.h"
+#include "yb/util/flag_validators.h"
 #include "yb/util/flags.h"
+#include "yb/util/metrics.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/size_literals.h"
+#include "yb/util/status_format.h"
 #include "yb/util/status_log.h"
 
+#include "yb/vector_index/coordinate_codec.h"
 #include "yb/vector_index/vector_index_if.h"
 #include "yb/vector_index/vector_payload_map.h"
 
@@ -35,6 +43,13 @@ DEFINE_RUNTIME_uint64(yb_hnsw_max_block_size, 64_KB,
 
 DEFINE_RUNTIME_bool(yb_hnsw_keep_new_blocks_in_cache, false,
     "Whether to keep new generated blocks in cache after YbHnsw index is built.");
+
+DEFINE_RUNTIME_bool(yb_hnsw_prefetch_neighbors, true,
+    "Whether a base layer search resolves and prefetches the record addresses of a node's "
+    "unvisited neighbours as a batch before computing any of their distances. Both settings "
+    "visit the same vectors and return the same results; batching only overlaps the cache "
+    "misses. Turn it off on an index small enough to sit in cache, where the prefetches are "
+    "pure overhead.");
 
 #define YB_MISALIGNED_STORE(ptr, type, field, value) \
   MisalignedAssign<decltype(type::field)>(ptr, offsetof(type, field), value)
@@ -69,6 +84,8 @@ class YbHnswIndexAdapter {
 
   virtual int16_t NodeLevel(size_t index) = 0;
   virtual vector_index::VectorId NodeKey(size_t index) = 0;
+  // Writes this node's coordinates into `out` in the encoding MakeHeader() declared. Must fill
+  // exactly vector_data_size - sizeof(VectorData) bytes.
   virtual void NodeCoordinates(size_t index, void* out) = 0;
   virtual NeighborsType Neighbors(size_t index, size_t level) = 0;
   virtual NeighborsType NeighborsBase(size_t index) = 0;
@@ -83,6 +100,9 @@ class YbHnswIndexAdapter {
     return payloads_->Get(index);
   }
 
+  // Coordinates NodeCoordinates() had to clamp. Zero for adapters that do not narrow.
+  virtual size_t NumClampedCoordinates() const { return 0; }
+
   virtual ~YbHnswIndexAdapter() = default;
 
  private:
@@ -90,6 +110,28 @@ class YbHnswIndexAdapter {
 };
 
 namespace {
+
+size_t RecordCoordinateBytes(const Header& header) {
+  return vector_index::CoordinateBytes(header.storage_kind, header.dimensions);
+}
+
+// Checks a header parsed from a file against itself, before anything reads a record through it.
+// A vector_data_size disagreeing with the encoding is otherwise silent: it reads past every
+// record into the next.
+Status ValidateHeader(const Header& header) {
+  // Range-checked before anything switches on it: CoordinateBytes ends in
+  // FATAL_INVALID_ENUM_VALUE, so a single corrupt footer byte would abort the process instead of
+  // failing this one file. The enum is contiguous from zero.
+  SCHECK_LT(
+      static_cast<size_t>(std::to_underlying(header.storage_kind)),
+      vector_index::kElementsInVectorStorageKind, Corruption,
+      Format("YbHnsw chunk has an unknown storage kind: $0", header));
+
+  SCHECK_EQ(
+      header.vector_data_size, sizeof(YbHnswVectorData) + RecordCoordinateBytes(header),
+      Corruption, Format("YbHnsw record size disagrees with its encoding: $0", header));
+  return Status::OK();
+}
 
 using VectorData = YbHnswVectorData;
 
@@ -135,6 +177,9 @@ class YbHnswBuilder {
 
   Result<std::pair<FileBlockCachePtr, Header>> Build() {
     header_ = inspector_.MakeHeader();
+    // ValidateHeader()'s invariant, on write: a mismatch means the adapter's MakeHeader and
+    // NodeCoordinates disagree about the record layout, producing an unreadable file.
+    DCHECK_EQ(header_.vector_data_size, sizeof(VectorData) + RecordCoordinateBytes(header_));
     PrepareVectors();
     VLOG_WITH_FUNC(4) << "Size: " << inspector_.Size() << ", header: " << header_.ToString();
 
@@ -149,6 +194,10 @@ class YbHnswBuilder {
     RETURN_NOT_OK(out_->Close());
     out_.reset();
     RETURN_NOT_OK(block_cache_.env().RenameFile(tmp_path, path_));
+    LOG_IF(WARNING, inspector_.NumClampedCoordinates() != 0)
+        << "YbHnsw " << path_ << ": clamped " << inspector_.NumClampedCoordinates()
+        << " coordinate(s) that this chunk's encoding cannot represent (storage_kind: "
+        << header_.storage_kind << "); searches involving those vectors will be less accurate";
     std::unique_ptr<RandomAccessFile> file;
     RETURN_NOT_OK(block_cache_.env().NewRandomAccessFile(path_, &file));
     auto file_block_cache = std::make_unique<FileBlockCache>(
@@ -474,11 +523,25 @@ SearchCacheScope::SearchCacheScope(SearchCache& cache, const YbHnsw& hnsw) : cac
   cache.Bind(hnsw.header_, *hnsw.file_block_cache_);
 }
 
-YbHnsw::YbHnsw(MetricPtr&& metric, BlockCachePtr block_cache)
-    : metric_(std::move(metric)), block_cache_(std::move(block_cache)) {
+YbHnsw::YbHnsw(const UsearchMetric::Impl& metric, BlockCachePtr block_cache)
+    : YbHnsw(
+          [metric](size_t, vector_index::VectorStorageKind storage_kind) -> MetricPtr {
+            LOG_IF(DFATAL, storage_kind != vector_index::VectorStorageKind::kFloat32)
+                << "Fixed float32 metric cannot decode " << storage_kind << " records";
+            return std::make_unique<UsearchMetric>(metric);
+          },
+          std::move(block_cache)) {
+}
+
+YbHnsw::YbHnsw(MetricFactory metric_factory, BlockCachePtr block_cache)
+    : metric_factory_(std::move(metric_factory)), block_cache_(std::move(block_cache)) {
 }
 
 YbHnsw::~YbHnsw() = default;
+
+void YbHnsw::InitMetrics() {
+  metric_ = metric_factory_(header_.dimensions, header_.storage_kind);
+}
 
 Status YbHnsw::Import(
     const unum::usearch::index_dense_gt<vector_index::VectorId>& index, const std::string& path,
@@ -486,6 +549,7 @@ Status YbHnsw::Import(
   YbHnswUsearchIndexAdapter inspector(index, payloads);
   YbHnswBuilder builder(inspector, *block_cache_, path);
   std::tie(file_block_cache_, header_) = VERIFY_RESULT(builder.Build());
+  InitMetrics();
   return Status::OK();
 }
 
@@ -493,8 +557,10 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
  public:
   YbHnswHnswlibIndexAdapter(
       std::reference_wrapper<const HnswlibIndex<YbHnsw::DistanceType>> index,
-      const vector_index::VectorPayloadMap* payloads)
-      : YbHnswIndexAdapter(payloads), index_(index) {}
+      const vector_index::VectorPayloadMap* payloads,
+      vector_index::VectorStorageKind storage_kind)
+      : YbHnswIndexAdapter(payloads), index_(index), storage_kind_(storage_kind),
+        dimensions_(index.get().data_size_ / sizeof(YbHnswBuilder::CoordinateType)) {}
 
   size_t Size() override {
     return index_.getCurrentElementCount();
@@ -507,8 +573,10 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
   Header MakeHeader() override {
     Header result;
     result.max_block_size = FLAGS_yb_hnsw_max_block_size;
-    result.dimensions = index_.data_size_ / sizeof(YbHnswBuilder::CoordinateType);
-    result.vector_data_size = index_.data_size_ + sizeof(VectorData);
+    result.dimensions = dimensions_;
+    result.storage_kind = storage_kind_;
+    result.vector_data_size =
+        vector_index::CoordinateBytes(storage_kind_, dimensions_) + sizeof(VectorData);
     InitVectorDataAmountPerBlock(result, index_.getCurrentElementCount());
     result.max_level = index_.getMaxLevel();
     result.config.connectivity_base = index_.maxM_;
@@ -529,7 +597,19 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
   }
 
   void NodeCoordinates(size_t index, void* out) override {
-    memcpy(out, index_.getDataByInternalId(CastIndex(index)), index_.data_size_);
+    const auto* coordinates =
+        pointer_cast<const YbHnswBuilder::CoordinateType*>(
+            index_.getDataByInternalId(CastIndex(index)));
+    if (storage_kind_ == vector_index::VectorStorageKind::kFloat32) {
+      memcpy(out, coordinates, index_.data_size_);
+    } else {
+      vector_index::NarrowCoordinates(
+          storage_kind_, coordinates, dimensions_, out, &num_clamped_);
+    }
+  }
+
+  size_t NumClampedCoordinates() const override {
+    return num_clamped_;
   }
 
   NeighborsType Neighbors(size_t index, size_t level) override {
@@ -553,15 +633,20 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
   }
 
   const HnswlibIndex<YbHnsw::DistanceType>& index_;
+  const vector_index::VectorStorageKind storage_kind_;
+  const size_t dimensions_;
+  size_t num_clamped_ = 0;
 };
 
 Status YbHnsw::Import(
     const HnswlibIndex<DistanceType>& index,
     const std::string& path,
-    const vector_index::VectorPayloadMap* payloads) {
-  YbHnswHnswlibIndexAdapter inspector(index, payloads);
+    const vector_index::VectorPayloadMap* payloads,
+    vector_index::VectorStorageKind storage_kind) {
+  YbHnswHnswlibIndexAdapter inspector(index, payloads, storage_kind);
   YbHnswBuilder builder(inspector, *block_cache_, path);
   std::tie(file_block_cache_, header_) = VERIFY_RESULT(builder.Build());
+  InitMetrics();
   return Status::OK();
 }
 
@@ -570,6 +655,8 @@ Status YbHnsw::Init(const std::string& path) {
   RETURN_NOT_OK(block_cache_->env().NewRandomAccessFile(path, &file));
   file_block_cache_ = std::make_unique<FileBlockCache>(*block_cache_, std::move(file));
   header_ = VERIFY_RESULT(file_block_cache_->Load());
+  RETURN_NOT_OK(ValidateHeader(header_));
+  InitMetrics();
   return Status::OK();
 }
 
@@ -583,6 +670,19 @@ YbHnsw::SearchResult YbHnsw::Search(
       query_vector, context.search_cache);
   SearchInBaseLayer(query_vector, best_vector, best_dist, options, context);
   return MakeResult(options.max_num_results, context);
+}
+
+YbHnsw::SearchResult YbHnsw::Search(
+    const CoordinateType* query_vector, const vector_index::SearchOptions& options,
+    YbHnswSearchContext& context) const {
+  if (header_.storage_kind == vector_index::VectorStorageKind::kFloat32) {
+    return Search(pointer_cast<const std::byte*>(query_vector), options, context);
+  }
+  auto& buffer = context.narrowed_query;
+  buffer.resize(vector_index::CoordinateBytes(header_.storage_kind, header_.dimensions));
+  vector_index::NarrowCoordinates(
+      header_.storage_kind, query_vector, header_.dimensions, buffer.data());
+  return Search(buffer.data(), options, context);
 }
 
 YbHnsw::SearchResult YbHnsw::MakeResult(size_t max_results, YbHnswSearchContext& context) const {
@@ -659,11 +759,10 @@ void YbHnsw::SearchInBaseLayer(
     auto neighbors = cache.GetNeighborsInBaseLayer(vector);
     visited.reserve(visited.size() + std::ranges::size(neighbors));
 
-    for (auto neighbor : neighbors) {
-      if (visited.set(neighbor)) {
-        continue;
-      }
-      auto neighbor_dist = Distance(query_vector, neighbor, cache);
+    // Distance and heap update for one unvisited neighbour. Both loop shapes below invoke this
+    // in neighbour order, so best_dist evolves identically and the two produce the same results.
+    auto visit = [&](VectorNo neighbor, const std::byte* coordinates) {
+      auto neighbor_dist = Distance(query_vector, coordinates);
 
       if (top.size() < top_limit || extra_top.size() < extra_top_limit ||
           neighbor_dist < best_dist) {
@@ -687,28 +786,58 @@ void YbHnsw::SearchInBaseLayer(
           best_dist = extra_top.empty() ? top.top().first : extra_top.top();
         }
       }
+    };
+
+    if (!FLAGS_yb_hnsw_prefetch_neighbors) {
+      for (auto neighbor : neighbors) {
+        if (visited.set(neighbor)) {
+          continue;
+        }
+        visit(neighbor, cache.CoordinatesPtr(neighbor));
+      }
+      continue;
+    }
+
+    // A record's address is pure arithmetic on the neighbour id, but the CPU cannot speculate
+    // through blocks_[index] and then through the record itself, so both loads stall. Filtering
+    // and resolving the whole neighbour batch before computing any distance lets those misses
+    // overlap each other, and gives the prefetches the length of the batch's distance
+    // computations to land -- more slack than a one-ahead cursor, which matters for the short
+    // int8 kernel.
+    //
+    // The visited filter must stay first: resolving addresses for already-visited neighbours
+    // would Take() blocks the search does not need, inflating used_blocks_ and Release().
+    auto& unvisited = context.unvisited;
+    unvisited.clear();
+    for (auto it = neighbors.begin(), end = neighbors.end(); it != end; ++it) {
+      auto neighbor = *it;
+      if (visited.set(neighbor)) {
+        continue;
+      }
+      if (auto next_it = it + 1; next_it != end) {
+        cache.PrefetchVectorHeaderBlock(*next_it);
+      }
+      auto* coordinates = cache.CoordinatesPtr(neighbor);
+      __builtin_prefetch(coordinates);
+      unvisited.emplace_back(neighbor, coordinates);
+    }
+
+    // Resolved addresses stay valid across visit(): the search holds a reference on every block
+    // it took, which keeps CachedBlock::Unload from freeing the contents until Release().
+    for (auto [neighbor, coordinates] : unvisited) {
+      visit(neighbor, coordinates);
     }
   }
 }
 
 YbHnsw::DistanceType YbHnsw::Distance(const std::byte* lhs, const std::byte* rhs) const {
+  DCHECK(metric_) << "Distance requested before Init/Import";
   return metric_->Distance(lhs, rhs);
 }
 
 YbHnsw::DistanceType YbHnsw::Distance(
     const std::byte* lhs, size_t vector, SearchCache& cache) const {
   return Distance(lhs, cache.CoordinatesPtr(vector));
-}
-
-boost::iterator_range<MisalignedPtr<const YbHnsw::CoordinateType>> YbHnsw::MakeCoordinates(
-    const std::byte* ptr) const {
-  auto start = MisalignedPtr<const CoordinateType>(ptr);
-  return boost::make_iterator_range(start, start + header_.dimensions);
-}
-
-boost::iterator_range<MisalignedPtr<const YbHnsw::CoordinateType>> YbHnsw::Coordinates(
-    size_t vector, SearchCache& cache) const {
-  return MakeCoordinates(cache.CoordinatesPtr(vector));
 }
 
 const Header& YbHnsw::header() const {
@@ -720,7 +849,10 @@ const std::byte* SearchCache::Data(size_t index) {
   if (block) {
     return block;
   }
-  auto data = CHECK_RESULT(file_block_cache_->Take(index));
+  bool was_hit = false;
+  auto data = CHECK_RESULT(file_block_cache_->Take(index, &was_hit));
+  ++takes_;
+  hits_ += was_hit;
   used_blocks_.push_back(index);
   return block = data;
 }
@@ -733,6 +865,16 @@ void SearchCache::Bind(std::reference_wrapper<const Header> header, FileBlockCac
 }
 
 void SearchCache::Release() {
+  // One metrics update per search rather than one per block taken: a query touches roughly as
+  // many blocks as it visits vectors, and Take() is the only site that feeds these counters, so
+  // the totals are unchanged and only the update granularity is coarser.
+  if (takes_) {
+    auto& metrics = file_block_cache_->metrics();
+    metrics.query->IncrementBy(takes_);
+    metrics.hit->IncrementBy(hits_);
+    takes_ = 0;
+    hits_ = 0;
+  }
   for (auto block : used_blocks_) {
     blocks_[block] = nullptr;
     file_block_cache_->Release(block);
@@ -807,6 +949,11 @@ std::pair<vector_index::VectorId, Slice> SearchCache::GetVectorIdAndPayload(size
 
 const std::byte* SearchCache::CoordinatesPtr(size_t vector) {
   return VectorHeader(vector).raw() + offsetof(VectorData, coordinates);
+}
+
+void SearchCache::PrefetchVectorHeaderBlock(size_t vector) {
+  __builtin_prefetch(&blocks_[
+      header_->vector_data_block + vector / header_->vector_data_amount_per_block]);
 }
 
 HnswDistanceType UsearchMetric::Distance(

--- a/src/yb/hnsw/hnsw.cc
+++ b/src/yb/hnsw/hnsw.cc
@@ -51,6 +51,20 @@ DEFINE_RUNTIME_bool(yb_hnsw_prefetch_neighbors, true,
     "misses. Turn it off on an index small enough to sit in cache, where the prefetches are "
     "pure overhead.");
 
+DEFINE_RUNTIME_uint32(vector_index_rerank_overfetch_factor, 2,
+    "Multiplier applied to the requested result count to size the candidate set a vector index "
+    "chunk with a rerank tier rescores at full precision before returning. 1 retains exactly the "
+    "requested count, which makes reranking a no-op. Only affects chunks whose coordinates are "
+    "stored in a lossy encoding. Costs nothing while factor * LIMIT stays within ef_search, since "
+    "the search already retains that many candidates; past that it raises the candidate budget to "
+    "factor * LIMIT and the traversal does proportionally more work, which at the default 2 makes "
+    "a LIMIT 100 query at ef_search=100 explore 200 candidates rather than 100.");
+
+// Bounded because the value multiplies the candidates a search explores once it exceeds ef, so a
+// mistyped large value turns every query into a scan.
+DEFINE_validator(vector_index_rerank_overfetch_factor,
+    FLAG_COND_VALIDATOR(_value >= 1 && _value <= 64, "Must be between 1 and 64"));
+
 #define YB_MISALIGNED_STORE(ptr, type, field, value) \
   MisalignedAssign<decltype(type::field)>(ptr, offsetof(type, field), value)
 
@@ -84,8 +98,9 @@ class YbHnswIndexAdapter {
 
   virtual int16_t NodeLevel(size_t index) = 0;
   virtual vector_index::VectorId NodeKey(size_t index) = 0;
-  // Writes this node's coordinates into `out` in the encoding MakeHeader() declared. Must fill
-  // exactly vector_data_size - sizeof(VectorData) bytes.
+  // Writes this node's coordinates into `out` in the encodings MakeHeader() declared -- traversal
+  // first, then the rerank copy if any. Must fill exactly
+  // vector_data_size - sizeof(VectorData) bytes.
   virtual void NodeCoordinates(size_t index, void* out) = 0;
   virtual NeighborsType Neighbors(size_t index, size_t level) = 0;
   virtual NeighborsType NeighborsBase(size_t index) = 0;
@@ -111,25 +126,41 @@ class YbHnswIndexAdapter {
 
 namespace {
 
+// Coordinate bytes a record holds, across both tiers.
 size_t RecordCoordinateBytes(const Header& header) {
-  return vector_index::CoordinateBytes(header.storage_kind, header.dimensions);
+  return vector_index::CoordinateBytes(header.storage_kind, header.dimensions) +
+         (header.rerank_kind == vector_index::RerankStorageKind::kNone
+              ? 0
+              : vector_index::CoordinateBytes(
+                    vector_index::StorageKindForRerank(header.rerank_kind), header.dimensions));
 }
 
 // Checks a header parsed from a file against itself, before anything reads a record through it.
-// A vector_data_size disagreeing with the encoding is otherwise silent: it reads past every
-// record into the next.
+// Both failures are otherwise silent: a vector_data_size disagreeing with the encodings reads
+// past every record into the next, and an unusable scale decodes coordinates to zero or infinity
+// -- and an infinite coordinate makes every distance NaN, corrupting the heaps' ordering.
 Status ValidateHeader(const Header& header) {
-  // Range-checked before anything switches on it: CoordinateBytes ends in
-  // FATAL_INVALID_ENUM_VALUE, so a single corrupt footer byte would abort the process instead of
-  // failing this one file. The enum is contiguous from zero.
+  // Range-checked before anything switches on them: CoordinateBytes and StorageKindForRerank end
+  // in FATAL_INVALID_ENUM_VALUE, so a single corrupt footer byte would abort the process instead
+  // of failing this one file. Both enums are contiguous from zero.
   SCHECK_LT(
       static_cast<size_t>(std::to_underlying(header.storage_kind)),
       vector_index::kElementsInVectorStorageKind, Corruption,
       Format("YbHnsw chunk has an unknown storage kind: $0", header));
+  SCHECK_LT(
+      static_cast<size_t>(std::to_underlying(header.rerank_kind)),
+      vector_index::kElementsInRerankStorageKind, Corruption,
+      Format("YbHnsw chunk has an unknown rerank kind: $0", header));
 
   SCHECK_EQ(
       header.vector_data_size, sizeof(YbHnswVectorData) + RecordCoordinateBytes(header),
-      Corruption, Format("YbHnsw record size disagrees with its encoding: $0", header));
+      Corruption, Format("YbHnsw record size disagrees with its encodings: $0", header));
+
+  if (header.storage_kind == vector_index::VectorStorageKind::kInt8) {
+    SCHECK(
+        header.quantization_scale > 0 && std::isfinite(header.quantization_scale), Corruption,
+        Format("YbHnsw int8 chunk has an unusable quantization scale: $0", header));
+  }
   return Status::OK();
 }
 
@@ -197,7 +228,8 @@ class YbHnswBuilder {
     LOG_IF(WARNING, inspector_.NumClampedCoordinates() != 0)
         << "YbHnsw " << path_ << ": clamped " << inspector_.NumClampedCoordinates()
         << " coordinate(s) that this chunk's encoding cannot represent (storage_kind: "
-        << header_.storage_kind << "); searches involving those vectors will be less accurate";
+        << header_.storage_kind << ", rerank_kind: " << header_.rerank_kind
+        << "); searches involving those vectors will be less accurate";
     std::unique_ptr<RandomAccessFile> file;
     RETURN_NOT_OK(block_cache_.env().NewRandomAccessFile(path_, &file));
     auto file_block_cache = std::make_unique<FileBlockCache>(
@@ -541,6 +573,28 @@ YbHnsw::~YbHnsw() = default;
 
 void YbHnsw::InitMetrics() {
   metric_ = metric_factory_(header_.dimensions, header_.storage_kind);
+  rerank_metric_ = header_.rerank_kind == vector_index::RerankStorageKind::kNone
+      ? nullptr
+      : metric_factory_(
+            header_.dimensions, vector_index::StorageKindForRerank(header_.rerank_kind));
+}
+
+size_t YbHnsw::RerankCandidateCount(size_t max_num_results) const {
+  if (!rerank_metric_) {
+    return max_num_results;
+  }
+  const size_t factor = FLAGS_vector_index_rerank_overfetch_factor;
+  // The flag validator rejects zero, but a test writing the flag directly bypasses it and zero
+  // would divide by zero below.
+  if (factor <= 1) {
+    return max_num_results;
+  }
+  // Saturate rather than wrap: a wrap would silently return the wrong rows, where giving up the
+  // over-fetch only gives up the recall reranking would have recovered.
+  if (max_num_results > std::numeric_limits<size_t>::max() / factor) {
+    return max_num_results;
+  }
+  return max_num_results * factor;
 }
 
 Status YbHnsw::Import(
@@ -558,9 +612,12 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
   YbHnswHnswlibIndexAdapter(
       std::reference_wrapper<const HnswlibIndex<YbHnsw::DistanceType>> index,
       const vector_index::VectorPayloadMap* payloads,
-      vector_index::VectorStorageKind storage_kind)
+      vector_index::VectorStorageKind storage_kind,
+      vector_index::RerankStorageKind rerank_kind)
       : YbHnswIndexAdapter(payloads), index_(index), storage_kind_(storage_kind),
-        dimensions_(index.get().data_size_ / sizeof(YbHnswBuilder::CoordinateType)) {}
+        rerank_kind_(rerank_kind),
+        dimensions_(index.get().data_size_ / sizeof(YbHnswBuilder::CoordinateType)),
+        quantization_scale_(CalcQuantizationScale()) {}
 
   size_t Size() override {
     return index_.getCurrentElementCount();
@@ -575,8 +632,11 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
     result.max_block_size = FLAGS_yb_hnsw_max_block_size;
     result.dimensions = dimensions_;
     result.storage_kind = storage_kind_;
+    result.rerank_kind = rerank_kind_;
+    result.quantization_scale = quantization_scale_;
     result.vector_data_size =
-        vector_index::CoordinateBytes(storage_kind_, dimensions_) + sizeof(VectorData);
+        vector_index::CoordinateBytes(storage_kind_, dimensions_) + RerankBytes() +
+        sizeof(VectorData);
     InitVectorDataAmountPerBlock(result, index_.getCurrentElementCount());
     result.max_level = index_.getMaxLevel();
     result.config.connectivity_base = index_.maxM_;
@@ -604,8 +664,17 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
       memcpy(out, coordinates, index_.data_size_);
     } else {
       vector_index::NarrowCoordinates(
-          storage_kind_, coordinates, dimensions_, out, &num_clamped_);
+          storage_kind_, quantization_scale_, coordinates, dimensions_, out, &num_clamped_);
     }
+    if (rerank_kind_ == vector_index::RerankStorageKind::kNone) {
+      return;
+    }
+    // Both copies narrow the same full-precision source, so the rerank copy does not inherit the
+    // traversal copy's error.
+    vector_index::NarrowCoordinates(
+        vector_index::StorageKindForRerank(rerank_kind_), coordinates, dimensions_,
+        static_cast<std::byte*>(out) + vector_index::CoordinateBytes(storage_kind_, dimensions_),
+        &num_clamped_);
   }
 
   size_t NumClampedCoordinates() const override {
@@ -632,9 +701,46 @@ class YbHnswHnswlibIndexAdapter : public YbHnswIndexAdapter {
     return NeighborsType(VectorNoPtr(start), VectorNoPtr(start + size * sizeof(VectorNo)));
   }
 
+  size_t RerankBytes() const {
+    return rerank_kind_ == vector_index::RerankStorageKind::kNone
+        ? 0
+        : vector_index::CoordinateBytes(
+              vector_index::StorageKindForRerank(rerank_kind_), dimensions_);
+  }
+
+  // Symmetric quantization step for the whole chunk, from the largest magnitude it contains.
+  // Scoped to the chunk so it stays a pure function of data already in hand -- no sampling, no
+  // configuration, nothing to recalibrate as the index grows. The extra linear pass is affordable
+  // against a graph build that is not linear.
+  float CalcQuantizationScale() const {
+    if (storage_kind_ != vector_index::VectorStorageKind::kInt8) {
+      return 0;
+    }
+    float max_abs = 0;
+    const auto size = index_.getCurrentElementCount();
+    for (size_t index = 0; index != size; ++index) {
+      const auto* coordinates = pointer_cast<const YbHnswBuilder::CoordinateType*>(
+          index_.getDataByInternalId(CastIndex(index)));
+      for (size_t i = 0; i != dimensions_; ++i) {
+        // Only finite coordinates set the scale: one infinity would make the scale infinite and
+        // quantize the whole chunk, well-behaved coordinates included, to zero. NarrowCoordinates
+        // clamps infinities and maps NaN to zero anyway. NaN fails the comparison for free.
+        const auto magnitude = std::fabs(coordinates[i]);
+        if (std::isfinite(magnitude) && magnitude > max_abs) {
+          max_abs = magnitude;
+        }
+      }
+    }
+    // A zero scale would make every coordinate infinite; any positive scale encodes zeros
+    // exactly, so the fallback value is arbitrary.
+    return max_abs == 0 ? 1.0f : max_abs / vector_index::kMaxInt8;
+  }
+
   const HnswlibIndex<YbHnsw::DistanceType>& index_;
   const vector_index::VectorStorageKind storage_kind_;
+  const vector_index::RerankStorageKind rerank_kind_;
   const size_t dimensions_;
+  const float quantization_scale_;
   size_t num_clamped_ = 0;
 };
 
@@ -642,8 +748,9 @@ Status YbHnsw::Import(
     const HnswlibIndex<DistanceType>& index,
     const std::string& path,
     const vector_index::VectorPayloadMap* payloads,
-    vector_index::VectorStorageKind storage_kind) {
-  YbHnswHnswlibIndexAdapter inspector(index, payloads, storage_kind);
+    vector_index::VectorStorageKind storage_kind,
+    vector_index::RerankStorageKind rerank_kind) {
+  YbHnswHnswlibIndexAdapter inspector(index, payloads, storage_kind, rerank_kind);
   YbHnswBuilder builder(inspector, *block_cache_, path);
   std::tie(file_block_cache_, header_) = VERIFY_RESULT(builder.Build());
   InitMetrics();
@@ -675,17 +782,45 @@ YbHnsw::SearchResult YbHnsw::Search(
 YbHnsw::SearchResult YbHnsw::Search(
     const CoordinateType* query_vector, const vector_index::SearchOptions& options,
     YbHnswSearchContext& context) const {
+  if (header_.rerank_kind != vector_index::RerankStorageKind::kNone) {
+    auto rerank_kind = vector_index::StorageKindForRerank(header_.rerank_kind);
+    auto& buffer = context.rerank_query;
+    buffer.resize(vector_index::CoordinateBytes(rerank_kind, header_.dimensions));
+    vector_index::NarrowCoordinates(
+        rerank_kind, query_vector, header_.dimensions, buffer.data());
+  }
   if (header_.storage_kind == vector_index::VectorStorageKind::kFloat32) {
     return Search(pointer_cast<const std::byte*>(query_vector), options, context);
   }
   auto& buffer = context.narrowed_query;
   buffer.resize(vector_index::CoordinateBytes(header_.storage_kind, header_.dimensions));
+  // Clamped against this chunk's own scale, so a query coordinate outside the range the chunk
+  // contains is clipped. Not counted: that is a property of the query, not of the stored data.
   vector_index::NarrowCoordinates(
-      header_.storage_kind, query_vector, header_.dimensions, buffer.data());
+      header_.storage_kind, header_.quantization_scale, query_vector, header_.dimensions,
+      buffer.data());
   return Search(buffer.data(), options, context);
 }
 
 YbHnsw::SearchResult YbHnsw::MakeResult(size_t max_results, YbHnswSearchContext& context) const {
+  if (rerank_metric_) {
+    // Distances leave the chunk here, so this is where they must start meaning something outside
+    // it: the traversal ranked in its encoding's units, and rescoring puts them into the metric's
+    // own so VectorLSM can merge across chunks. This breaks context.top's heap invariant, which
+    // is safe only because MakeResult is its last use and SearchInBaseLayer clears it on entry.
+    //
+    // A wrong rerank_query size means the byte-pointer Search overload was called directly on a
+    // file with a rerank tier, which would read past the buffer.
+    DCHECK_EQ(
+        context.rerank_query.size(),
+        vector_index::CoordinateBytes(
+            vector_index::StorageKindForRerank(header_.rerank_kind), header_.dimensions));
+    const auto* query = context.rerank_query.data();
+    for (auto& entry : context.top.data()) {
+      entry.first = rerank_metric_->Distance(
+          query, context.search_cache.RerankCoordinatesPtr(entry.second));
+    }
+  }
   return vector_index::MakeResult<DistanceType>(
       max_results, context.top.data(),
       [&](const auto& entry) {
@@ -740,9 +875,16 @@ void YbHnsw::SearchInBaseLayer(
   // So could use the following as initial capacity for visited.
   visited.reserve(header_.config.connectivity_base + 1u);
 
-  auto top_limit = options.max_num_results;
-  auto extra_top_limit = std::max<size_t>(
-      options.ef, options.max_num_results) - options.max_num_results;
+  // With a rerank tier the search must retain more than the caller asked for, or MakeResult
+  // reranks exactly the entries it would have returned anyway.
+  //
+  // budget takes the max so it never caps top_limit. Capping at max(ef, max_num_results) instead
+  // looks harmless but silently defeats reranking whenever ef <= max_num_results: top_limit
+  // collapses to max_num_results with no extra candidates. Without a rerank tier top_limit is
+  // max_num_results and these reduce to what they were before.
+  auto top_limit = RerankCandidateCount(options.max_num_results);
+  auto budget = std::max({options.ef, options.max_num_results, top_limit});
+  auto extra_top_limit = budget - top_limit;
   next.push({best_dist, best_vector});
   if (!options.filter || std::apply(options.filter, cache.GetVectorIdAndPayload(best_vector))) {
     top.push({best_dist, best_vector});
@@ -833,6 +975,11 @@ void YbHnsw::SearchInBaseLayer(
 YbHnsw::DistanceType YbHnsw::Distance(const std::byte* lhs, const std::byte* rhs) const {
   DCHECK(metric_) << "Distance requested before Init/Import";
   return metric_->Distance(lhs, rhs);
+}
+
+YbHnsw::DistanceType YbHnsw::RerankDistance(const std::byte* lhs, const std::byte* rhs) const {
+  DCHECK(rerank_metric_) << "RerankDistance requested on a file without a rerank tier";
+  return rerank_metric_->Distance(lhs, rhs);
 }
 
 YbHnsw::DistanceType YbHnsw::Distance(
@@ -954,6 +1101,11 @@ const std::byte* SearchCache::CoordinatesPtr(size_t vector) {
 void SearchCache::PrefetchVectorHeaderBlock(size_t vector) {
   __builtin_prefetch(&blocks_[
       header_->vector_data_block + vector / header_->vector_data_amount_per_block]);
+}
+
+const std::byte* SearchCache::RerankCoordinatesPtr(size_t vector) {
+  DCHECK(header_->rerank_kind != vector_index::RerankStorageKind::kNone);
+  return CoordinatesPtr(vector) + header_->coordinates_size();
 }
 
 HnswDistanceType UsearchMetric::Distance(

--- a/src/yb/hnsw/hnsw.h
+++ b/src/yb/hnsw/hnsw.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <functional>
 #include <queue>
 
 #include <boost/range/iterator_range.hpp>
@@ -59,6 +60,11 @@ class SearchCache {
   std::pair<vector_index::VectorId, Slice> GetVectorIdAndPayload(size_t vector);
   const std::byte* CoordinatesPtr(size_t vector);
 
+  // Prefetches the blocks_ slot that VectorHeader(vector) will load. The slot index is pure
+  // arithmetic on the vector id, so it can be issued ahead of time, while the data-dependent
+  // load of the slot itself is something the CPU cannot speculate through.
+  void PrefetchVectorHeaderBlock(size_t vector);
+
  private:
   Slice GetVectorDataSlice(size_t vector);
   const std::byte* BlockPtr(
@@ -68,6 +74,10 @@ class SearchCache {
   FileBlockCache* file_block_cache_ = nullptr;
   std::vector<const std::byte*> blocks_;
   std::vector<size_t> used_blocks_;
+
+  // Block cache query/hit counts for the current search, flushed to the metrics in Release().
+  size_t takes_ = 0;
+  size_t hits_ = 0;
 };
 
 class SearchCacheScope {
@@ -107,6 +117,15 @@ struct YbHnswSearchContext {
   ExtraTop extra_top;
   NextQueue next;
   SearchCache search_cache;
+
+  // Query narrowed to the file's storage encoding. Grown once per pooled context and reused;
+  // unused when the file stores float32.
+  std::vector<std::byte> narrowed_query;
+
+  // Neighbours of the current node that passed the visited filter, with their record addresses
+  // already resolved. Reused across calls; bounded by the neighbour count, i.e. by
+  // config.connectivity_base.
+  std::vector<std::pair<VectorNo, const std::byte*>> unvisited;
 };
 
 class YbHnswMetric {
@@ -135,11 +154,17 @@ class YbHnsw {
   using MetricPtr = std::unique_ptr<Metric>;
   using SearchResult = std::vector<vector_index::VectorWithDistance<DistanceType>>;
 
-  YbHnsw(const UsearchMetric::Impl& metric, BlockCachePtr block_cache)
-      : YbHnsw(std::make_unique<UsearchMetric>(metric), block_cache) {
-  }
+  // Builds the metric for a dimension count and coordinate encoding. The metric decodes stored
+  // records, so it must agree with how they were written: Init() passes the encoding from the
+  // file's own footer, never caller-supplied configuration, which can drift from what the chunk
+  // actually contains.
+  using MetricFactory =
+      std::function<MetricPtr(size_t dimensions, vector_index::VectorStorageKind storage_kind)>;
 
-  YbHnsw(MetricPtr&& metric, BlockCachePtr block_cache);
+  // Convenience constructor for a fixed float32 metric.
+  YbHnsw(const UsearchMetric::Impl& metric, BlockCachePtr block_cache);
+
+  YbHnsw(MetricFactory metric_factory, BlockCachePtr block_cache);
   ~YbHnsw();
 
   // Imports specified index to YbHnsw structure, also storing this structure to disk.
@@ -150,22 +175,25 @@ class YbHnsw {
     const vector_index::VectorPayloadMap* payloads);
   Status Import(
     const HnswlibIndex<DistanceType>& index, const std::string& path,
-    const vector_index::VectorPayloadMap* payloads);
+    const vector_index::VectorPayloadMap* payloads,
+    vector_index::VectorStorageKind storage_kind = vector_index::VectorStorageKind::kFloat32);
 
   // Initialize YbHnsw from specified file, using block_cache to cache blocks.
   Status Init(const std::string& path);
 
+  // Searches with a query already in this file's storage encoding.
   SearchResult Search(
       const std::byte* query_vector, const vector_index::SearchOptions& options,
       YbHnswSearchContext& context) const;
 
+  // Narrows the query through the same conversion the stored records went through, then
+  // delegates to the overload above.
   SearchResult Search(
       const CoordinateType* query_vector, const vector_index::SearchOptions& options,
-      YbHnswSearchContext& context) const {
-    return Search(
-        pointer_cast<const std::byte*>(query_vector), options, context);
-  }
+      YbHnswSearchContext& context) const;
 
+  // Distance between two records in this file's storage encoding. Full-precision callers must
+  // narrow first -- see NarrowCoordinates.
   DistanceType Distance(const std::byte* lhs, const std::byte* rhs) const;
 
   const Header& header() const;
@@ -181,13 +209,13 @@ class YbHnsw {
   SearchResult MakeResult(size_t max_results, YbHnswSearchContext& context) const;
 
   DistanceType Distance(const std::byte* lhs, size_t vector, SearchCache& cache) const;
-  boost::iterator_range<MisalignedPtr<const CoordinateType>> MakeCoordinates(
-      const std::byte* ptr) const;
-  boost::iterator_range<MisalignedPtr<const CoordinateType>> Coordinates(
-      size_t vector, SearchCache& cache) const;
 
-  MetricPtr metric_;
+  // Builds metric_ from header_, which must already be populated.
+  void InitMetrics();
+
+  const MetricFactory metric_factory_;
   const BlockCachePtr block_cache_;
+  MetricPtr metric_;
 
   Header header_;
   FileBlockCachePtr file_block_cache_;

--- a/src/yb/hnsw/hnsw.h
+++ b/src/yb/hnsw/hnsw.h
@@ -60,6 +60,10 @@ class SearchCache {
   std::pair<vector_index::VectorId, Slice> GetVectorIdAndPayload(size_t vector);
   const std::byte* CoordinatesPtr(size_t vector);
 
+  // Rerank copy, which follows the traversal coordinates in the same record. Only meaningful
+  // when the bound header has a rerank tier.
+  const std::byte* RerankCoordinatesPtr(size_t vector);
+
   // Prefetches the blocks_ slot that VectorHeader(vector) will load. The slot index is pure
   // arithmetic on the vector id, so it can be issued ahead of time, while the data-dependent
   // load of the slot itself is something the CPU cannot speculate through.
@@ -118,9 +122,11 @@ struct YbHnswSearchContext {
   NextQueue next;
   SearchCache search_cache;
 
-  // Query narrowed to the file's storage encoding. Grown once per pooled context and reused;
-  // unused when the file stores float32.
+  // Query narrowed to the file's storage encoding, then to its rerank encoding. Grown once per
+  // pooled context and reused. Both are live at once on a chunk with a rerank tier, so they
+  // cannot share storage; neither is used when the file stores float32.
   std::vector<std::byte> narrowed_query;
+  std::vector<std::byte> rerank_query;
 
   // Neighbours of the current node that passed the visited filter, with their record addresses
   // already resolved. Reused across calls; bounded by the neighbour count, i.e. by
@@ -176,12 +182,14 @@ class YbHnsw {
   Status Import(
     const HnswlibIndex<DistanceType>& index, const std::string& path,
     const vector_index::VectorPayloadMap* payloads,
-    vector_index::VectorStorageKind storage_kind = vector_index::VectorStorageKind::kFloat32);
+    vector_index::VectorStorageKind storage_kind = vector_index::VectorStorageKind::kFloat32,
+    vector_index::RerankStorageKind rerank_kind = vector_index::RerankStorageKind::kNone);
 
   // Initialize YbHnsw from specified file, using block_cache to cache blocks.
   Status Init(const std::string& path);
 
-  // Searches with a query already in this file's storage encoding.
+  // Searches with a query already in this file's storage encoding. Does not fill
+  // context.rerank_query, so on a file with a rerank tier the caller must have done so.
   SearchResult Search(
       const std::byte* query_vector, const vector_index::SearchOptions& options,
       YbHnswSearchContext& context) const;
@@ -195,6 +203,10 @@ class YbHnsw {
   // Distance between two records in this file's storage encoding. Full-precision callers must
   // narrow first -- see NarrowCoordinates.
   DistanceType Distance(const std::byte* lhs, const std::byte* rhs) const;
+
+  // Distance between two records in this file's rerank encoding, i.e. in true metric units.
+  // Only valid when this file has a rerank tier.
+  DistanceType RerankDistance(const std::byte* lhs, const std::byte* rhs) const;
 
   const Header& header() const;
 
@@ -210,12 +222,19 @@ class YbHnsw {
 
   DistanceType Distance(const std::byte* lhs, size_t vector, SearchCache& cache) const;
 
-  // Builds metric_ from header_, which must already be populated.
+  // Builds metric_ and rerank_metric_ from header_, which must already be populated.
   void InitMetrics();
+
+  // Candidates a search must retain so reranking them yields the true top max_num_results.
+  // Equal to max_num_results without a rerank tier, leaving the heap limits unchanged.
+  size_t RerankCandidateCount(size_t max_num_results) const;
 
   const MetricFactory metric_factory_;
   const BlockCachePtr block_cache_;
   MetricPtr metric_;
+
+  // Metric over the rerank copy. Null when header_.rerank_kind is kNone.
+  MetricPtr rerank_metric_;
 
   Header header_;
   FileBlockCachePtr file_block_cache_;

--- a/src/yb/hnsw/hnsw_block_cache.cc
+++ b/src/yb/hnsw/hnsw_block_cache.cc
@@ -69,15 +69,22 @@ namespace {
 
 // Version 1: original layout.
 // Version 2: appends Header::storage_kind.
+// Version 3: appends Header::rerank_kind and Header::quantization_scale.
 //
 // The writer picks the lowest version that can represent the header, so a float32 index still
 // produces a byte-identical version-1 file readable by binaries that predate narrowed storage.
-// A version-2 file is not, so float16 is a one-way step for the chunks written while it is on.
+// Version-2 and -3 files are not, so enabling either is a one-way step for the chunks written
+// while it is on.
 constexpr uint8_t kSerializationVersionV1 = 1;
 constexpr uint8_t kSerializationVersionV2 = 2;
-constexpr uint8_t kMaxSupportedSerializationVersion = kSerializationVersionV2;
+constexpr uint8_t kSerializationVersionV3 = 3;
+constexpr uint8_t kMaxSupportedSerializationVersion = kSerializationVersionV3;
 
 uint8_t SerializationVersionFor(const Header& header) {
+  if (header.rerank_kind != vector_index::RerankStorageKind::kNone ||
+      header.storage_kind == vector_index::VectorStorageKind::kInt8) {
+    return kSerializationVersionV3;
+  }
   return header.storage_kind == vector_index::VectorStorageKind::kFloat32
       ? kSerializationVersionV1 : kSerializationVersionV2;
 }
@@ -104,6 +111,16 @@ template <class Type, class Value, class Writer>
 requires(std::is_enum_v<Value> && HasAppend<Type, Type, Writer>)
 void ConvertField(const Value& value, Writer& writer) {
   writer.template Append<Type>(static_cast<Type>(value));
+}
+
+// Floats go out as their bit pattern, keeping the on-disk form fixed-width and BlockWriter/
+// BlockReader dealing only in integers.
+template <class Writer>
+requires(HasAppend<uint32_t, uint32_t, Writer>)
+void ConvertFloatField(const float& value, Writer& writer) {
+  uint32_t bits;
+  memcpy(&bits, &value, sizeof(bits));
+  writer.template Append<uint32_t>(bits);
 }
 
 template <class Converter, class Type>
@@ -138,6 +155,13 @@ void ConvertField(Value& value, Reader& reader) {
   value = static_cast<Value>(reader.template Read<Type>());
 }
 
+template <class Reader>
+requires(HasRead<uint32_t, Reader>)
+void ConvertFloatField(float& value, Reader& reader) {
+  auto bits = reader.template Read<uint32_t>();
+  memcpy(&value, &bits, sizeof(value));
+}
+
 template <class Vector, class Reader>
 requires(HasRead<uint64_t, Reader>)
 void ConvertVector(size_t version, Vector& vector, Reader& reader) {
@@ -168,6 +192,10 @@ void Convert(size_t version, RefForConverter<Converter, Header> header, Converte
   ConvertVector(version, header.layers, serializer);
   if (version >= kSerializationVersionV2) {
     ConvertField<uint8_t>(header.storage_kind, serializer);
+  }
+  if (version >= kSerializationVersionV3) {
+    ConvertField<uint8_t>(header.rerank_kind, serializer);
+    ConvertFloatField(header.quantization_scale, serializer);
   }
   // Anything appended here must be consumed by this function: FileBlockCache::Load derives the
   // block count from the bytes the header converter leaves behind.

--- a/src/yb/hnsw/hnsw_block_cache.cc
+++ b/src/yb/hnsw/hnsw_block_cache.cc
@@ -13,12 +13,16 @@
 
 #include "yb/hnsw/hnsw_block_cache.h"
 
+#include <cstring>
+#include <type_traits>
+
 #include <boost/intrusive/list.hpp>
 
 #include "yb/hnsw/block_writer.h"
 #include "yb/rocksdb/cache.h"
 
 #include "yb/util/crc.h"
+#include "yb/util/format.h"
 #include "yb/util/metrics.h"
 #include "yb/util/size_literals.h"
 #include "yb/util/unique_lock.h"
@@ -63,6 +67,21 @@ namespace yb::hnsw {
 
 namespace {
 
+// Version 1: original layout.
+// Version 2: appends Header::storage_kind.
+//
+// The writer picks the lowest version that can represent the header, so a float32 index still
+// produces a byte-identical version-1 file readable by binaries that predate narrowed storage.
+// A version-2 file is not, so float16 is a one-way step for the chunks written while it is on.
+constexpr uint8_t kSerializationVersionV1 = 1;
+constexpr uint8_t kSerializationVersionV2 = 2;
+constexpr uint8_t kMaxSupportedSerializationVersion = kSerializationVersionV2;
+
+uint8_t SerializationVersionFor(const Header& header) {
+  return header.storage_kind == vector_index::VectorStorageKind::kFloat32
+      ? kSerializationVersionV1 : kSerializationVersionV2;
+}
+
 template <class Type, class Value, class Writer>
 concept HasAppend = requires(Writer& writer) {
   writer.template Append<Type>(std::declval<Value>());
@@ -74,9 +93,17 @@ concept HasRead = requires(Reader& reader) {
 };
 
 template <class Type, class Value, class Writer>
-requires(HasAppend<Type, Value, Writer>)
+requires(!std::is_enum_v<Value> && HasAppend<Type, Value, Writer>)
 void ConvertField(const Value& value, Writer& writer) {
   writer.template Append<Type>(value);
+}
+
+// Scoped enums do not convert implicitly, so they need their own overloads to serialize as
+// their underlying integer.
+template <class Type, class Value, class Writer>
+requires(std::is_enum_v<Value> && HasAppend<Type, Type, Writer>)
+void ConvertField(const Value& value, Writer& writer) {
+  writer.template Append<Type>(static_cast<Type>(value));
 }
 
 template <class Converter, class Type>
@@ -100,9 +127,15 @@ void ConvertVector(size_t version, const Vector& vector, Writer& writer) {
 }
 
 template <class Type, class Value, class Reader>
-requires(HasRead<Type, Reader>)
+requires(!std::is_enum_v<Value> && HasRead<Type, Reader>)
 void ConvertField(Value& value, Reader& reader) {
   value = reader.template Read<Type>();
+}
+
+template <class Type, class Value, class Reader>
+requires(std::is_enum_v<Value> && HasRead<Type, Reader>)
+void ConvertField(Value& value, Reader& reader) {
+  value = static_cast<Value>(reader.template Read<Type>());
 }
 
 template <class Vector, class Reader>
@@ -133,6 +166,11 @@ void Convert(size_t version, RefForConverter<Converter, Header> header, Converte
   ConvertField<uint64_t>(header.vector_data_block, serializer);
   ConvertField<uint64_t>(header.vector_data_amount_per_block, serializer);
   ConvertVector(version, header.layers, serializer);
+  if (version >= kSerializationVersionV2) {
+    ConvertField<uint8_t>(header.storage_kind, serializer);
+  }
+  // Anything appended here must be consumed by this function: FileBlockCache::Load derives the
+  // block count from the bytes the header converter leaves behind.
 }
 
 class WriteCounter {
@@ -150,16 +188,14 @@ class WriteCounter {
   size_t value_ = 0;
 };
 
-constexpr size_t kSerializationVersion = 1;
-
 template <class Out, class... Args>
-void Serialize(const Out& out, Args&&... args) {
-  Convert(kSerializationVersion, out, std::forward<Args&&>(args)...);
+void Serialize(uint8_t version, const Out& out, Args&&... args) {
+  Convert(version, out, std::forward<Args&&>(args)...);
 }
 
-size_t SerializedSize(const Header& header) {
+size_t SerializedSize(uint8_t version, const Header& header) {
   WriteCounter counter;
-  Convert(kSerializationVersion, header, counter);
+  Convert(version, header, counter);
   return counter.value();
 }
 
@@ -197,7 +233,7 @@ BlockCacheMetrics::BlockCacheMetrics(const MetricEntityPtr& entity)
       evict(METRIC_vector_index_cache_evict.Instantiate(entity)),
       remove(METRIC_vector_index_cache_remove.Instantiate(entity)),
       read_us(METRIC_vector_index_cache_read_us.Instantiate(entity)),
-      take_wait_us(METRIC_vector_index_cache_read_us.Instantiate(entity)) {
+      take_wait_us(METRIC_vector_index_cache_take_wait_us.Instantiate(entity)) {
 }
 
 struct CachedBlock {
@@ -236,13 +272,21 @@ struct CachedBlock {
     }
   }
 
-  Result<const std::byte*> Take(RandomAccessFile& file) {
-    cache->metrics().query->Increment();
-
+  // The cache_query/cache_hit counters are not touched here: they are reported through was_hit
+  // and accumulated by the caller, because at thousands of Take() calls per search the
+  // increments themselves showed up on the hot path.
+  Result<const std::byte*> Take(RandomAccessFile& file, bool* was_hit) {
+    // Written before any early return: both miss paths below would otherwise leave it untouched,
+    // making the counters depend on the caller having pre-initialized it.
+    if (was_hit) {
+      *was_hit = false;
+    }
     UniqueLock lock(mutex);
     ++use_count;
     if (content.data) {
-      cache->metrics().hit->Increment();
+      if (was_hit) {
+        *was_hit = true;
+      }
       auto result = content.data.get();
       auto need_handle = !handle && use_count == 1;
       lock.unlock();
@@ -333,14 +377,15 @@ struct CachedBlock {
 };
 
 DataBlock FileBlockCacheBuilder::MakeFooter(const Header& header) const {
+  const auto version = SerializationVersionFor(header);
   DataBlock buffer(
     sizeof(uint8_t) +
-    SerializedSize(header) + sizeof(uint64_t) * blocks_.size() +
+    SerializedSize(version, header) + sizeof(uint64_t) * blocks_.size() +
     sizeof(uint32_t) + // CRC32
     sizeof(uint64_t)); // Size
   BlockWriter writer(buffer);
-  writer.Append<uint8_t>(kSerializationVersion);
-  Serialize(header, writer);
+  writer.Append<uint8_t>(version);
+  Serialize(version, header, writer);
   uint64_t sum = 0;
   for (const auto& block : blocks_) {
     sum += block.size;
@@ -409,7 +454,12 @@ Result<Header> FileBlockCache::Load() {
   RSTATUS_DCHECK_EQ(expected_crc, found_crc, Corruption, "Wrong footer CRC");
   Header header;
   SliceReader reader(footer_data);
-  size_t version = reader.Read<uint8_t>();
+  // Without this an unknown version is read and ignored, and the extra header fields it carries
+  // are consumed as block offsets.
+  auto version = reader.Read<uint8_t>();
+  SCHECK(
+      version >= kSerializationVersionV1 && version <= kMaxSupportedSerializationVersion,
+      Corruption, Format("Unsupported YbHnsw serialization version: $0", version));
   Deserialize(version, header, reader);
   AllocateBlocks(reader.Left() / sizeof(uint64_t));
   size_t prev_end = 0;
@@ -421,8 +471,12 @@ Result<Header> FileBlockCache::Load() {
   return header;
 }
 
-Result<const std::byte*> FileBlockCache::Take(size_t index) {
-  return blocks_[index].Take(*file_);
+Result<const std::byte*> FileBlockCache::Take(size_t index, bool* was_hit) {
+  return blocks_[index].Take(*file_, was_hit);
+}
+
+BlockCacheMetrics& FileBlockCache::metrics() const {
+  return block_cache_.metrics();
 }
 
 void FileBlockCache::Release(size_t index) {

--- a/src/yb/hnsw/hnsw_block_cache.h
+++ b/src/yb/hnsw/hnsw_block_cache.h
@@ -68,8 +68,15 @@ class FileBlockCache {
     return size_;
   }
 
-  Result<const std::byte*> Take(size_t index);
+  // Takes a reference on a block. When was_hit is non-null it is set to whether the block was
+  // already resident, so the caller can account the cache_query/cache_hit counters itself. The
+  // search path uses this to batch those counters once per search rather than once per block --
+  // see SearchCache::Data. A caller that passes nullptr must account them another way: the
+  // counters have no other update site.
+  Result<const std::byte*> Take(size_t index, bool* was_hit = nullptr);
   void Release(size_t index);
+
+  BlockCacheMetrics& metrics() const;
 
  private:
   void AllocateBlocks(size_t size);

--- a/src/yb/hnsw/types.h
+++ b/src/yb/hnsw/types.h
@@ -18,7 +18,9 @@
 #include "yb/util/logging.h"
 #include "yb/util/tostring.h"
 
+#include "yb/vector_index/coordinate_codec.h"
 #include "yb/vector_index/vector_index_fwd.h"
+#include "yb/vector_index/vector_storage_kind.h"
 
 namespace hnswlib {
 
@@ -80,10 +82,15 @@ struct Header {
   size_t vector_data_amount_per_block;
   std::vector<LayerInfo> layers;
 
+  // Coordinate encoding the graph traversal computes distances on, stored first in each vector
+  // data record. Absent from version-1 footers, which are always float32.
+  vector_index::VectorStorageKind storage_kind = vector_index::VectorStorageKind::kFloat32;
+
   std::string ToString() const {
     return YB_STRUCT_TO_STRING(
         dimensions, vector_data_size, entry, max_level, config, max_block_size,
-        max_vectors_per_non_base_block, vector_data_block, vector_data_amount_per_block, layers);
+        max_vectors_per_non_base_block, vector_data_block, vector_data_amount_per_block, layers,
+        storage_kind);
   }
 };
 

--- a/src/yb/hnsw/types.h
+++ b/src/yb/hnsw/types.h
@@ -86,11 +86,25 @@ struct Header {
   // data record. Absent from version-1 footers, which are always float32.
   vector_index::VectorStorageKind storage_kind = vector_index::VectorStorageKind::kFloat32;
 
+  // Encoding of the rerank copy, stored right after the traversal coordinates in the same
+  // record. kNone means no second copy and traversal distances are returned as-is. Absent
+  // from footers before version 3.
+  vector_index::RerankStorageKind rerank_kind = vector_index::RerankStorageKind::kNone;
+
+  // Quantization step for kInt8 traversal coordinates: stored = round(coordinate / scale).
+  // Derived per chunk, so it must be read from the file and never recomputed. Zero otherwise.
+  float quantization_scale = 0;
+
+  // Bytes the traversal metric reads from a record, i.e. the offset of the rerank copy in it.
+  size_t coordinates_size() const {
+    return vector_index::CoordinateBytes(storage_kind, dimensions);
+  }
+
   std::string ToString() const {
     return YB_STRUCT_TO_STRING(
         dimensions, vector_data_size, entry, max_level, config, max_block_size,
         max_vectors_per_non_base_block, vector_data_block, vector_data_amount_per_block, layers,
-        storage_kind);
+        storage_kind, rerank_kind, quantization_scale);
   }
 };
 

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -642,17 +642,22 @@ TAG_FLAG(vector_index_backend, advanced);
 
 static constexpr char kVectorStorageFloat32[] = "float32";
 static constexpr char kVectorStorageFloat16[] = "float16";
+static constexpr char kVectorStorageInt8[] = "int8";
 
 DEFINE_RUNTIME_string(vector_index_storage_coordinate_type, kVectorStorageFloat32,
     "Coordinate encoding for the on-disk chunks of newly created vector indexes. \"float32\" "
     "stores full precision. \"float16\" halves the coordinate bytes of every served chunk, so "
-    "roughly twice as much of the index fits in the block cache, at a small recall cost. The "
-    "graph is built at full precision in either case. Recorded per index at creation time, so it "
-    "never changes for an existing index, and chunks written as anything other than float32 "
-    "cannot be read by releases that predate the encoding.");
+    "roughly twice as much of the index fits in the block cache, at a small recall cost. "
+    "\"int8\" quarters the bytes a distance evaluation touches and stores a float16 rerank copy "
+    "alongside, which makes the whole record 0.75x float32 -- so it trades disk against search "
+    "cost in the other direction from \"float16\" and suits an index that already fits in the "
+    "block cache. The graph is built at full precision in every case. Recorded per index at "
+    "creation time, so it never changes for an existing index, and chunks written as anything "
+    "other than float32 cannot be read by releases that predate the encoding.");
 
 DEFINE_validator(vector_index_storage_coordinate_type,
-    FLAG_IN_SET_VALIDATOR(kVectorStorageFloat32, kVectorStorageFloat16));
+    FLAG_IN_SET_VALIDATOR(
+        kVectorStorageFloat32, kVectorStorageFloat16, kVectorStorageInt8));
 
 TAG_FLAG(vector_index_storage_coordinate_type, advanced);
 
@@ -4707,6 +4712,8 @@ Status CatalogManager::CreateTable(const CreateTableRequestPB* orig_req,
       const auto storage_type = FLAGS_vector_index_storage_coordinate_type;
       if (storage_type == kVectorStorageFloat16) {
         vector_index_options.mutable_hnsw()->set_storage_type(VectorStorageType::STORAGE_FLOAT16);
+      } else if (storage_type == kVectorStorageInt8) {
+        vector_index_options.mutable_hnsw()->set_storage_type(VectorStorageType::STORAGE_INT8);
       }
     } else if (!is_pg_table) {
       DCHECK_EQ(index_info.columns().size(), schema.num_columns())

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -640,6 +640,22 @@ DEFINE_validator(vector_index_backend,
 TAG_FLAG(vector_index_backend, hidden);
 TAG_FLAG(vector_index_backend, advanced);
 
+static constexpr char kVectorStorageFloat32[] = "float32";
+static constexpr char kVectorStorageFloat16[] = "float16";
+
+DEFINE_RUNTIME_string(vector_index_storage_coordinate_type, kVectorStorageFloat32,
+    "Coordinate encoding for the on-disk chunks of newly created vector indexes. \"float32\" "
+    "stores full precision. \"float16\" halves the coordinate bytes of every served chunk, so "
+    "roughly twice as much of the index fits in the block cache, at a small recall cost. The "
+    "graph is built at full precision in either case. Recorded per index at creation time, so it "
+    "never changes for an existing index, and chunks written as anything other than float32 "
+    "cannot be read by releases that predate the encoding.");
+
+DEFINE_validator(vector_index_storage_coordinate_type,
+    FLAG_IN_SET_VALIDATOR(kVectorStorageFloat32, kVectorStorageFloat16));
+
+TAG_FLAG(vector_index_storage_coordinate_type, advanced);
+
 DEFINE_RUNTIME_AUTO_bool(enable_table_owned_vector_reverse_mapping, kExternal, false, true,
     "When true, newly created YSQL tables hold vector reverse mapping ownership. "
     "Such tables write vector reverse mappings on row insert/update regardless of "
@@ -4685,6 +4701,12 @@ Status CatalogManager::CreateTable(const CreateTableRequestPB* orig_req,
         vector_index_options.mutable_hnsw()->set_backend(HnswBackend::YB_HNSW_USEARCH);
       } else if (backend == kYbHnswHnswlib) {
         vector_index_options.mutable_hnsw()->set_backend(HnswBackend::YB_HNSW_HNSWLIB);
+      }
+      // Copied, not referenced: the flag is runtime-settable, so holding a reference to its
+      // std::string races with a concurrent set. The backend flag above is read the same way.
+      const auto storage_type = FLAGS_vector_index_storage_coordinate_type;
+      if (storage_type == kVectorStorageFloat16) {
+        vector_index_options.mutable_hnsw()->set_storage_type(VectorStorageType::STORAGE_FLOAT16);
       }
     } else if (!is_pg_table) {
       DCHECK_EQ(index_info.columns().size(), schema.num_columns())

--- a/src/yb/vector_index/CMakeLists.txt
+++ b/src/yb/vector_index/CMakeLists.txt
@@ -38,6 +38,7 @@ set(VECTOR_INDEX_SRCS
   vector_lsm_metadata.cc
   vector_lsm_metrics.cc
   vector_payload_map.cc
+  vector_storage_kind.cc
   )
 
 set(VECTOR_INDEX_LIBS

--- a/src/yb/vector_index/CMakeLists.txt
+++ b/src/yb/vector_index/CMakeLists.txt
@@ -29,6 +29,7 @@ ADD_YB_LIBRARY(vector_index_proto
 set(VECTOR_INDEX_SRCS
   ann_validation.cc
   benchmark_data.cc
+  coordinate_codec.cc
   hnsw_options.cc
   hnsw_util.cc
   index_wrapper_base.cc
@@ -58,4 +59,5 @@ add_dependencies(
 set(YB_TEST_LINK_LIBS
     vector_index yb_common_test_util ${YB_MIN_TEST_LIBS})
 
+ADD_YB_TEST(coordinate_codec-test)
 ADD_YB_TEST(hnsw_util-test)

--- a/src/yb/vector_index/coordinate_codec-test.cc
+++ b/src/yb/vector_index/coordinate_codec-test.cc
@@ -38,6 +38,21 @@ std::vector<float> Widen(VectorStorageKind kind, const std::vector<std::byte>& i
   return out;
 }
 
+std::vector<std::byte> Narrow(
+    VectorStorageKind kind, float scale, const std::vector<float>& in,
+    size_t* clamped = nullptr) {
+  std::vector<std::byte> out(CoordinateBytes(kind, in.size()));
+  NarrowCoordinates(kind, scale, in.data(), in.size(), out.data(), clamped);
+  return out;
+}
+
+std::vector<float> Widen(
+    VectorStorageKind kind, float scale, const std::vector<std::byte>& in, size_t dims) {
+  std::vector<float> out(dims);
+  WidenCoordinates(kind, scale, in.data(), dims, out.data());
+  return out;
+}
+
 std::vector<float> RandomVector(size_t dimensions) {
   std::mt19937_64 rng(42);
   std::uniform_real_distribution<float> dis(-1.0f, 1.0f);
@@ -165,18 +180,181 @@ TEST_F(CoordinateCodecTest, HandlesUnalignedBuffers) {
   constexpr size_t kDims = 37;
   auto in = RandomVector(kDims);
 
+  constexpr float kScale = 0.01f;
+
   for (size_t offset = 0; offset != 4; ++offset) {
-    for (auto kind : {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16}) {
+    for (auto kind : {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16,
+                      VectorStorageKind::kInt8}) {
       std::vector<std::byte> buffer(CoordinateBytes(kind, kDims) + offset);
-      NarrowCoordinates(kind, in.data(), kDims, buffer.data() + offset);
+      NarrowCoordinates(kind, kScale, in.data(), kDims, buffer.data() + offset);
 
       std::vector<float> back(kDims);
-      WidenCoordinates(kind, buffer.data() + offset, kDims, back.data());
+      WidenCoordinates(kind, kScale, buffer.data() + offset, kDims, back.data());
 
-      ASSERT_EQ(Widen(kind, Narrow(kind, in), kDims), back)
-          << "kind: " << kind << ", offset: " << offset;
+      auto aligned = Widen(kind, kScale, Narrow(kind, kScale, in), kDims);
+      ASSERT_EQ(aligned, back) << "kind: " << kind << ", offset: " << offset;
     }
   }
+}
+
+
+TEST_F(CoordinateCodecTest, Int8SizeMatchesScalarWidth) {
+  ASSERT_EQ(CoordinateBytes(VectorStorageKind::kInt8, 768), size_t{768});
+  ASSERT_EQ(CoordinateBytes(VectorStorageKind::kInt8, 0), size_t{0});
+}
+
+// Everything else in the design rests on this: a value that has been through the codec once must
+// re-encode to the same bytes, or repeated compaction walks a vector away from where it started.
+TEST_F(CoordinateCodecTest, Int8NarrowingIsIdempotent) {
+  constexpr size_t kDims = 97;
+  constexpr float kScale = 0.003f;
+  auto in = RandomVector(kDims);
+
+  auto once = Narrow(VectorStorageKind::kInt8, kScale, in);
+  auto widened = Widen(VectorStorageKind::kInt8, kScale, once, kDims);
+  auto twice = Narrow(VectorStorageKind::kInt8, kScale, widened);
+  ASSERT_EQ(once, twice);
+
+  auto widened_again = Widen(VectorStorageKind::kInt8, kScale, twice, kDims);
+  ASSERT_EQ(widened, widened_again);
+}
+
+// The writer and the query path both come through here, so the same input has to produce the same
+// bytes -- otherwise an indexed vector stops being at distance zero from itself.
+TEST_F(CoordinateCodecTest, Int8SameInputNarrowsToSameBytes) {
+  constexpr size_t kDims = 64;
+  constexpr float kScale = 0.007f;
+  auto in = RandomVector(kDims);
+  ASSERT_EQ(
+      Narrow(VectorStorageKind::kInt8, kScale, in),
+      Narrow(VectorStorageKind::kInt8, kScale, in));
+}
+
+// int8's guarantee is absolute, not relative: within half a quantization step everywhere in
+// range. That is the opposite shape from float16, whose bound is relative and collapses for
+// subnormals, and it is why the two encodings suit different jobs.
+TEST_F(CoordinateCodecTest, Int8ErrorIsWithinHalfAStep) {
+  constexpr size_t kDims = 512;
+  // The scale has to cover RandomVector's [-1, 1]: int8 represents +-127 steps, so anything
+  // beyond 127 * kScale clamps and its error is the distance to the range edge, not a rounding
+  // error. Picking a scale narrower than the inputs tests clamping, which
+  // Int8ClampsOutOfRangeCoordinates already covers, and says nothing about the bound below.
+  constexpr float kScale = 1.0f / 127;
+
+  auto in = RandomVector(kDims);
+  // Include the exact boundaries and a value far below the step size.
+  in[0] = 0.0f;
+  in[1] = kScale;
+  in[2] = -kScale;
+  in[3] = kScale / 2;
+  in[4] = kScale * 126.5f;
+  in[5] = 1e-30f;
+
+  auto back = Widen(
+      VectorStorageKind::kInt8, kScale, Narrow(VectorStorageKind::kInt8, kScale, in), kDims);
+
+  float worst = 0;
+  for (size_t i = 0; i != kDims; ++i) {
+    worst = std::max(worst, std::fabs(back[i] - in[i]));
+  }
+  LOG(INFO) << "worst absolute int8 error: " << worst << ", half a step: " << kScale / 2;
+  ASSERT_LE(worst, kScale / 2 * 1.0001f);
+
+  // Zero is exact at any scale, which is what makes an all-zero vector's self-distance zero.
+  ASSERT_EQ(back[0], 0.0f);
+  ASSERT_EQ(back[1], kScale);
+  ASSERT_EQ(back[2], -kScale);
+}
+
+// float16 saturates an out-of-range magnitude to infinity; an out-of-range float -> int8_t
+// conversion is undefined behaviour instead. So the clamp here is not just protecting accuracy,
+// it is the only thing keeping the stored byte meaningful at all.
+TEST_F(CoordinateCodecTest, Int8ClampsValuesOutsideRange) {
+  constexpr float kScale = 0.01f;
+  size_t clamped = 0;
+  std::vector<float> in = {
+      0.0f,                      // exact
+      kScale * 127,              // the largest in-range value
+      -kScale * 127,             // and its negation
+      kScale * 128,              // one step past
+      1e9f,                      // far past
+      -1e9f,
+      std::numeric_limits<float>::quiet_NaN(),
+  };
+  auto out = Narrow(VectorStorageKind::kInt8, kScale, in, &clamped);
+  const auto* bytes = reinterpret_cast<const int8_t*>(out.data());
+
+  ASSERT_EQ(bytes[0], 0);
+  ASSERT_EQ(bytes[1], 127);
+  ASSERT_EQ(bytes[2], -127);
+  ASSERT_EQ(bytes[3], 127);
+  ASSERT_EQ(bytes[4], 127);
+  ASSERT_EQ(bytes[5], -127);
+  // NaN becomes zero rather than an arbitrary byte.
+  ASSERT_EQ(bytes[6], 0);
+
+  // kScale * 128, +-1e9 and NaN are out of range; 0 and +-kScale * 127 are not.
+  ASSERT_EQ(clamped, size_t{4});
+
+  // Every byte is a valid int8, which is the undefined behaviour the clamp prevents.
+  for (size_t i = 0; i != in.size(); ++i) {
+    ASSERT_GE(bytes[i], -127) << "index " << i;
+    ASSERT_LE(bytes[i], 127) << "index " << i;
+  }
+}
+
+TEST_F(CoordinateCodecTest, Int8ClampCounterAccumulates) {
+  constexpr float kScale = 0.01f;
+  size_t clamped = 0;
+  Narrow(VectorStorageKind::kInt8, kScale, {1e9f}, &clamped);
+  Narrow(VectorStorageKind::kInt8, kScale, {1e9f, -1e9f}, &clamped);
+  ASSERT_EQ(clamped, size_t{3});
+}
+
+// The two encodings sit back to back in one record, so writing the second must not disturb the
+// first and reading either must not stray into the other.
+TEST_F(CoordinateCodecTest, InterleavedEncodingsDoNotOverlap) {
+  constexpr size_t kDims = 97;
+  constexpr float kScale = 0.003f;
+  constexpr size_t kRecordHeader = 20;   // sizeof(YbHnswVectorData)
+  auto in = RandomVector(kDims);
+
+  const auto traversal_bytes = CoordinateBytes(VectorStorageKind::kInt8, kDims);
+  const auto rerank_bytes = CoordinateBytes(VectorStorageKind::kFloat16, kDims);
+  std::vector<std::byte> record(kRecordHeader + traversal_bytes + rerank_bytes);
+
+  NarrowCoordinates(
+      VectorStorageKind::kInt8, kScale, in.data(), kDims, record.data() + kRecordHeader);
+  NarrowCoordinates(
+      VectorStorageKind::kFloat16, in.data(), kDims,
+      record.data() + kRecordHeader + traversal_bytes);
+
+  std::vector<float> traversal(kDims), rerank(kDims);
+  WidenCoordinates(
+      VectorStorageKind::kInt8, kScale, record.data() + kRecordHeader, kDims, traversal.data());
+  WidenCoordinates(
+      VectorStorageKind::kFloat16, record.data() + kRecordHeader + traversal_bytes, kDims,
+      rerank.data());
+
+  ASSERT_EQ(traversal, Widen(
+      VectorStorageKind::kInt8, kScale, Narrow(VectorStorageKind::kInt8, kScale, in), kDims));
+  ASSERT_EQ(rerank, Widen(
+      VectorStorageKind::kFloat16, Narrow(VectorStorageKind::kFloat16, in), kDims));
+
+  // The rerank copy has to be materially closer to the original, or it cannot correct anything.
+  float traversal_worst = 0, rerank_worst = 0;
+  for (size_t i = 0; i != kDims; ++i) {
+    traversal_worst = std::max(traversal_worst, std::fabs(traversal[i] - in[i]));
+    rerank_worst = std::max(rerank_worst, std::fabs(rerank[i] - in[i]));
+  }
+  LOG(INFO) << "traversal worst error " << traversal_worst << ", rerank worst error "
+            << rerank_worst;
+  ASSERT_LT(rerank_worst, traversal_worst);
+}
+
+TEST_F(CoordinateCodecTest, StorageKindForRerankMapsEveryTier) {
+  ASSERT_EQ(StorageKindForRerank(RerankStorageKind::kFloat16), VectorStorageKind::kFloat16);
+  ASSERT_EQ(StorageKindForRerank(RerankStorageKind::kFloat32), VectorStorageKind::kFloat32);
 }
 
 }  // namespace yb::vector_index

--- a/src/yb/vector_index/coordinate_codec-test.cc
+++ b/src/yb/vector_index/coordinate_codec-test.cc
@@ -1,0 +1,182 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include <cmath>
+#include <limits>
+#include <random>
+#include <vector>
+
+#include "yb/vector_index/coordinate_codec.h"
+
+#include "yb/util/logging.h"
+#include "yb/util/test_util.h"
+
+namespace yb::vector_index {
+
+namespace {
+
+std::vector<std::byte> Narrow(
+    VectorStorageKind kind, const std::vector<float>& in, size_t* clamped = nullptr) {
+  std::vector<std::byte> out(CoordinateBytes(kind, in.size()));
+  NarrowCoordinates(kind, in.data(), in.size(), out.data(), clamped);
+  return out;
+}
+
+std::vector<float> Widen(VectorStorageKind kind, const std::vector<std::byte>& in, size_t dims) {
+  std::vector<float> out(dims);
+  WidenCoordinates(kind, in.data(), dims, out.data());
+  return out;
+}
+
+std::vector<float> RandomVector(size_t dimensions) {
+  std::mt19937_64 rng(42);
+  std::uniform_real_distribution<float> dis(-1.0f, 1.0f);
+  std::vector<float> result(dimensions);
+  for (auto& value : result) {
+    value = dis(rng);
+  }
+  return result;
+}
+
+}  // namespace
+
+class CoordinateCodecTest : public YBTest {
+};
+
+TEST_F(CoordinateCodecTest, SizesMatchScalarWidths) {
+  for (size_t dims : {1, 8, 128, 384, 768, 1536}) {
+    ASSERT_EQ(CoordinateBytes(VectorStorageKind::kFloat32, dims), dims * 4);
+    ASSERT_EQ(CoordinateBytes(VectorStorageKind::kFloat16, dims), dims * 2);
+  }
+}
+
+TEST_F(CoordinateCodecTest, Float32IsIdentity) {
+  std::vector<float> in{-1.5f, 0.0f, 3.25f, 1e20f, -1e-20f};
+  auto widened = Widen(VectorStorageKind::kFloat32, Narrow(VectorStorageKind::kFloat32, in),
+                       in.size());
+  ASSERT_EQ(in, widened);
+}
+
+// Repeated compaction reads chunks back through WidenCoordinates and writes them out through
+// NarrowCoordinates again. If that were not idempotent, precision would drift a little on every
+// compaction until the index no longer resembled the vectors it was built from.
+TEST_F(CoordinateCodecTest, NarrowingIsIdempotent) {
+  constexpr size_t kDims = 4096;
+  std::vector<float> in(kDims);
+  for (size_t i = 0; i != kDims; ++i) {
+    // Sweep sign and eleven orders of magnitude, including the subnormal range.
+    in[i] = static_cast<float>(
+        std::sin(static_cast<double>(i) * 0.37) * std::pow(10.0, (i % 11) - 6));
+  }
+
+  auto once = Narrow(VectorStorageKind::kFloat16, in);
+  auto twice = Narrow(
+      VectorStorageKind::kFloat16, Widen(VectorStorageKind::kFloat16, once, kDims));
+  ASSERT_EQ(once, twice);
+}
+
+// The writer and the query path share this function precisely so that a vector is still at
+// distance zero from itself after narrowing.
+TEST_F(CoordinateCodecTest, SameInputNarrowsToSameBytes) {
+  auto in = RandomVector(1536);
+  ASSERT_EQ(Narrow(VectorStorageKind::kFloat16, in), Narrow(VectorStorageKind::kFloat16, in));
+}
+
+// Two separate bounds, because only the first one is a relative bound. Coordinates below fp16's
+// smallest normal lose relative precision entirely, but their absolute error stays tiny, which
+// is all a squared distance is sensitive to.
+TEST_F(CoordinateCodecTest, Float16ErrorBounds) {
+  constexpr size_t kSamples = 20000;
+  constexpr float kRelativeBound = 4.883e-4f;  // 2^-11
+  constexpr float kAbsoluteBound = 3e-8f;
+  constexpr float kMinNormal = 6.103515625e-05f;  // fp16's smallest normal, the sweep boundary
+
+  double worst_relative = 0;
+  for (size_t i = 0; i <= kSamples; ++i) {
+    const float value = static_cast<float>(
+        kMinNormal * std::pow(6.5e4 / kMinNormal,
+                                     static_cast<double>(i) / kSamples));
+    const auto back = Widen(
+        VectorStorageKind::kFloat16, Narrow(VectorStorageKind::kFloat16, {value}), 1)[0];
+    worst_relative = std::max<double>(worst_relative, std::fabs((back - value) / value));
+  }
+  ASSERT_LE(worst_relative, kRelativeBound) << "relative error over fp16 normals";
+
+  double worst_absolute = 0;
+  for (size_t i = 0; i <= kSamples; ++i) {
+    const float value = static_cast<float>(
+        1e-10 * std::pow(kMinNormal / 1e-10, static_cast<double>(i) / kSamples));
+    const auto back = Widen(
+        VectorStorageKind::kFloat16, Narrow(VectorStorageKind::kFloat16, {value}), 1)[0];
+    worst_absolute = std::max<double>(worst_absolute, std::fabs(back - value));
+  }
+  ASSERT_LE(worst_absolute, kAbsoluteBound) << "absolute error below fp16's smallest normal";
+}
+
+// Without clamping, fp16_ieee_from_fp32_value saturates to infinity, and inf - inf makes every
+// distance to the vector NaN -- which corrupts the ordering of the search heaps silently rather
+// than failing. Same for a NaN coordinate arriving from the table.
+TEST_F(CoordinateCodecTest, ClampsValuesOutsideFloat16Range) {
+  const std::vector<float> in{1e30f, -1e30f, std::numeric_limits<float>::quiet_NaN(),
+                              kMaxFloat16, 65520.0f, 1.0f};
+  size_t clamped = 0;
+  auto back = Widen(
+      VectorStorageKind::kFloat16, Narrow(VectorStorageKind::kFloat16, in, &clamped), in.size());
+
+  for (size_t i = 0; i != back.size(); ++i) {
+    ASSERT_TRUE(std::isfinite(back[i])) << "coordinate " << i << " = " << back[i];
+  }
+  ASSERT_EQ(back[0], kMaxFloat16);
+  ASSERT_EQ(back[1], -kMaxFloat16);
+  ASSERT_EQ(back[2], 0.0f);
+  ASSERT_EQ(back[3], kMaxFloat16);
+  ASSERT_EQ(back[4], kMaxFloat16);
+  ASSERT_EQ(back[5], 1.0f);
+
+  // 1e30, -1e30, NaN and 65520 are all outside the representable range; 65504 and 1.0 are not.
+  ASSERT_EQ(clamped, size_t{4});
+
+  size_t none = 0;
+  Narrow(VectorStorageKind::kFloat16, {0.0f, 1.0f, -1.0f, kMaxFloat16}, &none);
+  ASSERT_EQ(none, size_t{0});
+}
+
+// The clamp counter accumulates so a caller can total it across a whole index build.
+TEST_F(CoordinateCodecTest, ClampCounterAccumulates) {
+  size_t clamped = 0;
+  Narrow(VectorStorageKind::kFloat16, {1e30f}, &clamped);
+  Narrow(VectorStorageKind::kFloat16, {1e30f, 1e30f}, &clamped);
+  ASSERT_EQ(clamped, size_t{3});
+}
+
+// Coordinates land at unaligned offsets inside a YbHnsw record (20 bytes in, with a stride that
+// is not a multiple of 4), so neither side of the codec may assume alignment.
+TEST_F(CoordinateCodecTest, HandlesUnalignedBuffers) {
+  constexpr size_t kDims = 37;
+  auto in = RandomVector(kDims);
+
+  for (size_t offset = 0; offset != 4; ++offset) {
+    for (auto kind : {VectorStorageKind::kFloat32, VectorStorageKind::kFloat16}) {
+      std::vector<std::byte> buffer(CoordinateBytes(kind, kDims) + offset);
+      NarrowCoordinates(kind, in.data(), kDims, buffer.data() + offset);
+
+      std::vector<float> back(kDims);
+      WidenCoordinates(kind, buffer.data() + offset, kDims, back.data());
+
+      ASSERT_EQ(Widen(kind, Narrow(kind, in), kDims), back)
+          << "kind: " << kind << ", offset: " << offset;
+    }
+  }
+}
+
+}  // namespace yb::vector_index

--- a/src/yb/vector_index/coordinate_codec.cc
+++ b/src/yb/vector_index/coordinate_codec.cc
@@ -45,12 +45,25 @@ size_t CoordinateBytes(VectorStorageKind kind, size_t dimensions) {
       return dimensions * sizeof(float);
     case VectorStorageKind::kFloat16:
       return dimensions * sizeof(uint16_t);
+    case VectorStorageKind::kInt8:
+      return dimensions * sizeof(int8_t);
   }
   FATAL_INVALID_ENUM_VALUE(VectorStorageKind, kind);
 }
 
 void NarrowCoordinates(
     VectorStorageKind kind, const float* src, size_t dimensions, void* dst,
+    size_t* num_clamped) {
+  // CHECK, not DCHECK: with a zero scale every coordinate quantizes to the clamp limit, so in a
+  // release build this would silently write 127s over a whole chunk. Once per vector, not per
+  // coordinate.
+  CHECK_NE(kind, VectorStorageKind::kInt8)
+      << "kInt8 needs a scale: use the overload that takes one";
+  return NarrowCoordinates(kind, 0.0f, src, dimensions, dst, num_clamped);
+}
+
+void NarrowCoordinates(
+    VectorStorageKind kind, float scale, const float* src, size_t dimensions, void* dst,
     size_t* num_clamped) {
   switch (kind) {
     case VectorStorageKind::kFloat32:
@@ -74,12 +87,50 @@ void NarrowCoordinates(
       }
       return;
     }
+    case VectorStorageKind::kInt8: {
+      // Zero would make every coordinate infinite and a negative scale would invert the
+      // ordering; neither is recoverable downstream.
+      DCHECK_GT(scale, 0.0f);
+      const auto inv_scale = 1.0f / scale;
+      auto* out = static_cast<int8_t*>(dst);
+      size_t clamped = 0;
+      for (size_t i = 0; i != dimensions; ++i) {
+        // Checked before scaling so NaN is counted, not turned into a zero that passes the
+        // range test below.
+        if (PREDICT_FALSE(std::isnan(src[i]))) {
+          ++clamped;
+          out[i] = 0;
+          continue;
+        }
+        // Round before the range test, not after: a coordinate just past 127 steps rounds back
+        // to 127 and has lost nothing, so it is not clamping. The clamp itself is load-bearing --
+        // an out-of-range float -> int8_t conversion is undefined behaviour, not saturating.
+        auto value = std::round(src[i] * inv_scale);
+        if (PREDICT_FALSE(!(value >= -kMaxInt8 && value <= kMaxInt8))) {
+          ++clamped;
+          value = std::copysign(kMaxInt8, value);
+        }
+        out[i] = static_cast<int8_t>(value);
+      }
+      if (num_clamped) {
+        *num_clamped += clamped;
+      }
+      return;
+    }
   }
   FATAL_INVALID_ENUM_VALUE(VectorStorageKind, kind);
 }
 
 void WidenCoordinates(
     VectorStorageKind kind, const void* src, size_t dimensions, float* dst) {
+  // See the NarrowCoordinates counterpart: a zero scale decodes every coordinate to zero.
+  CHECK_NE(kind, VectorStorageKind::kInt8)
+      << "kInt8 needs a scale: use the overload that takes one";
+  return WidenCoordinates(kind, 0.0f, src, dimensions, dst);
+}
+
+void WidenCoordinates(
+    VectorStorageKind kind, float scale, const void* src, size_t dimensions, float* dst) {
   switch (kind) {
     case VectorStorageKind::kFloat32:
       memcpy(dst, src, dimensions * sizeof(float));
@@ -89,6 +140,14 @@ void WidenCoordinates(
         dst[i] = fp16_ieee_to_fp32_value(LoadU16(src, i));
       }
       return;
+    case VectorStorageKind::kInt8: {
+      DCHECK_GT(scale, 0.0f);
+      const auto* in = static_cast<const int8_t*>(src);
+      for (size_t i = 0; i != dimensions; ++i) {
+        dst[i] = static_cast<float>(in[i]) * scale;
+      }
+      return;
+    }
   }
   FATAL_INVALID_ENUM_VALUE(VectorStorageKind, kind);
 }

--- a/src/yb/vector_index/coordinate_codec.cc
+++ b/src/yb/vector_index/coordinate_codec.cc
@@ -1,0 +1,96 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/vector_index/coordinate_codec.h"
+
+#include <cmath>
+#include <cstring>
+
+#include "fp16/fp16.h"
+
+#include "yb/util/logging.h"
+
+namespace yb::vector_index {
+
+namespace {
+
+// Records sit at whatever offset the surrounding layout gives them (YbHnsw coordinates start 20
+// bytes into a record whose stride is not a multiple of 4), so every access goes through memcpy
+// rather than a typed load.
+uint16_t LoadU16(const void* src, size_t index) {
+  uint16_t result;
+  memcpy(&result, static_cast<const std::byte*>(src) + index * sizeof(uint16_t), sizeof(result));
+  return result;
+}
+
+void StoreU16(void* dst, size_t index, uint16_t value) {
+  memcpy(static_cast<std::byte*>(dst) + index * sizeof(uint16_t), &value, sizeof(value));
+}
+
+}  // namespace
+
+size_t CoordinateBytes(VectorStorageKind kind, size_t dimensions) {
+  switch (kind) {
+    case VectorStorageKind::kFloat32:
+      return dimensions * sizeof(float);
+    case VectorStorageKind::kFloat16:
+      return dimensions * sizeof(uint16_t);
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageKind, kind);
+}
+
+void NarrowCoordinates(
+    VectorStorageKind kind, const float* src, size_t dimensions, void* dst,
+    size_t* num_clamped) {
+  switch (kind) {
+    case VectorStorageKind::kFloat32:
+      memcpy(dst, src, dimensions * sizeof(float));
+      return;
+    case VectorStorageKind::kFloat16: {
+      size_t clamped = 0;
+      for (size_t i = 0; i != dimensions; ++i) {
+        auto value = src[i];
+        // NaN fails both comparisons, so it takes the same branch as an out-of-range magnitude.
+        // TODO(vector_index): vectorize with _mm256_cvtps_ph. The scalar conversion costs ~8us
+        // per query at 1536 dimensions, once per chunk per search.
+        if (PREDICT_FALSE(!(value >= -kMaxFloat16 && value <= kMaxFloat16))) {
+          ++clamped;
+          value = std::isnan(value) ? 0.0f : std::copysign(kMaxFloat16, value);
+        }
+        StoreU16(dst, i, fp16_ieee_from_fp32_value(value));
+      }
+      if (num_clamped) {
+        *num_clamped += clamped;
+      }
+      return;
+    }
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageKind, kind);
+}
+
+void WidenCoordinates(
+    VectorStorageKind kind, const void* src, size_t dimensions, float* dst) {
+  switch (kind) {
+    case VectorStorageKind::kFloat32:
+      memcpy(dst, src, dimensions * sizeof(float));
+      return;
+    case VectorStorageKind::kFloat16:
+      for (size_t i = 0; i != dimensions; ++i) {
+        dst[i] = fp16_ieee_to_fp32_value(LoadU16(src, i));
+      }
+      return;
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageKind, kind);
+}
+
+}  // namespace yb::vector_index

--- a/src/yb/vector_index/coordinate_codec.h
+++ b/src/yb/vector_index/coordinate_codec.h
@@ -1,0 +1,49 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+// Conversion between full-precision coordinates and the narrowed encodings a served vector
+// index stores on disk (VectorStorageKind).
+//
+// Both directions live here and nothing else narrows coordinates: writer and query path must
+// round identically, or a vector stops being at distance zero from itself.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "yb/vector_index/vector_storage_kind.h"
+
+namespace yb::vector_index {
+
+// Largest finite value in IEEE 754 binary16, used as the clamp threshold.
+constexpr float kMaxFloat16 = 65504.0f;
+
+// Bytes occupied by `dimensions` coordinates stored as `kind`.
+size_t CoordinateBytes(VectorStorageKind kind, size_t dimensions);
+
+// Narrows `dimensions` float32 coordinates from `src` into `dst` in the `kind` encoding. `dst`
+// must have room for CoordinateBytes(kind, dimensions) bytes and need not be aligned.
+//
+// Unrepresentable values are clamped to the encoding's finite extremes and NaN becomes zero;
+// `num_clamped`, when non-null, counts them. Clamping rather than saturating matters: an infinite
+// coordinate makes every distance to that vector NaN, silently corrupting the heaps' ordering.
+void NarrowCoordinates(
+    VectorStorageKind kind, const float* src, size_t dimensions, void* dst,
+    size_t* num_clamped = nullptr);
+
+// Widens `dimensions` coordinates in the `kind` encoding at `src` back to float32 in `dst`.
+// `src` need not be aligned. Exact for both encodings.
+void WidenCoordinates(
+    VectorStorageKind kind, const void* src, size_t dimensions, float* dst);
+
+}  // namespace yb::vector_index

--- a/src/yb/vector_index/coordinate_codec.h
+++ b/src/yb/vector_index/coordinate_codec.h
@@ -28,6 +28,9 @@ namespace yb::vector_index {
 // Largest finite value in IEEE 754 binary16, used as the clamp threshold.
 constexpr float kMaxFloat16 = 65504.0f;
 
+// 127 rather than 128 keeps the range symmetric, so -128 never occurs.
+constexpr float kMaxInt8 = 127.0f;
+
 // Bytes occupied by `dimensions` coordinates stored as `kind`.
 size_t CoordinateBytes(VectorStorageKind kind, size_t dimensions);
 
@@ -41,9 +44,25 @@ void NarrowCoordinates(
     VectorStorageKind kind, const float* src, size_t dimensions, void* dst,
     size_t* num_clamped = nullptr);
 
+// As above, for encodings that quantize: stored = round(coordinate / scale).
+//
+// `scale` must be the one in the header of the chunk these records are compared against, never a
+// freshly computed one: it is per chunk, so a wrong scale silently degrades that chunk's recall.
+void NarrowCoordinates(
+    VectorStorageKind kind, float scale, const float* src, size_t dimensions, void* dst,
+    size_t* num_clamped = nullptr);
+
 // Widens `dimensions` coordinates in the `kind` encoding at `src` back to float32 in `dst`.
-// `src` need not be aligned. Exact for both encodings.
+// `src` need not be aligned.
+//
+// Exact for the float encodings. kInt8 recovers scale * stored, and narrow(widen(narrow(x))) ==
+// narrow(x) at a fixed scale, but that fixed point does not survive a merge -- hence the rerank
+// tier.
 void WidenCoordinates(
     VectorStorageKind kind, const void* src, size_t dimensions, float* dst);
+
+// As above, for encodings that quantize. See NarrowCoordinates for what `scale` must be.
+void WidenCoordinates(
+    VectorStorageKind kind, float scale, const void* src, size_t dimensions, float* dst);
 
 }  // namespace yb::vector_index

--- a/src/yb/vector_index/hnsw_options.cc
+++ b/src/yb/vector_index/hnsw_options.cc
@@ -50,6 +50,16 @@ scalar_kind_t ConvertCoordinateKind(CoordinateKind coordinate_kind) {
   FATAL_INVALID_ENUM_VALUE(CoordinateKind, coordinate_kind);
 }
 
+scalar_kind_t ScalarKindFromStorageKind(VectorStorageKind storage_kind) {
+  switch (storage_kind) {
+    case VectorStorageKind::kFloat32:
+      return scalar_kind_t::f32_k;
+    case VectorStorageKind::kFloat16:
+      return scalar_kind_t::f16_k;
+  }
+  FATAL_INVALID_ENUM_VALUE(VectorStorageKind, storage_kind);
+}
+
 } // namespace
 
 std::string HNSWOptions::ToString() const {
@@ -61,11 +71,12 @@ std::string HNSWOptions::ToString() const {
       num_neighbors_per_vertex_base,
       max_neighbors_per_vertex_base,
       ef_construction,
-      robust_prune_alpha);
+      robust_prune_alpha,
+      storage_kind);
 }
 
 template <class Vector>
-unum::usearch::metric_punned_t HNSWOptions::CreateMetric() const {
+unum::usearch::metric_punned_t HNSWOptions::CreateBuildMetric() const {
   return unum::usearch::metric_punned_t(
       dimensions,
       MetricKindFromDistanceType(distance_kind),
@@ -73,6 +84,14 @@ unum::usearch::metric_punned_t HNSWOptions::CreateMetric() const {
 }
 
 template
-unum::usearch::metric_punned_t HNSWOptions::CreateMetric<FloatVector>() const;
+unum::usearch::metric_punned_t HNSWOptions::CreateBuildMetric<FloatVector>() const;
+
+unum::usearch::metric_punned_t HNSWOptions::CreateStoredMetric(
+    size_t dimensions_arg, VectorStorageKind storage_kind_arg) const {
+  return unum::usearch::metric_punned_t(
+      dimensions_arg,
+      MetricKindFromDistanceType(distance_kind),
+      ScalarKindFromStorageKind(storage_kind_arg));
+}
 
 }  // namespace yb::vector_index

--- a/src/yb/vector_index/hnsw_options.cc
+++ b/src/yb/vector_index/hnsw_options.cc
@@ -56,6 +56,8 @@ scalar_kind_t ScalarKindFromStorageKind(VectorStorageKind storage_kind) {
       return scalar_kind_t::f32_k;
     case VectorStorageKind::kFloat16:
       return scalar_kind_t::f16_k;
+    case VectorStorageKind::kInt8:
+      return scalar_kind_t::i8_k;
   }
   FATAL_INVALID_ENUM_VALUE(VectorStorageKind, storage_kind);
 }
@@ -72,7 +74,8 @@ std::string HNSWOptions::ToString() const {
       max_neighbors_per_vertex_base,
       ef_construction,
       robust_prune_alpha,
-      storage_kind);
+      storage_kind,
+      rerank_kind);
 }
 
 template <class Vector>

--- a/src/yb/vector_index/hnsw_options.h
+++ b/src/yb/vector_index/hnsw_options.h
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "yb/vector_index/distance.h"
+#include "yb/vector_index/vector_storage_kind.h"
 
 namespace unum::usearch {
 class metric_punned_t;
@@ -61,9 +62,20 @@ struct HNSWOptions {
 
   DistanceKind distance_kind = DistanceKind::kL2Squared;
 
+  // Encoding for coordinates written into immutable, file-backed chunks. Graph construction is
+  // unaffected: it always runs at the index's in-memory coordinate type.
+  VectorStorageKind storage_kind = VectorStorageKind::kFloat32;
+
   std::string ToString() const;
+
+  // Metric over Vector::value_type, the in-memory type the graph is built at.
   template <class Vector>
-  unum::usearch::metric_punned_t CreateMetric() const;
+  unum::usearch::metric_punned_t CreateBuildMetric() const;
+
+  // Metric over stored records. Takes the encoding explicitly rather than reading storage_kind,
+  // because YbHnsw::Init must use what the file it just opened records, not what this says now.
+  unum::usearch::metric_punned_t CreateStoredMetric(
+      size_t dimensions, VectorStorageKind storage_kind) const;
 };
 
 }  // namespace yb::vector_index

--- a/src/yb/vector_index/hnsw_options.h
+++ b/src/yb/vector_index/hnsw_options.h
@@ -66,6 +66,10 @@ struct HNSWOptions {
   // unaffected: it always runs at the index's in-memory coordinate type.
   VectorStorageKind storage_kind = VectorStorageKind::kFloat32;
 
+  // Encoding of the rerank copy stored alongside them. Only meaningful with a lossy
+  // storage_kind, which in turn requires it.
+  RerankStorageKind rerank_kind = RerankStorageKind::kNone;
+
   std::string ToString() const;
 
   // Metric over Vector::value_type, the in-memory type the graph is built at.

--- a/src/yb/vector_index/usearch_include_wrapper_internal.h
+++ b/src/yb/vector_index/usearch_include_wrapper_internal.h
@@ -65,8 +65,20 @@
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
 #endif
 
+// SimSIMD keys each target family off the corresponding -march macro, and x86-64 builds at
+// -march=ivybridge (top-level CMakeLists.txt), so no AVX-512 family enables itself. Forcing one
+// on is safe: every kernel carries its own target attribute so it compiles under the baseline,
+// and simsimd_capabilities() dispatches on CPUID, so a kernel the host cannot run is never
+// called.
+//
+// ICE is needed because SimSIMD has no *_i8_skylake -- without it the int8 ladder drops from
+// AVX-512 to 256-bit Haswell kernels. cos/l2sq/dot_i8_ice accumulate into int32 exactly as the
+// Haswell kernels do, so results are bit-identical. See
+// architecture/design/docdb-vector-index-quantization.md.
 #define SIMSIMD_TARGET_HASWELL 1
 #define SIMSIMD_TARGET_SKYLAKE 1
+#define SIMSIMD_TARGET_ICE 1
+
 #endif
 
 // Getting these errors with both Clang and GCC on Linux, as well as with in an x86_64 build with

--- a/src/yb/vector_index/vector_storage_kind.cc
+++ b/src/yb/vector_index/vector_storage_kind.cc
@@ -1,0 +1,32 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/vector_index/vector_storage_kind.h"
+
+#include "yb/util/logging.h"
+
+namespace yb::vector_index {
+
+VectorStorageKind StorageKindForRerank(RerankStorageKind kind) {
+  switch (kind) {
+    case RerankStorageKind::kNone:
+      break;
+    case RerankStorageKind::kFloat16:
+      return VectorStorageKind::kFloat16;
+    case RerankStorageKind::kFloat32:
+      return VectorStorageKind::kFloat32;
+  }
+  FATAL_INVALID_ENUM_VALUE(RerankStorageKind, kind);
+}
+
+}  // namespace yb::vector_index

--- a/src/yb/vector_index/vector_storage_kind.h
+++ b/src/yb/vector_index/vector_storage_kind.h
@@ -1,0 +1,28 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <cstdint>
+
+#include "yb/util/enums.h"
+
+namespace yb::vector_index {
+
+// On-disk encoding of a served vector index's coordinates. Separate from CoordinateKind: the
+// graph is built at full precision and this narrows only the copy in the immutable chunk.
+//
+// Serialized as uint8 in the footer: kFloat32 must stay 0, as version-1 footers lack the field.
+YB_DEFINE_TYPED_ENUM(VectorStorageKind, uint8_t, (kFloat32)(kFloat16));
+
+}  // namespace yb::vector_index

--- a/src/yb/vector_index/vector_storage_kind.h
+++ b/src/yb/vector_index/vector_storage_kind.h
@@ -22,7 +22,20 @@ namespace yb::vector_index {
 // On-disk encoding of a served vector index's coordinates. Separate from CoordinateKind: the
 // graph is built at full precision and this narrows only the copy in the immutable chunk.
 //
+// kInt8 quantizes to a per-chunk scale, so its distances are in quantized units and it is only
+// valid with a rerank tier: raising ef cannot recover the recall, since the search ranks by that
+// quantized distance.
+//
 // Serialized as uint8 in the footer: kFloat32 must stay 0, as version-1 footers lack the field.
-YB_DEFINE_TYPED_ENUM(VectorStorageKind, uint8_t, (kFloat32)(kFloat16));
+YB_DEFINE_TYPED_ENUM(VectorStorageKind, uint8_t, (kFloat32)(kFloat16)(kInt8));
+
+// A second copy of each vector, after the traversal coordinates in the same record. Retained
+// candidates are rescored against it, so distances leaving the chunk are in true units.
+//
+// kNone must stay 0: footers predating this field are read back as having no rerank tier.
+YB_DEFINE_TYPED_ENUM(RerankStorageKind, uint8_t, (kNone)(kFloat16)(kFloat32));
+
+// Panics on kNone: callers must check for a tier before asking what encoding it uses.
+VectorStorageKind StorageKindForRerank(RerankStorageKind kind);
 
 }  // namespace yb::vector_index

--- a/src/yb/yql/pgwrapper/pg_vector_index-test.cc
+++ b/src/yb/yql/pgwrapper/pg_vector_index-test.cc
@@ -11,7 +11,10 @@
 // under the License.
 //
 
+#include <cmath>
+#include <map>
 #include <queue>
+#include <set>
 
 #include "yb/client/client_error.h"
 #include "yb/client/client_fwd.h"
@@ -94,6 +97,7 @@ DECLARE_int64(db_block_size_bytes);
 DECLARE_int64(db_write_buffer_size);
 DECLARE_int64(tablet_force_split_threshold_bytes);
 DECLARE_string(vector_index_backend);
+DECLARE_string(vector_index_storage_coordinate_type);
 DECLARE_uint64(post_split_compaction_input_size_threshold_bytes);
 DECLARE_bool(vector_index_allow_parallel_compactions);
 DECLARE_int32(vector_index_files_number_compaction_trigger);
@@ -101,6 +105,7 @@ DECLARE_uint32(vector_index_compaction_chunk_max_mem_store_size_percentage);
 DECLARE_uint32(vector_index_concurrent_reads);
 DECLARE_uint32(vector_index_concurrent_writes);
 DECLARE_uint32(vector_index_num_compactions_limit);
+DECLARE_uint32(vector_index_rerank_overfetch_factor);
 DECLARE_uint64(vector_index_compaction_chunk_max_mem_store_size_mb);
 DECLARE_uint64(vector_index_initial_chunk_size);
 DECLARE_uint64(vector_index_max_insert_tasks);
@@ -4684,6 +4689,222 @@ TEST_P(PgVectorIndexTest, StatusResolutionDuringBootstrapBackfill) {
 
   // Reaching here without the tserver crashing means the fix holds.
   threads.Stop();
+}
+
+////////////////////////////////////////////////////////
+// Narrowed coordinate storage (float16)
+////////////////////////////////////////////////////////
+
+// Shared by the narrowed-storage fixtures below, each of which names one encoding, so the same
+// suite runs against all of them. The graph is still built at full precision, so what these cover
+// is whether narrowed records survive flush, restart, compaction and the query path.
+class PgVectorIndexNarrowStorageTest : public PgVectorIndexTestBase {
+ protected:
+  virtual std::string StorageCoordinateType() const = 0;
+
+  bool IsColocated() const override { return false; }
+  VectorIndexEngine Engine() const override { return VectorIndexEngine::kYbHnswHnswlib; }
+  PackingMode GetPackingMode() const override { return PackingMode::kV1; }
+
+  void SetUp() override {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_storage_coordinate_type) =
+        StorageCoordinateType();
+    PgVectorIndexTestBase::SetUp();
+    // The base fixture forces brute-force search; these tests want the real graph walk over
+    // narrowed records.
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_vector_index_exact) = false;
+  }
+
+  // Ids of the `limit` nearest rows by exact float32 distance, computed from the vectors the test
+  // inserted rather than from anything the index stored.
+  std::vector<int64_t> ExactNearest(const FloatVector& query_vector, size_t limit) {
+    unum::usearch::metric_punned_t metric(
+        dimensions_, UsearchMetricKind(), unum::usearch::scalar_kind_t::f32_k);
+    std::vector<int64_t> ids(vectors_.size());
+    std::generate(ids.begin(), ids.end(), [n{0LL}]() mutable { return n++; });
+    std::sort(ids.begin(), ids.end(), [&](int64_t lhs, int64_t rhs) {
+      return metric(VectorToBytePtr(query_vector), VectorToBytePtr(vectors_[lhs])) <
+             metric(VectorToBytePtr(query_vector), VectorToBytePtr(vectors_[rhs]));
+    });
+    ids.resize(std::min(ids.size(), limit));
+    return ids;
+  }
+
+  // Fraction of the exact top-`limit` that the index actually returned, averaged over
+  // `iterations` random queries.
+  Result<double> MeasureRecall(PGConn& conn, size_t limit, size_t iterations) {
+    size_t found = 0;
+    for (size_t i = 0; i != iterations; ++i) {
+      auto query_vector = RandomVector();
+      auto rows = VERIFY_RESULT(conn.FetchRows<int64_t>(
+          "SELECT id FROM test" + IndexQuerySuffix(query_vector, limit)));
+      auto expected = ExactNearest(query_vector, limit);
+      std::set<int64_t> expected_set(expected.begin(), expected.end());
+      for (auto id : rows) {
+        found += expected_set.contains(id);
+      }
+    }
+    return static_cast<double>(found) / (limit * iterations);
+  }
+
+  // Storage type recorded on every vector index this cluster is serving.
+  std::map<VectorStorageType, size_t> StorageTypeCounts() {
+    std::map<VectorStorageType, size_t> counts;
+    for (const auto& peer : ListTabletPeersWithVectorIndexes(cluster_.get())) {
+      auto tablet = CHECK_RESULT(peer->shared_tablet());
+      auto indexes = tablet->vector_indexes().List();
+      CHECK(indexes);
+      for (const auto& index : *indexes) {
+        ++counts[index->options().hnsw().storage_type()];
+      }
+    }
+    return counts;
+  }
+};
+
+class PgVectorIndexFloat16Test : public PgVectorIndexNarrowStorageTest {
+ protected:
+  std::string StorageCoordinateType() const override { return "float16"; }
+};
+
+// The encoding is fixed per index at creation time so every replica agrees on it. A tserver-local
+// setting would let replicas of the same tablet disagree about the accuracy of their answers.
+TEST_F(PgVectorIndexFloat16Test, StorageTypeIsRecordedInTheCatalog) {
+  auto conn = ASSERT_RESULT(MakeIndex());
+
+  size_t checked = 0;
+  for (const auto& peer : ListTabletPeersWithVectorIndexes(cluster_.get())) {
+    auto tablet = ASSERT_RESULT(peer->shared_tablet());
+    auto indexes = tablet->vector_indexes().List();
+    ASSERT_TRUE(indexes);
+    for (const auto& index : *indexes) {
+      ASSERT_EQ(index->options().hnsw().storage_type(), VectorStorageType::STORAGE_FLOAT16);
+      ++checked;
+    }
+  }
+  ASSERT_GT(checked, 0);
+}
+
+// Narrowing changes which rows come back, not the distances the user sees: ybvectorgettuple
+// leaves xs_orderbyvals unset and xs_recheckorderby false, so the executor evaluates `<->` over
+// the full-precision heap value. They are not even the same quantity -- `<->` is sqrt(L2 squared)
+// where the index ranks on L2 squared -- so a leaked index distance fails this by a wide margin.
+TEST_F(PgVectorIndexFloat16Test, ReportedDistancesStayFullPrecision) {
+  constexpr size_t kNumRows = 500;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+
+  // Mirrors pgvector's l2_distance: float32 accumulation, then sqrt in double.
+  auto exact_l2_distance = [](const FloatVector& lhs, const FloatVector& rhs) {
+    float squared = 0.0f;
+    for (size_t i = 0; i != lhs.size(); ++i) {
+      const float diff = lhs[i] - rhs[i];
+      squared += diff * diff;
+    }
+    return std::sqrt(static_cast<double>(squared));
+  };
+
+  for (size_t i = 0; i != 10; ++i) {
+    auto query_vector = RandomVector();
+    auto rows = ASSERT_RESULT((conn.FetchRows<int64_t, double>(Format(
+        "SELECT id, $0 FROM test$1",
+        DistanceToQuery(query_vector), IndexQuerySuffix(query_vector, kLimit)))));
+    ASSERT_FALSE(rows.empty());
+
+    for (const auto& [id, reported] : rows) {
+      const auto exact = exact_l2_distance(query_vector, vectors_[id]);
+      // 1e-5 sits two orders of magnitude above float32 accumulation noise and two below the
+      // ~5e-4 relative error of a float16 distance, so it tells the two apart.
+      ASSERT_LE(std::fabs(reported - exact), 1e-5 * std::max<double>(exact, 1.0))
+          << "id: " << id << ", reported: " << reported << ", exact: " << exact;
+    }
+  }
+}
+
+TEST_F(PgVectorIndexFloat16Test, Recall) {
+  constexpr size_t kNumRows = 2000;
+  constexpr size_t kLimit = 10;
+  constexpr size_t kIterations = 20;
+
+  dimensions_ = 32;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+
+  auto recall = ASSERT_RESULT(MeasureRecall(conn, kLimit, kIterations));
+  LOG(INFO) << "float16 recall@" << kLimit << ": " << recall;
+  ASSERT_GE(recall, 0.8);
+}
+
+// Flush turns the mutable chunk into a narrowed file, and restart reopens it through
+// YbHnsw::Init -- the path where the metric has to be rebuilt from the file's own footer.
+TEST_F(PgVectorIndexFloat16Test, SurvivesFlushAndRestart) {
+  constexpr size_t kNumRows = 1000;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+  ASSERT_OK(cluster_->FlushTablets());
+
+  auto before = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  ASSERT_OK(RestartCluster());
+  conn = ASSERT_RESULT(Connect());
+
+  auto after = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+  LOG(INFO) << "recall before restart: " << before << ", after: " << after;
+  ASSERT_GE(after, 0.8);
+}
+
+// Compaction reads source chunks back through YbHnswIterator, which has to decode narrowed
+// records rather than copy float32-wide out of them. Re-narrowing what it read is idempotent, so
+// recall should not decay across compactions either.
+TEST_F(PgVectorIndexFloat16Test, SurvivesCompaction) {
+  constexpr size_t kRowsPerChunk = 300;
+  constexpr size_t kNumChunks = 4;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndex(dimensions_));
+  for (size_t chunk = 0; chunk != kNumChunks; ++chunk) {
+    ASSERT_OK(InsertRandomRows(conn, kRowsPerChunk));
+    ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+    ASSERT_OK(cluster_->FlushTablets());
+  }
+
+  auto before = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  ASSERT_OK(cluster_->CompactTablets());
+  auto after = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  LOG(INFO) << "recall before compaction: " << before << ", after: " << after;
+  ASSERT_GE(after, 0.8);
+}
+
+// A float16 index has to coexist with a float32 one in the same cluster: the encoding is a
+// per-index property, and each chunk records its own.
+TEST_F(PgVectorIndexFloat16Test, CoexistsWithFloat32Index) {
+  constexpr size_t kNumRows = 500;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_storage_coordinate_type) = "float32";
+  ASSERT_OK(conn.Execute(
+      "CREATE INDEX vi_f32 ON test USING ybhnsw (embedding vector_l2_ops) WITH (m=16)"));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 60s * kTimeMultiplier));
+  ASSERT_OK(cluster_->FlushTablets());
+
+  auto counts = StorageTypeCounts();
+  LOG(INFO) << "indexes by storage type: " << AsString(counts);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_FLOAT16], 0);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_FLOAT32], 0);
+
+  ASSERT_GE(ASSERT_RESULT(MeasureRecall(conn, kLimit, 10)), 0.8);
 }
 
 }  // namespace yb::pgwrapper

--- a/src/yb/yql/pgwrapper/pg_vector_index-test.cc
+++ b/src/yb/yql/pgwrapper/pg_vector_index-test.cc
@@ -4767,6 +4767,14 @@ class PgVectorIndexFloat16Test : public PgVectorIndexNarrowStorageTest {
   std::string StorageCoordinateType() const override { return "float16"; }
 };
 
+// int8 traversal coordinates with a float16 rerank copy. The rerank tier is what makes the
+// encoding usable: int8 alone loses recall that no amount of ef recovers, because the search
+// still keeps only max_num_results entries ranked by the quantized distance.
+class PgVectorIndexInt8Test : public PgVectorIndexNarrowStorageTest {
+ protected:
+  std::string StorageCoordinateType() const override { return "int8"; }
+};
+
 // The encoding is fixed per index at creation time so every replica agrees on it. A tserver-local
 // setting would let replicas of the same tablet disagree about the accuracy of their answers.
 TEST_F(PgVectorIndexFloat16Test, StorageTypeIsRecordedInTheCatalog) {
@@ -4901,6 +4909,186 @@ TEST_F(PgVectorIndexFloat16Test, CoexistsWithFloat32Index) {
 
   auto counts = StorageTypeCounts();
   LOG(INFO) << "indexes by storage type: " << AsString(counts);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_FLOAT16], 0);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_FLOAT32], 0);
+
+  ASSERT_GE(ASSERT_RESULT(MeasureRecall(conn, kLimit, 10)), 0.8);
+}
+
+
+TEST_F(PgVectorIndexInt8Test, StorageTypeIsRecordedInTheCatalog) {
+  auto conn = ASSERT_RESULT(MakeIndex());
+
+  auto counts = StorageTypeCounts();
+  LOG(INFO) << "indexes by storage type: " << AsString(counts);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_INT8], 0);
+  ASSERT_EQ(counts[VectorStorageType::STORAGE_FLOAT32], 0);
+  ASSERT_EQ(counts[VectorStorageType::STORAGE_FLOAT16], 0);
+}
+
+// As above, and int8 is its strongest form: a leaked index distance would be in quantized units,
+// off by orders of magnitude rather than by rounding.
+TEST_F(PgVectorIndexInt8Test, ReportedDistancesStayFullPrecision) {
+  constexpr size_t kNumRows = 500;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+
+  // Mirrors pgvector's l2_distance: float32 accumulation, then sqrt in double.
+  auto exact_l2_distance = [](const FloatVector& lhs, const FloatVector& rhs) {
+    float squared = 0.0f;
+    for (size_t i = 0; i != lhs.size(); ++i) {
+      const float diff = lhs[i] - rhs[i];
+      squared += diff * diff;
+    }
+    return std::sqrt(static_cast<double>(squared));
+  };
+
+  for (size_t i = 0; i != 10; ++i) {
+    auto query_vector = RandomVector();
+    auto rows = ASSERT_RESULT((conn.FetchRows<int64_t, double>(Format(
+        "SELECT id, $0 FROM test$1",
+        DistanceToQuery(query_vector), IndexQuerySuffix(query_vector, kLimit)))));
+    ASSERT_FALSE(rows.empty());
+
+    for (const auto& [id, reported] : rows) {
+      const auto exact = exact_l2_distance(query_vector, vectors_[id]);
+      ASSERT_LE(std::fabs(reported - exact), 1e-5 * std::max<double>(exact, 1.0))
+          << "id: " << id << ", reported: " << reported << ", exact: " << exact;
+    }
+  }
+}
+
+// The threshold matches the float16 suite's, which is the whole point: reranking should leave the
+// user-visible recall indistinguishable from storing float16 outright.
+TEST_F(PgVectorIndexInt8Test, Recall) {
+  constexpr size_t kNumRows = 2000;
+  constexpr size_t kLimit = 10;
+  constexpr size_t kIterations = 20;
+
+  dimensions_ = 32;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+
+  auto recall = ASSERT_RESULT(MeasureRecall(conn, kLimit, kIterations));
+  LOG(INFO) << "int8 recall@" << kLimit << ": " << recall;
+  ASSERT_GE(recall, 0.8);
+}
+
+// Proves the over-fetch flag reaches the search path: turning it off must change which rows come
+// back. Not asserted on recall -- the gap size is data-dependent, and the YbHnsw unit tests pin
+// the mechanism deterministically. What this adds is that the tserver flag is wired through.
+TEST_F(PgVectorIndexInt8Test, OverFetchFlagReachesTheSearchPath) {
+  constexpr size_t kNumRows = 2000;
+  constexpr size_t kLimit = 10;
+  constexpr size_t kIterations = 30;
+
+  dimensions_ = 32;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+
+  std::vector<FloatVector> queries;
+  for (size_t i = 0; i != kIterations; ++i) {
+    queries.push_back(RandomVector());
+  }
+
+  auto fetch_all = [this, &conn, &queries]() -> Result<std::vector<std::string>> {
+    std::vector<std::string> result;
+    for (const auto& query : queries) {
+      result.push_back(AsString(VERIFY_RESULT(conn.FetchRows<int64_t>(
+          "SELECT id FROM test" + IndexQuerySuffix(query, kLimit)))));
+    }
+    return result;
+  };
+
+  auto with_overfetch = ASSERT_RESULT(fetch_all());
+  auto recall_with = ASSERT_RESULT(MeasureRecall(conn, kLimit, kIterations));
+
+  // Factor 1 retains exactly the requested count, so reranking can only reorder it. The flag is
+  // runtime-settable and the tservers share this process, so writing it here is enough.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_rerank_overfetch_factor) = 1;
+  auto without_overfetch = ASSERT_RESULT(fetch_all());
+  auto recall_without = ASSERT_RESULT(MeasureRecall(conn, kLimit, kIterations));
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_rerank_overfetch_factor) = 2;
+
+  LOG(INFO) << "int8 recall@" << kLimit << " with over-fetch: " << recall_with
+            << ", without: " << recall_without;
+  ASSERT_NE(with_overfetch, without_overfetch)
+      << "disabling the over-fetch returned identical rows for all " << kIterations
+      << " queries, so the flag is not reaching the search";
+  ASSERT_GE(recall_with, recall_without);
+}
+
+// Flush writes the two-tier records, and restart reopens them through YbHnsw::Init -- the path
+// where both metrics and the quantization scale have to be rebuilt from the file's own footer.
+TEST_F(PgVectorIndexInt8Test, SurvivesFlushAndRestart) {
+  constexpr size_t kNumRows = 1000;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+  ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+  ASSERT_OK(cluster_->FlushTablets());
+
+  auto before = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  ASSERT_OK(RestartCluster());
+  conn = ASSERT_RESULT(Connect());
+
+  auto after = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+  LOG(INFO) << "recall before restart: " << before << ", after: " << after;
+  ASSERT_GE(after, 0.8);
+}
+
+// The hazard specific to a quantized encoding: each merged chunk derives its own scale, so if
+// compaction read the int8 coordinates instead of the rerank copy, error would compound once per
+// merge. Several chunks merged in sequence is what makes that visible.
+TEST_F(PgVectorIndexInt8Test, SurvivesRepeatedCompaction) {
+  constexpr size_t kRowsPerChunk = 300;
+  constexpr size_t kNumChunks = 4;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndex(dimensions_));
+  for (size_t chunk = 0; chunk != kNumChunks; ++chunk) {
+    ASSERT_OK(InsertRandomRows(conn, kRowsPerChunk));
+    ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 30s * kTimeMultiplier));
+    ASSERT_OK(cluster_->FlushTablets());
+  }
+
+  auto before = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+
+  for (size_t round = 0; round != 3; ++round) {
+    ASSERT_OK(cluster_->CompactTablets());
+    auto after = ASSERT_RESULT(MeasureRecall(conn, kLimit, 10));
+    LOG(INFO) << "recall after compaction round " << round << ": " << after
+              << " (before any compaction: " << before << ")";
+    ASSERT_GE(after, 0.8) << "recall decayed by compaction round " << round;
+  }
+}
+
+// All three encodings on one table. Each index records its own, and each chunk its own scale, so
+// nothing here may be cached across indexes.
+TEST_F(PgVectorIndexInt8Test, CoexistsWithOtherEncodings) {
+  constexpr size_t kNumRows = 500;
+  constexpr size_t kLimit = 10;
+
+  dimensions_ = 16;
+  auto conn = ASSERT_RESULT(MakeIndexAndFillRandom(kNumRows));
+
+  for (auto [encoding, name] : {std::pair{"float32", "vi_f32"}, std::pair{"float16", "vi_f16"}}) {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_vector_index_storage_coordinate_type) = encoding;
+    ASSERT_OK(conn.Execute(Format(
+        "CREATE INDEX $0 ON test USING ybhnsw (embedding vector_l2_ops) WITH (m=16)", name)));
+    ASSERT_OK(WaitNoBackgroundInserts(WaitForIntents::kFalse, 60s * kTimeMultiplier));
+  }
+  ASSERT_OK(cluster_->FlushTablets());
+
+  auto counts = StorageTypeCounts();
+  LOG(INFO) << "indexes by storage type: " << AsString(counts);
+  ASSERT_GT(counts[VectorStorageType::STORAGE_INT8], 0);
   ASSERT_GT(counts[VectorStorageType::STORAGE_FLOAT16], 0);
   ASSERT_GT(counts[VectorStorageType::STORAGE_FLOAT32], 0);
 


### PR DESCRIPTION
## Summary

> **Stacked on #33808** (`float16` coordinate storage). Its first commit is #33808's; this PR's own
> contribution is the second commit, **1643 changed lines**. GitHub cannot base a fork PR on
> another fork branch, so the diff below reads ~3268 lines until #33808 lands; rebasing after that
> collapses it to this PR's own change. Review the second commit.

Builds on the `float16` chunk encoding, quartering rather than halving the bytes a distance
evaluation touches.

`int8` quantizes each coordinate to a per-chunk step and is only offered together with a `float16`
rerank copy, because raising `ef` cannot recover what quantization costs -- the search ranks
candidates by the quantized distance, so the fix is to retain more candidates than requested and
rescore them before they leave the chunk. `MakeResult` is the only place distances cross the chunk
boundary, so it is also the only place they must be in the metric's own units for VectorLSM to
merge them across chunks.

## Index size and memory footprint

The two encodings move footprint in opposite directions, which is the main reason to pick one over
the other. Measured for 1M vectors at 768 dimensions (single-node `ef_search=200` run):

| encoding | record | index size | vs `float32` | records per fixed cache budget | bytes touched per visit |
|---|---|---|---|---|---|
| `float32` | 3092 B | 3.19 GB | 1.00x | 1.00x | 3092 |
| `float16` | 1556 B | 1.65 GB | 0.52x | 1.99x | 1536 |
| `int8` + rerank | 2324 B | 2.42 GB | 0.76x | 1.33x | **788** |

`int8` shrinks the index **24%** where `float16` shrinks it 48%, and keeps 1.33x as many records
resident in a fixed block cache against `float16`'s 1.99x -- its record is *larger* than
`float16`'s, because the rerank copy costs more than the narrowed traversal copy saves. What it
buys instead is the hot path: a traversal reads only the header and traversal coordinates, so what
it touches per visit drops to **0.25x**, and the rerank copy is read only for the retained
candidates. Pick `float16` for capacity, `int8` for throughput.

Both file sizes follow from the record layout alone: 1M records account for 3.09 / 1.56 / 2.32 GB,
leaving ~0.10 GB of neighbour lists and aux entries that no encoding shrinks, and adding that back
reproduces the measured 1.65 GB and 2.42 GB to the last digit.

## Throughput

VectorDBBench `Performance768D1M` (Cohere, cosine), `k=100`, 30 clients, versus `float32` at the
same `ef_search`:

| setup | ef | configuration | recall delta | throughput |
|---|---|---|---|---|
| RF3 | 200 | `int8`, overfetch 1 | +0.01% | **+39.8%** |
| RF1 | 200 | `int8`, overfetch 2 | +0.01% | **+32.8%** |

Fitting `speedup = 1/((1-f) + f/c)` across eight recall-matched cells gives **f = 0.30 +/- 0.06**:
only ~30% of end-to-end query time scales with coordinate bytes, so no coordinate encoding can
exceed **1.43x** here and `int8` already reaches ~93% of that. The rest is tablet fan-out,
resolving and fetching `LIMIT` rows per query, neighbour-list reads that no encoding shrinks, and
YSQL/RPC overhead. A narrower encoding than `int8` would buy roughly 3%, which is why this stops
here.

## Per-chunk quantization scale

The scale is symmetric, `max|coordinate| / 127`, derived from the chunk's own coordinates and
recorded in its footer. Scoping it to the chunk keeps it a pure function of data already in hand
-- no sampling, no configuration, nothing to recalibrate as an index grows -- at the cost that two
chunks of one index hold different scales, so a query must be quantized against the scale of the
chunk it is compared against.

It is also why compaction reads the **rerank** copy rather than decoding the traversal
coordinates: a merged chunk derives a new scale, so decoding `int8` would feed already-quantized
values into a fresh quantization and lose a little more on every merge. The `float16` copy
round-trips exactly, making a vector a fixed point across arbitrarily many compactions.

## Flags

- `--vector_index_storage_coordinate_type=int8` (**master**, runtime-settable), alongside the
  existing `float32` and `float16`.
- `--vector_index_rerank_overfetch_factor` (**tserver**, runtime, default 2): candidates retained
  per requested result for rescoring. The candidate budget is
  `max(ef_search, LIMIT, factor * LIMIT)`, so the over-fetch is free while
  `factor * LIMIT <= ef_search` and otherwise raises the budget and makes `ef_search` inert below
  it. At the default 2 with `LIMIT 100`, `ef_search` 100 and 200 run the identical 200-candidate
  search. RF3 wants factor 1; RF1 needs 2, which is why this is a per-deployment choice rather
  than a better default.
- x86-64 builds at `-march=ivybridge`, so `usearch_include_wrapper_internal.h` now also forces
  `SIMSIMD_TARGET_ICE`. SimSIMD has no `*_i8_skylake`, so without it `int8` drops from AVX-512 to
  the 256-bit Haswell kernels while `float32` keeps a 512-bit one. `cos/l2sq/dot_i8_ice`
  accumulate into `int32` exactly as the Haswell kernels do, so results are bit-identical and cost
  no accuracy. `int32` headroom for `int8` inputs is 8.3x: saturation needs `d > 133,144` against
  a `VECTOR_MAX_DIM` of 16,000.

Design doc: `architecture/design/docdb-vector-index-narrowed-storage.md`

## Upgrade/Rollback safety

**Proto change:** `common.proto` adds `STORAGE_INT8 = 2` to the `VectorStorageType` enum
introduced by #33808. No new field.

**Upgrade is a no-op unless an operator opts in.** The master flag still defaults to `float32`, so
an upgraded cluster writes byte-identical version-1 chunk footers.

**Rollback is one-way for chunks written after the flag is set to `int8`.** The footer is
versioned: `float32` emits version 1, `float16` version 2, `int8` version 3 (it appends
`rerank_kind` and `quantization_scale`). A binary predating this change cannot read version 3.
Indexes created while the flag was `int8` keep that encoding in the catalog and their chunks are
unreadable by such a binary, so **those indexes must be dropped and rebuilt before rolling back**.
Clearing the flag stops new chunks from using the encoding but does not rewrite existing ones.

**Mixed-version window:** an older tserver that understands only versions 1-2 cannot read a
version-3 chunk at all. **Do not set the flag to `int8` until the rolling upgrade is complete on
every node.** As with #33808, a chunk records its own encoding, so a fully upgraded cluster reads
any mix correctly -- but an index whose chunks were written by a mix of binaries will have mixed
recall.

`ValidateHeader` additionally rejects a version-3 chunk whose `quantization_scale` is
non-positive or non-finite, since such a scale decodes every coordinate to zero or infinity and an
infinite coordinate makes every distance NaN, silently corrupting the search heaps' ordering
rather than failing.

## Test plan

Jenkins: all

New tests:

- [x] `coordinate_codec-test` -- that `int8`'s error stays within half a quantization step
      everywhere in range (an absolute bound, unlike `float16`'s relative one); that clamping is
      load-bearing rather than cosmetic, since an out-of-range `float -> int8_t` conversion is
      undefined behaviour rather than saturating; that the two encodings sit back to back in one
      record without overlapping; that the clamp counter accumulates across a whole index build.
- [x] `hnsw-test` -- that reranking recovers what `int8` costs *and* that the un-reranked
      configuration is measurably worse, without which the test would pass just as happily when
      the rerank tier does nothing; that over-fetch works when `ef <= max_num_results`, the regime
      a naive candidate budget silently breaks; that an infinite coordinate cannot set the
      quantization scale; that an all-zero chunk is handled; that the footer round-trips the scale
      and rerank kind; that `int8` survives a reload.
- [x] `yb_hnsw_storage-test` -- that iteration reads the rerank copy rather than decoding `int8`,
      and that repeated compaction reaches a bit-identical fixed point; that `Distance` uses the
      rerank metric so its result is in the metric's units; that two chunks of one index can hold
      different scales and stay mutually comparable.
- [ ] `pg_vector_index-test` -- the suite against `int8` end-to-end through flush, restart,
      compaction and the query path; that the tserver over-fetch flag is wired through; that the
      encodings coexist in one cluster.

Ran locally, macOS arm64 debug -- all pass: `coordinate_codec-test` (worst absolute int8 error
0.00393701 against a half-step of 0.00393701), `hnsw-test`, `yb_hnsw_storage-test`.

`pg_vector_index-test` compiles but does not run on this host: it needs `127.0.0.x` loopback
aliases, which macOS does not configure by default. CI is its first execution.

Benchmarks: VectorDBBench `Performance768D1M` at RF1 and RF3, `ef_search` 100 and 200, overfetch
1 and 2 -- results in the Summary and in the design doc.
