### PR TITLE
[BACKPORT 2026.1][#32967] DocDB: per-drive write throughput and fsync latency metrics

### DIFF
--- a/src/yb/fs/fs_manager-test.cc
+++ b/src/yb/fs/fs_manager-test.cc
@@ -40,6 +40,7 @@
 
 #include "yb/gutil/strings/util.h"
 
+#include "yb/util/drive_io_stats.h"
 #include "yb/util/metrics.h"
 #include "yb/util/multi_drive_test_env.h"
 #include "yb/util/status.h"
@@ -54,6 +55,7 @@ using std::vector;
 DECLARE_string(fs_data_dirs);
 DECLARE_string(fs_wal_dirs);
 DECLARE_bool(TEST_fail_write_pb_container);
+DECLARE_bool(export_drive_io_metrics);
 
 namespace yb {
 
@@ -408,5 +410,68 @@ TEST_F(FsManagerTestDriveFault, SingleDriveFault) {
   EXPECT_TRUE(Slice(dirs[0]).starts_with(Slice(GetTestPath(kOkDrive))));
 }
 
+// A drive that failed the startup write check must not be registered for IO metrics: it has been
+// dropped from the root lists, nothing will be written to it, and it already reports drive_fault.
+TEST_F(FsManagerTestDriveFault, FaultyDriveIsNotRegisteredForIoMetrics) {
+  // The fixture's SetUp only gets as far as creating the layout; the first
+  // CheckAndOpenFileSystemRoots returns NotFound and returns before reaching registration. Real
+  // startup re-opens after creating (server_base.cc), so do the same here.
+  ASSERT_OK(fs_manager()->CheckAndOpenFileSystemRoots());
+
+  ASSERT_NE(nullptr, DriveIoStatsRegistry::Instance().Find(GetTestPath(kOkDrive)));
+  ASSERT_EQ(nullptr, DriveIoStatsRegistry::Instance().Find(GetTestPath(kFailedDrive)));
+}
+
+// Coverage for FsManager::SetUpDriveIoMetrics: which roots get registered, and the flag that
+// turns the whole thing off. Roots are GetTestPath-derived and so unique per test, which is what
+// lets these tests share the process-global registry.
+class FsManagerTestDriveIoMetrics : public YBTest {
+ public:
+  void ReinitFsManager(const vector<string>& wal_paths, const vector<string>& data_paths) {
+    fs_manager_.reset();
+    FsManagerOpts opts;
+    opts.wal_paths = wal_paths;
+    opts.data_paths = data_paths;
+    opts.server_type = kServerType;
+    opts.metric_registry = &metric_registry_;
+    fs_manager_ = std::make_unique<FsManager>(env_.get(), opts);
+  }
+
+  Status OpenFileSystem(const vector<string>& wal_paths, const vector<string>& data_paths) {
+    ReinitFsManager(wal_paths, data_paths);
+    RETURN_NOT_OK(fs_manager_->CreateInitialFileSystemLayout());
+    return fs_manager_->CheckAndOpenFileSystemRoots();
+  }
+
+  const char* kServerType = "tserver_test";
+
+ private:
+  std::unique_ptr<FsManager> fs_manager_;
+  MetricRegistry metric_registry_;
+};
+
+// The WAL and data roots can be different devices, and both must be attributed.
+TEST_F(FsManagerTestDriveIoMetrics, RegistersWalAndDataRoots) {
+  const auto wal = GetTestPath("wal_root");
+  const auto data = GetTestPath("data_root");
+  ASSERT_OK(OpenFileSystem({ wal }, { data }));
+
+  auto& registry = DriveIoStatsRegistry::Instance();
+  ASSERT_NE(nullptr, registry.Find(wal)) << "WAL root should be registered";
+  ASSERT_NE(nullptr, registry.Find(data)) << "data root should be registered";
+  ASSERT_NE(registry.Find(wal), registry.Find(data)) << "and they are distinct drives";
+
+  // A file under a root resolves to that root's counters, which is the whole attribution path.
+  ASSERT_EQ(registry.Find(wal), registry.Find(wal + "/yb-data/tserver_test/wals/x/wal-000001"));
+}
+
+TEST_F(FsManagerTestDriveIoMetrics, FlagOffRegistersNothing) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_export_drive_io_metrics) = false;
+  const auto root = GetTestPath("fs_root");
+  ASSERT_OK(OpenFileSystem({ root }, { root }));
+
+  ASSERT_EQ(nullptr, DriveIoStatsRegistry::Instance().Find(root))
+      << "with --export_drive_io_metrics off, the write path must see no drive at all";
+}
 
 } // namespace yb

--- a/src/yb/fs/fs_manager.cc
+++ b/src/yb/fs/fs_manager.cc
@@ -54,6 +54,7 @@
 #include "yb/gutil/walltime.h"
 
 #include "yb/util/debug-util.h"
+#include "yb/util/drive_io_stats.h"
 #include "yb/util/env_util.h"
 #include "yb/util/flags.h"
 #include "yb/util/format.h"
@@ -98,6 +99,12 @@ METRIC_DEFINE_counter(drive, drive_fault,
                       "Drive Fault. Tablet Server isn't able to read/write on this drive.",
                       yb::MetricUnit::kUnits,
                       "Drive Fault. Tablet Server isn't able to read/write on this drive.");
+
+DEFINE_NON_RUNTIME_bool(export_drive_io_metrics, true,
+    "Whether to export per-drive write throughput and sync latency metrics on the 'drive' "
+    "metric entity. When disabled, the instrumentation in the writable-file layer sees no "
+    "registered drive for any path and does no work at all.");
+TAG_FLAG(export_drive_io_metrics, advanced);
 
 using google::protobuf::Message;
 using yb::env_util::ScopedFileDeleter;
@@ -413,6 +420,10 @@ Status FsManager::CheckAndOpenFileSystemRoots() {
     }
   }
 
+  // Deliberately after the per-root write check above, so the startup check's own writes stay
+  // out of the drive counters. Do not move this earlier.
+  SetUpDriveIoMetrics();
+
   LOG(INFO) << "Opened local filesystem: " << JoinStrings(canonicalized_all_fs_roots_, ",")
             << std::endl << metadata_->DebugString();
   return Status::OK();
@@ -538,12 +549,9 @@ Status FsManager::CreateFileSystemRoots(const InstanceMetadataPB& metadata,
   std::deque<ScopedFileDeleter> delete_on_failure;
   unordered_set<string> to_sync;
 
-  std::set<std::string> roots = canonicalized_data_fs_roots_;
-  roots.insert(canonicalized_wal_fs_roots_.begin(), canonicalized_wal_fs_roots_.end());
-
   // All roots are either empty or non-existent. Create missing roots and all
   // subdirectories.
-  for (const auto& root : roots) {
+  for (const auto& root : UsableFsRoots()) {
     bool created;
     std::string out_dir;
     RETURN_NOT_OK(SetupRootDir(env_, root, server_type_, &out_dir, &created));
@@ -680,15 +688,36 @@ Status FsManager::CheckWrite(const std::string& root) {
   return Status::OK();
 }
 
-void FsManager::CreateAndSetFaultDriveMetric(const std::string& path) {
+scoped_refptr<MetricEntity> FsManager::GetOrCreateDriveMetricEntity(const std::string& path) {
   MetricEntity::AttributeMap attrs;
   attrs["drive_path"] = path;
-  auto metric_entity = METRIC_ENTITY_drive.Instantiate(metric_registry_,
-                                                       kPrefixMetricId + path,
-                                                       attrs);
-  auto counter = METRIC_drive_fault.Instantiate(metric_entity);
+  return METRIC_ENTITY_drive.Instantiate(metric_registry_, kPrefixMetricId + path, attrs);
+}
+
+void FsManager::CreateAndSetFaultDriveMetric(const std::string& path) {
+  if (metric_registry_ == nullptr) {
+    return;
+  }
+  auto counter = METRIC_drive_fault.Instantiate(GetOrCreateDriveMetricEntity(path));
   counter->Increment();
   counters_.emplace_back(std::move(counter));
+}
+
+std::set<string> FsManager::UsableFsRoots() const {
+  // The exclusion this promises is not done here: the write-check failure path above erases the
+  // faulted root from both of these sets, so it simply is not found. See the declaration.
+  std::set<string> roots = canonicalized_wal_fs_roots_;
+  roots.insert(canonicalized_data_fs_roots_.begin(), canonicalized_data_fs_roots_.end());
+  return roots;
+}
+
+void FsManager::SetUpDriveIoMetrics() {
+  if (!FLAGS_export_drive_io_metrics || metric_registry_ == nullptr) {
+    return;
+  }
+  for (const auto& root : UsableFsRoots()) {
+    yb::RegisterDriveIoMetrics(GetOrCreateDriveMetricEntity(root), root);
+  }
 }
 
 Status FsManager::CreateDirIfMissing(const string& path, bool* created) {

--- a/src/yb/fs/fs_manager.h
+++ b/src/yb/fs/fs_manager.h
@@ -79,8 +79,9 @@ struct FsManagerOpts {
   FsManagerOpts(const FsManagerOpts&);
   FsManagerOpts& operator=(const FsManagerOpts&);
 
-  // The aggregated registry associated with the server.
-  MetricRegistry* metric_registry;
+  // The aggregated registry associated with the server. Left null by callers that do not export
+  // metrics (tools, unit tests), so every use has to be null-checked.
+  MetricRegistry* metric_registry = nullptr;
 
   // The memory tracker under which all new memory trackers will be parented.
   // If NULL, new memory trackers will be parented to the root tracker.
@@ -291,6 +292,24 @@ class FsManager {
   Status CheckWrite(const std::string& path);
 
   void CreateAndSetFaultDriveMetric(const std::string& path);
+
+  // The union of the WAL and data roots we are actually going to use, i.e. excluding any dropped
+  // for failing the startup write check.
+  //
+  // Deliberately not canonicalized_all_fs_roots_, which is the same union as configured but is
+  // never narrowed afterwards: the write-check failure path in CheckAndOpenFileSystemRoots()
+  // erases a faulted root from the WAL and data sets only. That is the right set for callers that
+  // clean up (lock files, DeleteFileSystemLayout, DumpFileSystemTree), which still have business
+  // with a faulted root, and the wrong one for callers about to write to or account for a drive.
+  std::set<std::string> UsableFsRoots() const;
+
+  // Instantiates the 'drive' metric entity for every root we are going to use and wires it to the
+  // per-drive IO counters that the writable-file layer feeds. Until a root is registered here,
+  // writes under it are not attributed to any drive and cost nothing.
+  void SetUpDriveIoMetrics();
+
+  // Instantiates the 'drive' metric entity for 'path', creating it if needed.
+  scoped_refptr<MetricEntity> GetOrCreateDriveMetricEntity(const std::string& path);
 
   // ==========================================================================
   //  file-system helpers

--- a/src/yb/util/CMakeLists.txt
+++ b/src/yb/util/CMakeLists.txt
@@ -137,6 +137,7 @@ set(UTIL_SRCS
   decimal.cc
   delayer.cc
   dist_trace.cc
+  drive_io_stats.cc
   enums.cc
   env.cc
   env_posix.cc
@@ -377,6 +378,7 @@ ADD_YB_TEST(crypt-test)
 ADD_YB_TEST(date_time-test)
 ADD_YB_TEST(debug-util-test)
 ADD_YB_TEST(decimal-test)
+ADD_YB_TEST(drive_io_stats-test)
 ADD_YB_TEST(env-test LABELS no_tsan)
 ADD_YB_TEST(errno-test)
 ADD_YB_TEST(failure_detector-test)

--- a/src/yb/util/drive_io_stats-test.cc
+++ b/src/yb/util/drive_io_stats-test.cc
@@ -1,0 +1,379 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+// Tests for per-drive write-IO accounting. The design being tested is in drive_io_stats.h.
+//
+// Three groups, in file order: which drive a path is attributed to; the unsynced-bytes contract,
+// which is the only part of the accounting a caller can get wrong; and the export onto the 'drive'
+// metric entity. The first two are driven against DriveIoStats directly where a real file cannot
+// reach the case - notably the O_DIRECT path, which would otherwise need a filesystem that
+// supports O_DIRECT.
+//
+// Two things to know before adding a case here. The registry is process-global and entries are
+// never removed, so each test takes roots of its own instead of resetting it (see UniqueRoot).
+// And YBTest sets FLAGS_never_fsync, which makes DoSync() return and Flush() skip
+// sync_file_range entirely - so a test that means to measure a real syscall has to clear it, and
+// only the two that say so do.
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "yb/util/drive_io_stats.h"
+#include "yb/util/env.h"
+#include "yb/util/metrics.h"
+#include "yb/util/path_util.h"
+#include "yb/util/status.h"
+#include "yb/util/test_macros.h"
+#include "yb/util/test_util.h"
+#include "yb/util/tsan_util.h"
+
+// FsManager owns this entity prototype in the real server; util tests do not link yb_fs, so
+// define it here. The name has to match the entity the drive_* prototypes were defined against,
+// which MetricEntity::FindOrCreateMetric checks.
+METRIC_DEFINE_entity(drive);
+
+METRIC_DECLARE_gauge_uint64(drive_bytes_written);
+METRIC_DECLARE_gauge_uint64(drive_sync_count);
+METRIC_DECLARE_gauge_uint64(drive_bytes_unsynced);
+METRIC_DECLARE_event_stats(drive_sync_latency);
+
+DECLARE_bool(never_fsync);
+
+namespace yb {
+
+class DriveIoStatsTest : public YBTest {
+ protected:
+  // The registry is process-global and entries are never removed, so every test uses roots unique
+  // to itself rather than resetting shared state - a reset would dangle the DriveIoStats* that
+  // open files cache for their whole lifetime.
+  std::string UniqueRoot(const std::string& suffix) const {
+    return JoinPathSegments(
+        "/drive-io-stats-test",
+        JoinPathSegments(
+            ::testing::UnitTest::GetInstance()->current_test_info()->name(), suffix));
+  }
+
+  DriveIoStatsRegistry& registry() { return DriveIoStatsRegistry::Instance(); }
+
+  MetricRegistry metric_registry_;
+};
+
+TEST_F(DriveIoStatsTest, AttributesByPathBoundary) {
+  const auto d1 = UniqueRoot("mnt/d1");
+  const auto d10 = UniqueRoot("mnt/d10");
+  auto* s1 = &registry().Register(d1, nullptr);
+  auto* s10 = &registry().Register(d10, nullptr);
+  ASSERT_NE(s1, s10);
+
+  // The prefix match is path-boundary aligned, so ".../d1" must not swallow ".../d10".
+  ASSERT_EQ(s1, registry().Find(d1 + "/yb-data/tserver/wals/tablet/wal-000001"));
+  ASSERT_EQ(s10, registry().Find(d10 + "/yb-data/tserver/wals/tablet/wal-000001"));
+  ASSERT_EQ(s1, registry().Find(d1));
+
+  // Nothing outside a registered root is attributed, and there is no partial-component match.
+  ASSERT_EQ(nullptr, registry().Find(UniqueRoot("mnt/d2") + "/yb-data"));
+  ASSERT_EQ(nullptr, registry().Find(d1 + "x/yb-data"));
+  ASSERT_EQ(nullptr, registry().Find(UniqueRoot("mnt")));
+
+  ASSERT_EQ(d10, registry().FindRoot(d10 + "/yb-data/tserver"));
+  ASSERT_EQ("", registry().FindRoot(UniqueRoot("mnt/d2") + "/yb-data/tserver"));
+}
+
+// A WAL directory pointed at a subdirectory of a data root is a legitimate configuration, so the
+// longest registered root has to win rather than whichever was registered first.
+TEST_F(DriveIoStatsTest, LongestRootWins) {
+  const auto outer_root = UniqueRoot("mnt/d1");
+  auto* outer = &registry().Register(outer_root, nullptr);
+  auto* inner = &registry().Register(outer_root + "/wals", nullptr);
+
+  ASSERT_EQ(inner, registry().Find(outer_root + "/wals/tablet/wal-000001"));
+  ASSERT_EQ(outer, registry().Find(outer_root + "/yb-data/tserver/data/rocksdb/x.sst"));
+}
+
+TEST_F(DriveIoStatsTest, RegisterIsIdempotent) {
+  const auto root = UniqueRoot("mnt/d1");
+  ASSERT_EQ(&registry().Register(root, nullptr), &registry().Register(root, nullptr));
+}
+
+// The unsynced gauge is an upper bound maintained from two directions, so the contract of each
+// entry point matters more than any single number. Exercised directly, because the O_DIRECT path
+// that motivates RecordDirectWrite needs a filesystem that supports O_DIRECT to reach through a
+// real file.
+TEST_F(DriveIoStatsTest, UnsyncedBytesAccounting) {
+  auto* stats = &registry().Register(UniqueRoot("mnt/d1"), nullptr);
+  const auto elapsed = MonoDelta::FromMicroseconds(10);
+
+  // Buffered writes owe an unsynced debt...
+  stats->RecordBufferedWrite(1000, elapsed);
+  ASSERT_EQ(1000, stats->bytes_written());
+  ASSERT_EQ(1000, stats->bytes_unsynced());
+  // ...which a sync settles.
+  stats->RecordSync(1000, elapsed);
+  ASSERT_EQ(0, stats->bytes_unsynced());
+  ASSERT_EQ(1, stats->sync_count());
+
+  // O_DIRECT writes owe nothing: the bytes are already on the device and this class's Sync() is
+  // the write itself, so no RecordSync will ever arrive to settle a debt. If RecordDirectWrite
+  // bumped the gauge, it would climb to equal bytes_written and never come down.
+  stats->RecordDirectWrite(4096, elapsed);
+  ASSERT_EQ(5096, stats->bytes_written());
+  ASSERT_EQ(0, stats->bytes_unsynced());
+
+  // A file closed without syncing releases its residual rather than leaking it.
+  stats->RecordBufferedWrite(700, elapsed);
+  ASSERT_EQ(700, stats->bytes_unsynced());
+  stats->ReleaseUnsyncedBytes(700);
+  ASSERT_EQ(0, stats->bytes_unsynced());
+
+  // Over-settling saturates at zero instead of wrapping.
+  stats->RecordSync(999999, elapsed);
+  ASSERT_EQ(0, stats->bytes_unsynced());
+
+  ASSERT_GT(stats->write_micros(), 0);
+  ASSERT_GT(stats->sync_micros(), 0);
+}
+
+// One DriveIoStats is shared by every tablet's WAL and every RocksDB flush on the mount, so
+// concurrent updates are the normal case. All of these counters are updated relaxed; this pins
+// what that does and does not give up. Each update is a read-modify-write on a single atomic, so
+// none is lost, and the exact totals below hold no matter how the threads interleave. What
+// relaxed gives up is any ordering between the counters, which is why no assertion here reads two
+// of them together while writers are running.
+TEST_F(DriveIoStatsTest, ConcurrentUpdatesLoseNothing) {
+  auto* stats = &registry().Register(UniqueRoot("mnt/d1"), nullptr);
+
+  constexpr int kThreads = 8;
+  // Scaled down under sanitizers: TSAN's race detection is happens-before-based, so it does not
+  // need volume, and the exact-totals check needs collisions only in regular builds.
+  constexpr int kIterations = RegularBuildVsSanitizers(5000, 500);
+  constexpr uint64_t kBytes = 7;
+  constexpr int64_t kMicros = 10;
+  const auto elapsed = MonoDelta::FromMicroseconds(kMicros);
+
+  std::vector<std::thread> threads;
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([stats, elapsed]() {
+      for (int j = 0; j < kIterations; ++j) {
+        // Each thread settles its own debt, so cumulative syncs never run ahead of cumulative
+        // writes and the gauge's saturation at zero is deliberately not in play here.
+        stats->RecordBufferedWrite(kBytes, elapsed);
+        stats->RecordSync(kBytes, elapsed);
+        stats->RecordDirectWrite(kBytes, elapsed);
+        stats->RecordRangeSync(elapsed);
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  constexpr uint64_t kOps = kThreads * kIterations;
+  ASSERT_EQ(2 * kOps * kBytes, stats->bytes_written());
+  ASSERT_EQ(2 * kOps * kMicros, stats->write_micros());
+  ASSERT_EQ(kOps, stats->sync_count());
+  ASSERT_EQ(kOps * kMicros, stats->sync_micros());
+  ASSERT_EQ(kOps, stats->range_sync_count());
+  ASSERT_EQ(kOps * kMicros, stats->range_sync_micros());
+  ASSERT_EQ(0, stats->bytes_unsynced());
+}
+
+TEST_F(DriveIoStatsTest, CountsWritesAndSyncs) {
+  const auto root = GetTestPath("drive");
+  ASSERT_OK(env_->CreateDir(root));
+  auto* stats = &registry().Register(root, nullptr);
+
+  const std::string payload(4096, 'x');
+  {
+    std::unique_ptr<WritableFile> file;
+    ASSERT_OK(env_->NewWritableFile(JoinPathSegments(root, "file"), &file));
+
+    ASSERT_OK(file->Append(Slice(payload)));
+    ASSERT_EQ(payload.size(), stats->bytes_written());
+    // Written but not yet synced: this is the volume the next fsync will be paying for.
+    ASSERT_EQ(payload.size(), stats->bytes_unsynced());
+    ASSERT_EQ(0, stats->sync_count());
+
+    ASSERT_OK(file->Append(Slice(payload)));
+    ASSERT_EQ(2 * payload.size(), stats->bytes_written());
+    ASSERT_EQ(2 * payload.size(), stats->bytes_unsynced());
+
+    ASSERT_OK(file->Sync());
+    ASSERT_EQ(1, stats->sync_count());
+    ASSERT_EQ(0, stats->bytes_unsynced());
+    // A second Sync with nothing pending must not be counted as a sync of the device.
+    ASSERT_OK(file->Sync());
+    ASSERT_EQ(1, stats->sync_count());
+
+    ASSERT_OK(file->Close());
+  }
+
+  // Bytes are cumulative for the drive, not per file, so a second file adds to the same counter.
+  {
+    std::unique_ptr<WritableFile> file;
+    ASSERT_OK(env_->NewWritableFile(JoinPathSegments(root, "file2"), &file));
+    ASSERT_OK(file->Append(Slice(payload)));
+    ASSERT_OK(file->Close());
+  }
+  ASSERT_EQ(3 * payload.size(), stats->bytes_written());
+}
+
+// Closing a file that was never synced must not leave its bytes on the drive gauge forever.
+// WritableFileOptions::sync_on_close defaults to false and RocksDB's writer does not sync on
+// close, so this is the common path, not an edge case.
+TEST_F(DriveIoStatsTest, CloseWithoutSyncDoesNotLeakUnsyncedBytes) {
+  const auto root = GetTestPath("drive");
+  ASSERT_OK(env_->CreateDir(root));
+  auto* stats = &registry().Register(root, nullptr);
+
+  const std::string payload(4096, 'x');
+  {
+    std::unique_ptr<WritableFile> file;
+    ASSERT_OK(env_->NewWritableFile(JoinPathSegments(root, "file"), &file));
+    ASSERT_OK(file->Append(Slice(payload)));
+    ASSERT_EQ(payload.size(), stats->bytes_unsynced());
+    ASSERT_OK(file->Close());
+  }
+  ASSERT_EQ(payload.size(), stats->bytes_written());
+  ASSERT_EQ(0, stats->bytes_unsynced());
+
+  // Same when the file is destroyed without an explicit Close().
+  {
+    std::unique_ptr<WritableFile> file;
+    ASSERT_OK(env_->NewWritableFile(JoinPathSegments(root, "file2"), &file));
+    ASSERT_OK(file->Append(Slice(payload)));
+    ASSERT_EQ(payload.size(), stats->bytes_unsynced());
+  }
+  ASSERT_EQ(0, stats->bytes_unsynced());
+}
+
+// sync_file_range is where SST write cost actually lands, so it gets its own counters.
+TEST_F(DriveIoStatsTest, CountsRangeSync) {
+  // Flush() returns before issuing sync_file_range when never_fsync is set, and YBTest sets it.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_never_fsync) = false;
+
+  const auto root = GetTestPath("drive");
+  ASSERT_OK(env_->CreateDir(root));
+  auto* stats = &registry().Register(root, nullptr);
+
+  std::unique_ptr<WritableFile> file;
+  ASSERT_OK(env_->NewWritableFile(JoinPathSegments(root, "file"), &file));
+  ASSERT_OK(file->Append(Slice(std::string(64 * 1024, 'x'))));
+  ASSERT_EQ(0, stats->range_sync_count());
+
+  ASSERT_OK(file->Flush(WritableFile::FLUSH_ASYNC));
+  ASSERT_EQ(1, stats->range_sync_count());
+  ASSERT_OK(file->Flush(WritableFile::FLUSH_SYNC));
+  ASSERT_EQ(2, stats->range_sync_count());
+  // Range sync is writeback, not durability, so it must not be counted as an fsync.
+  ASSERT_EQ(0, stats->sync_count());
+
+  ASSERT_OK(file->Close());
+}
+
+// Every other test in this file runs with YBTest's default FLAGS_never_fsync=true, which makes
+// DoSync() return without touching the device - so nothing else here proves the instrumentation
+// ever times a real fsync. This one turns that off.
+TEST_F(DriveIoStatsTest, MeasuresRealFsyncLatency) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_never_fsync) = false;
+
+  const auto root = GetTestPath("drive");
+  ASSERT_OK(env_->CreateDir(root));
+
+  MetricEntity::AttributeMap attrs;
+  attrs["drive_path"] = root;
+  auto entity = METRIC_ENTITY_drive.Instantiate(&metric_registry_, "drive:" + root, attrs);
+  RegisterDriveIoMetrics(entity, root);
+  auto* stats = registry().Find(root);
+  ASSERT_NE(stats, nullptr);
+
+  std::unique_ptr<WritableFile> file;
+  ASSERT_OK(env_->NewWritableFile(JoinPathSegments(root, "file"), &file));
+  ASSERT_OK(file->Append(Slice(std::string(256 * 1024, 'x'))));
+  ASSERT_OK(file->Sync());
+  ASSERT_OK(file->Close());
+
+  ASSERT_EQ(1, stats->sync_count());
+  ASSERT_GT(stats->sync_micros(), 0) << "a real fsync should take measurable time";
+
+  // The histogram must have received the same sample, not just the totals.
+  auto latency = entity->FindOrNull<EventStats>(METRIC_drive_sync_latency);
+  ASSERT_NE(latency, nullptr);
+  ASSERT_EQ(1, latency->TotalCount());
+  ASSERT_GT(latency->MeanValue(), 0);
+}
+
+TEST_F(DriveIoStatsTest, ExportsMetricsOnDriveEntity) {
+  const auto root = GetTestPath("drive");
+  ASSERT_OK(env_->CreateDir(root));
+
+  MetricEntity::AttributeMap attrs;
+  attrs["drive_path"] = root;
+  auto entity = METRIC_ENTITY_drive.Instantiate(&metric_registry_, "drive:" + root, attrs);
+  RegisterDriveIoMetrics(entity, root);
+
+  const std::string payload(8192, 'x');
+  std::unique_ptr<WritableFile> file;
+  ASSERT_OK(env_->NewWritableFile(JoinPathSegments(root, "file"), &file));
+  ASSERT_OK(file->Append(Slice(payload)));
+  ASSERT_OK(file->Sync());
+  ASSERT_OK(file->Close());
+
+  auto bytes_written = entity->FindOrNull<FunctionGauge<uint64_t>>(METRIC_drive_bytes_written);
+  ASSERT_NE(bytes_written, nullptr);
+  ASSERT_EQ(payload.size(), bytes_written->value());
+
+  auto sync_count = entity->FindOrNull<FunctionGauge<uint64_t>>(METRIC_drive_sync_count);
+  ASSERT_NE(sync_count, nullptr);
+  ASSERT_EQ(1, sync_count->value());
+
+  auto unsynced = entity->FindOrNull<FunctionGauge<uint64_t>>(METRIC_drive_bytes_unsynced);
+  ASSERT_NE(unsynced, nullptr);
+  ASSERT_EQ(0, unsynced->value());
+
+  // The metrics are declared counter-like so that a rate() over them is meaningful.
+  ASSERT_EQ(MetricType::kCounter, METRIC_drive_bytes_written.type());
+}
+
+// A second MetricRegistry for the same root happens when a mini-cluster restarts a server. The
+// drive's histogram has to follow the new entity, or the new registry exports a metric that is
+// never incremented while increments keep going to the retired one.
+TEST_F(DriveIoStatsTest, ReRegistrationRepointsHistogram) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_never_fsync) = false;
+
+  const auto root = GetTestPath("drive");
+  ASSERT_OK(env_->CreateDir(root));
+
+  MetricEntity::AttributeMap attrs;
+  attrs["drive_path"] = root;
+  auto first = METRIC_ENTITY_drive.Instantiate(&metric_registry_, "drive:" + root, attrs);
+  RegisterDriveIoMetrics(first, root);
+
+  MetricRegistry second_registry;
+  auto second = METRIC_ENTITY_drive.Instantiate(&second_registry, "drive:" + root, attrs);
+  RegisterDriveIoMetrics(second, root);
+
+  std::unique_ptr<WritableFile> file;
+  ASSERT_OK(env_->NewWritableFile(JoinPathSegments(root, "file"), &file));
+  ASSERT_OK(file->Append(Slice(std::string(4096, 'x'))));
+  ASSERT_OK(file->Sync());
+  ASSERT_OK(file->Close());
+
+  auto latency = second->FindOrNull<EventStats>(METRIC_drive_sync_latency);
+  ASSERT_NE(latency, nullptr);
+  ASSERT_EQ(1, latency->TotalCount()) << "increments must follow the most recent registration";
+}
+
+} // namespace yb

--- a/src/yb/util/drive_io_stats.cc
+++ b/src/yb/util/drive_io_stats.cc
@@ -1,0 +1,248 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/util/drive_io_stats.h"
+
+#include "yb/gutil/bind.h"
+
+#include "yb/util/metrics.h"
+#include "yb/util/shared_lock.h"
+
+// Note the units below: the *_time counters are cumulative microseconds, so the useful queries
+// are rates over a scrape interval. Effective write bandwidth for a drive is
+// rate(drive_bytes_written), and average cost per sync is
+// rate(drive_sync_time) / rate(drive_sync_count), with rate(drive_bytes_written) as the context
+// that makes that number mean something.
+//
+// rate(drive_sync_time) / rate(drive_bytes_written) is the one worth putting on a dashboard: time
+// in the device per byte delivered. It rises when a device degrades and stays flat when a device
+// with headroom simply gets more traffic, which is what separates those two causes of a latency
+// increase. It blurs near saturation, where queueing delay grows faster than the offered rate, so
+// read it against sibling drives or against the same drive's own history rather than as an
+// absolute.
+
+METRIC_DEFINE_gauge_uint64(drive, drive_bytes_written, "Drive Bytes Written",
+    yb::MetricUnit::kBytes,
+    "Bytes handed to write()/writev() for files on this drive, since the server started. "
+    "Covers the Raft WAL, RocksDB SSTs for both the regular and intents databases, RocksDB "
+    "bookkeeping files, tablet metadata, and remote bootstrap and snapshot writes. This is the "
+    "volume side of the picture: fsync latency is not interpretable without it. Note that under "
+    "O_DIRECT (durable_wal_write=true) writes are block-aligned, so a partially filled trailing "
+    "block is re-written on each sync and is counted each time. That is genuinely what reached "
+    "the device, but it means for a small-append workload this counter exceeds the payload "
+    "written and the derived throughput is device throughput rather than payload throughput.",
+    yb::EXPOSE_AS_COUNTER);
+
+METRIC_DEFINE_gauge_uint64(drive, drive_write_time, "Drive Write Time",
+    yb::MetricUnit::kMicroseconds,
+    "Cumulative time spent inside write()/writev() for files on this drive. Normally small, "
+    "because buffered writes land in the page cache. Under O_DIRECT (durable_wal_write=true) "
+    "there is no page cache in between and no fsync afterwards, so for those drives this "
+    "counter, not drive_sync_time, is where the device cost appears.",
+    yb::EXPOSE_AS_COUNTER);
+
+METRIC_DEFINE_gauge_uint64(drive, drive_sync_count, "Drive Sync Count",
+    yb::MetricUnit::kOperations,
+    "Number of fsync()/fdatasync() calls issued for files on this drive since the server "
+    "started.",
+    yb::EXPOSE_AS_COUNTER);
+
+METRIC_DEFINE_gauge_uint64(drive, drive_sync_time, "Drive Sync Time",
+    yb::MetricUnit::kMicroseconds,
+    "Cumulative time blocked in fsync()/fdatasync() for files on this drive. Divide by "
+    "drive_sync_count for average cost per sync, and read it beside drive_bytes_written to tell "
+    "a slow device apart from a large amount of data.",
+    yb::EXPOSE_AS_COUNTER);
+
+METRIC_DEFINE_gauge_uint64(drive, drive_range_sync_count, "Drive Range Sync Count",
+    yb::MetricUnit::kOperations,
+    "Number of sync_file_range() writeback calls issued for files on this drive since the "
+    "server started. RocksDB paces SST writeback this way rather than by fsyncing.",
+    yb::EXPOSE_AS_COUNTER);
+
+METRIC_DEFINE_gauge_uint64(drive, drive_range_sync_time, "Drive Range Sync Time",
+    yb::MetricUnit::kMicroseconds,
+    "Cumulative time spent in sync_file_range() writeback for files on this drive. Counted "
+    "separately from drive_sync_time because RocksDB drains SST dirty data continuously and "
+    "leaves the tail of the file unsynced, so the closing fsync on an SST can be cheap even on "
+    "a badly degraded device. Without this counter, SST write cost is invisible.",
+    yb::EXPOSE_AS_COUNTER);
+
+METRIC_DEFINE_gauge_uint64(drive, drive_bytes_unsynced, "Drive Bytes Unsynced",
+    yb::MetricUnit::kBytes,
+    "Approximate bytes written to this drive but not yet fsynced. This is an upper bound, not a "
+    "measurement: it only decreases when YugabyteDB itself fsyncs a file or closes one. It "
+    "therefore takes no account of writeback the kernel did on its own, nor of writeback we "
+    "initiate ourselves - Flush() and RangeSync() push data to the device via sync_file_range and "
+    "do not decrement it - so on a RocksDB-heavy drive this tracks bytes written since our last "
+    "fsync or close rather than bytes dirty in the page cache, and will read high on a perfectly "
+    "healthy node. O_DIRECT writes never contribute, since nothing is left pending. Useful for "
+    "spotting a drive whose backlog grows without bound relative to its peers, not as an absolute "
+    "figure.");
+
+METRIC_DEFINE_event_stats(drive, drive_sync_latency, "Drive Sync Latency",
+    yb::MetricUnit::kMicroseconds,
+    "Latency of individual fsync()/fdatasync() calls for files on this drive. Unlike the "
+    "table-level log_sync_latency, this can be attributed to a device.");
+
+namespace yb {
+
+namespace {
+
+// Subtracts without wrapping past zero. The unsynced-bytes gauge is an estimate maintained from
+// two directions, so it can legitimately be asked to go negative.
+void SubtractSaturating(std::atomic<uint64_t>& counter, uint64_t delta) {
+  auto current = counter.load(std::memory_order_relaxed);
+  while (current > 0) {
+    const auto next = delta >= current ? 0 : current - delta;
+    if (counter.compare_exchange_weak(
+            current, next, std::memory_order_relaxed, std::memory_order_relaxed)) {
+      return;
+    }
+  }
+}
+
+uint64_t Micros(MonoDelta elapsed) {
+  const auto micros = elapsed.ToMicroseconds();
+  return micros > 0 ? static_cast<uint64_t>(micros) : 0;
+}
+
+// True when `root` is a path-boundary-aligned prefix of `path`, so that "/mnt/d1" owns
+// "/mnt/d1/yb-data/..." but not "/mnt/d10/yb-data/...".
+bool IsPathPrefix(const std::string& root, const std::string& path) {
+  if (path.size() < root.size() || path.compare(0, root.size(), root) != 0) {
+    return false;
+  }
+  if (path.size() == root.size()) {
+    return true;
+  }
+  // A root recorded with a trailing slash already ends at a boundary.
+  return root.back() == '/' || path[root.size()] == '/';
+}
+
+} // namespace
+
+void DriveIoStats::RecordBufferedWrite(uint64_t bytes, MonoDelta elapsed) {
+  bytes_written_.fetch_add(bytes, std::memory_order_relaxed);
+  write_micros_.fetch_add(Micros(elapsed), std::memory_order_relaxed);
+  bytes_unsynced_.fetch_add(bytes, std::memory_order_relaxed);
+}
+
+void DriveIoStats::RecordDirectWrite(uint64_t bytes, MonoDelta elapsed) {
+  bytes_written_.fetch_add(bytes, std::memory_order_relaxed);
+  write_micros_.fetch_add(Micros(elapsed), std::memory_order_relaxed);
+}
+
+void DriveIoStats::RecordSync(uint64_t bytes_synced, MonoDelta elapsed) {
+  const auto micros = Micros(elapsed);
+  sync_count_.fetch_add(1, std::memory_order_relaxed);
+  sync_micros_.fetch_add(micros, std::memory_order_relaxed);
+  SubtractSaturating(bytes_unsynced_, bytes_synced);
+  // Acquire, unlike the counters: this pointer is dereferenced, so it has to be ordered against
+  // the construction of what it points at. See the member declaration.
+  auto* sync_latency = sync_latency_.load(std::memory_order_acquire);
+  if (sync_latency != nullptr) {
+    // Micros() already clamped to non-negative, and no fsync latency comes near INT64_MAX.
+    sync_latency->Increment(static_cast<int64_t>(micros));
+  }
+}
+
+void DriveIoStats::RecordRangeSync(MonoDelta elapsed) {
+  range_sync_count_.fetch_add(1, std::memory_order_relaxed);
+  range_sync_micros_.fetch_add(Micros(elapsed), std::memory_order_relaxed);
+}
+
+void DriveIoStats::ReleaseUnsyncedBytes(uint64_t bytes) {
+  SubtractSaturating(bytes_unsynced_, bytes);
+}
+
+DriveIoStatsRegistry& DriveIoStatsRegistry::Instance() {
+  static DriveIoStatsRegistry instance;
+  return instance;
+}
+
+DriveIoStats& DriveIoStatsRegistry::Register(
+    const std::string& root, const EventStatsPtr& sync_latency) {
+  std::lock_guard lock(mutex_);
+  auto it = roots_.find(root);
+  if (it == roots_.end()) {
+    it = roots_.emplace(root, std::make_unique<DriveIoStats>()).first;
+  }
+  if (sync_latency) {
+    // This load needs no ordering: mutex_ is held and the registry is the only writer.
+    auto* previous = it->second->sync_latency_.load(std::memory_order_relaxed);
+    if (previous != sync_latency.get()) {
+      // Retained forever: a writer may already hold the raw pointer being replaced. Retain only
+      // on an actual change, or a mini-cluster would accumulate one refptr per root per server
+      // restart.
+      retained_sync_stats_.push_back(sync_latency);
+      // Release: publishes a fully constructed EventStats to the acquire load in RecordSync(),
+      // which does not take mutex_.
+      it->second->sync_latency_.store(sync_latency.get(), std::memory_order_release);
+      LOG_IF(INFO, previous != nullptr)
+          << "Drive " << root << " sync-latency stats re-pointed at a newer metric entity; "
+          << "the previous one stops receiving samples.";
+    }
+  }
+  return *it->second;
+}
+
+std::map<std::string, std::unique_ptr<DriveIoStats>>::const_iterator
+DriveIoStatsRegistry::FindUnlocked(const std::string& path) const {
+  // Roots are few (one per --fs_data_dirs / --fs_wal_dirs entry) and this runs once per file
+  // open, so a linear scan for the longest match is cheaper than being clever.
+  auto best = roots_.end();
+  for (auto it = roots_.begin(); it != roots_.end(); ++it) {
+    if (IsPathPrefix(it->first, path) &&
+        (best == roots_.end() || it->first.size() > best->first.size())) {
+      best = it;
+    }
+  }
+  return best;
+}
+
+DriveIoStats* DriveIoStatsRegistry::Find(const std::string& path) const {
+  SharedLock lock(mutex_);
+  auto it = FindUnlocked(path);
+  return it == roots_.end() ? nullptr : it->second.get();
+}
+
+std::string DriveIoStatsRegistry::FindRoot(const std::string& path) const {
+  SharedLock lock(mutex_);
+  auto it = FindUnlocked(path);
+  return it == roots_.end() ? std::string() : it->first;
+}
+
+void RegisterDriveIoMetrics(const scoped_refptr<MetricEntity>& entity, const std::string& root) {
+  auto& stats = DriveIoStatsRegistry::Instance().Register(
+      root, METRIC_drive_sync_latency.Instantiate(entity));
+
+  // Unretained + NeverRetire because the counters live in the process-global registry and so
+  // does the drive.
+  entity->NeverRetire(METRIC_drive_bytes_written.InstantiateFunctionGauge(
+      entity, Bind(&DriveIoStats::bytes_written, Unretained(&stats))));
+  entity->NeverRetire(METRIC_drive_write_time.InstantiateFunctionGauge(
+      entity, Bind(&DriveIoStats::write_micros, Unretained(&stats))));
+  entity->NeverRetire(METRIC_drive_sync_count.InstantiateFunctionGauge(
+      entity, Bind(&DriveIoStats::sync_count, Unretained(&stats))));
+  entity->NeverRetire(METRIC_drive_sync_time.InstantiateFunctionGauge(
+      entity, Bind(&DriveIoStats::sync_micros, Unretained(&stats))));
+  entity->NeverRetire(METRIC_drive_range_sync_count.InstantiateFunctionGauge(
+      entity, Bind(&DriveIoStats::range_sync_count, Unretained(&stats))));
+  entity->NeverRetire(METRIC_drive_range_sync_time.InstantiateFunctionGauge(
+      entity, Bind(&DriveIoStats::range_sync_micros, Unretained(&stats))));
+  entity->NeverRetire(METRIC_drive_bytes_unsynced.InstantiateFunctionGauge(
+      entity, Bind(&DriveIoStats::bytes_unsynced, Unretained(&stats))));
+}
+
+} // namespace yb

--- a/src/yb/util/drive_io_stats.h
+++ b/src/yb/util/drive_io_stats.h
@@ -1,0 +1,194 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+// Per-drive write-IO accounting, exported on the 'drive' metric entity.
+//
+// Reading order: DriveIoStats for the counters and what each one obliges its caller to do,
+// DriveIoStatsRegistry for how a path is attributed to a drive, RegisterDriveIoMetrics for the
+// export.
+//
+// The single choke point this relies on: yb::PosixWritableFile is the one writable-file
+// implementation behind both the Raft WAL and everything RocksDB writes through the YugabyteDB
+// Env, so instrumenting it covers all of them without any of them knowing that drives exist.
+// Direct and buffered writes reach the device differently and owe different bookkeeping, which is
+// why they are separate entry points here rather than one RecordWrite().
+//
+// Layering constraint worth knowing before moving anything: yb_fs links yb_util, so util must not
+// depend on fs. That is why the registry and every metric prototype live here while FsManager
+// keeps ownership of the 'drive' metric entity prototype and passes an already-instantiated entity
+// in. Metric prototypes only stringize the entity name, so defining them here against the 'drive'
+// entity creates no link edge; only Instantiate needs METRIC_ENTITY_drive.
+//
+// The thread-local IOStatsContext was considered and not reused: it has the right fields, but it
+// is thread-local, perf-level-gated, RocksDB-scoped and never exported as a server metric, so
+// widening it is more code than a separate always-on per-drive accumulator.
+
+#include <atomic>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "yb/util/locks.h"
+#include "yb/util/metrics_fwd.h"
+#include "yb/util/monotime.h"
+
+namespace yb {
+
+// Per-drive write-IO accounting, aggregated over every writable file that lives under a
+// registered drive root.
+//
+// Why volume is counted and not just latency: an fsync duration with no byte count beside it is
+// not interpretable. 500 ms of fsync means a broken device if 64 KB went through it and means
+// nothing at all if 64 MB did. Before these counters existed a support bundle carried the duration
+// and not the volume, so those two cases could not be told apart after the fact. Reading
+// drive_bytes_written next to drive_sync_time is what tells them apart.
+//
+// Why the unit is the drive and not the tablet or the file: fsync latency is not a property of
+// the file being synced, it is set by the shared block device. The queue that fsync waits on is
+// fed concurrently by every other tablet's WAL, by memtable flushes and compactions writing
+// SSTs, and by anything else on the same mount. Pairing one file's bytes with one fsync's
+// duration therefore has a contaminated denominator and can be wrong by orders of magnitude in
+// either direction. Aggregating per drive over a scrape interval averages over exactly that
+// contention, which is what makes "is this device an order of magnitude slower than its peers"
+// answerable.
+//
+// Everything here is approximate on purpose: counters read in one scrape are not consistent with
+// each other, and no individual operation is ever paired with any other. The question being
+// answered is order-of-magnitude device throughput, not accounting.
+class DriveIoStats {
+ public:
+  // A buffered write of `bytes` bytes taking `elapsed`. The bytes are now dirty in the page
+  // cache and some later fsync will pay for them, so they also count toward the unsynced gauge -
+  // which makes this call impose a bookkeeping obligation on the caller: it must eventually
+  // report those bytes to RecordSync() or ReleaseUnsyncedBytes().
+  void RecordBufferedWrite(uint64_t bytes, MonoDelta elapsed);
+
+  // An O_DIRECT write of `bytes` bytes taking `elapsed`. Deliberately a separate entry point
+  // from the buffered case: there is no page cache in between and no fsync follows, so the bytes
+  // are already on the device, nothing is left pending, and no unsynced bookkeeping is owed.
+  // Under O_DIRECT this call also carries the whole device cost, which is why write time is
+  // tracked at all.
+  void RecordDirectWrite(uint64_t bytes, MonoDelta elapsed);
+
+  // fsync()/fdatasync() taking `elapsed`. `bytes_synced` is how much the calling file had
+  // written but not yet synced; it is used only to walk the approximate unsynced gauge back
+  // down, and is deliberately not divided by `elapsed` (see the class comment).
+  void RecordSync(uint64_t bytes_synced, MonoDelta elapsed);
+
+  // sync_file_range() writeback, counted apart from RecordSync because this is where SST write
+  // cost actually lands. RocksDB paces its own writeback with sync_file_range and deliberately
+  // leaves the tail of the file unsynced, so the closing fsync on an SST can be cheap even on a
+  // badly degraded device. A metric watching only fsync duration reports SST writes as nearly
+  // free.
+  void RecordRangeSync(MonoDelta elapsed);
+
+  // Drops `bytes` from the unsynced gauge without counting a sync. Used when a file goes away
+  // still holding dirty bytes: closing without syncing is normal (WritableFileOptions::
+  // sync_on_close defaults to false, and RocksDB's writer does not sync on close either), and
+  // without this the gauge would only ever climb.
+  void ReleaseUnsyncedBytes(uint64_t bytes);
+
+  // Relaxed like every other access to these counters: see the note on the members below.
+  uint64_t bytes_written() const { return bytes_written_.load(std::memory_order_relaxed); }
+  uint64_t write_micros() const { return write_micros_.load(std::memory_order_relaxed); }
+  uint64_t sync_count() const { return sync_count_.load(std::memory_order_relaxed); }
+  uint64_t sync_micros() const { return sync_micros_.load(std::memory_order_relaxed); }
+  uint64_t range_sync_count() const { return range_sync_count_.load(std::memory_order_relaxed); }
+  uint64_t range_sync_micros() const { return range_sync_micros_.load(std::memory_order_relaxed); }
+  uint64_t bytes_unsynced() const { return bytes_unsynced_.load(std::memory_order_relaxed); }
+
+ private:
+  friend class DriveIoStatsRegistry;
+
+  // Optional fsync-latency stats (EventStats: sum and count, not a full histogram), owned by the
+  // registry and never destroyed, so a raw pointer is safe. Atomic because the registry may
+  // re-point it (a second MetricRegistry in the same process, i.e. a mini-cluster server restart)
+  // while writers are running.
+  //
+  // This is the one member here that is not accessed relaxed. It publishes an object rather than
+  // a value: a reader dereferences what it loads, so the store has to be release and the load
+  // acquire, or the EventStats a reader reaches through the pointer is not guaranteed to be
+  // constructed yet.
+  std::atomic<EventStats*> sync_latency_{nullptr};
+
+  // Every counter below is read and written with memory_order_relaxed, which is what the rest of
+  // our metrics do (AtomicInt behind AtomicGauge defaults to kMemOrderNoBarrier, and the
+  // std::atomic counters behind yb::Thread's FunctionGauges pass relaxed explicitly). Nothing here
+  // orders anything else: no counter is consistent with another within a scrape by design, and a
+  // reader only ever wants a recent value. Ordering them would buy a guarantee nobody uses, at the
+  // price of a barrier per operation on the WAL and SST write paths.
+  //
+  // Contention is bounded rather than absent: roughly 50 ns per update on one thread and 275 ns
+  // with 16 threads sharing a drive, against fsyncs three orders of magnitude larger.
+  std::atomic<uint64_t> bytes_written_{0};
+  std::atomic<uint64_t> write_micros_{0};
+  std::atomic<uint64_t> sync_count_{0};
+  std::atomic<uint64_t> sync_micros_{0};
+  std::atomic<uint64_t> range_sync_count_{0};
+  std::atomic<uint64_t> range_sync_micros_{0};
+  std::atomic<uint64_t> bytes_unsynced_{0};
+};
+
+// Process-global map from drive root to its counters.
+//
+// Roots are registered once at FsManager startup and never removed, so the returned pointers are
+// stable for the whole lifetime of the process. Attribution is by longest matching path prefix,
+// which is what makes a single instrumentation point in PosixWritableFile cover the WAL, both
+// RocksDB databases, tablet metadata, remote bootstrap and snapshot writes without any of them
+// knowing about drives.
+class DriveIoStatsRegistry {
+ public:
+  static DriveIoStatsRegistry& Instance();
+
+  // Registers `root` and returns its counters, or the existing entry if already registered.
+  //
+  // A non-null `sync_latency` becomes the stats the drive reports into, replacing any earlier
+  // one; the earlier one is retained rather than freed, because writers may still hold it.
+  // Replacement happens when a second MetricRegistry appears for the same root in one process,
+  // e.g. a mini-cluster restarting a server.
+  DriveIoStats& Register(const std::string& root, const EventStatsPtr& sync_latency);
+
+  // Counters for the drive that owns `path`, or null when `path` is under no registered root.
+  DriveIoStats* Find(const std::string& path) const;
+
+  // The drive root that owns `path`, or an empty string. For log lines that want to name the
+  // drive.
+  std::string FindRoot(const std::string& path) const;
+
+ private:
+  // Returns an iterator to the longest registered root that is a path-boundary-aligned prefix
+  // of `path`, or end().
+  std::map<std::string, std::unique_ptr<DriveIoStats>>::const_iterator FindUnlocked(
+      const std::string& path) const REQUIRES_SHARED(mutex_);
+
+  mutable rw_spinlock mutex_;
+  std::map<std::string, std::unique_ptr<DriveIoStats>> roots_ GUARDED_BY(mutex_);
+
+  // Keeps every EventStats ever handed to Register() alive, including replaced ones, since a
+  // writer may be holding the raw pointer.
+  std::vector<EventStatsPtr> retained_sync_stats_ GUARDED_BY(mutex_);
+};
+
+// Instantiates the per-drive IO metrics on `entity` and wires them to the counters for `root`,
+// registering `root` if needed. Calling it again for the same root and the same entity is a
+// no-op; calling it with a different entity re-points the drive's sync stats at the new entity
+// (see DriveIoStatsRegistry::Register).
+//
+// Lives here rather than in FsManager so that every drive metric prototype sits next to the
+// code that feeds it; the caller only has to own the `drive` metric entity.
+void RegisterDriveIoMetrics(const scoped_refptr<MetricEntity>& entity, const std::string& root);
+
+} // namespace yb

--- a/src/yb/util/drive_io_stats_fwd.h
+++ b/src/yb/util/drive_io_stats_fwd.h
@@ -1,0 +1,20 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+namespace yb {
+
+class DriveIoStats;
+class DriveIoStatsRegistry;
+
+}  // namespace yb

--- a/src/yb/util/env_posix.cc
+++ b/src/yb/util/env_posix.cc
@@ -54,6 +54,7 @@
 
 #include "yb/util/alignment.h"
 #include "yb/util/debug/trace_event.h"
+#include "yb/util/drive_io_stats.h"
 #include "yb/util/env.h"
 #include "yb/util/errno.h"
 #include "yb/util/faststring.h"
@@ -464,6 +465,7 @@ class PosixDirectIOWritableFile final : public PosixWritableFile {
     struct iovec* remaining_iov = iov;
     int remaining_blocks = narrow_cast<int>(blocks_to_write);
     ssize_t total_written = 0;
+    const auto start = MonoTime::Now();
 
     while (remaining_blocks > 0) {
       ssize_t written = pwritev(
@@ -479,6 +481,19 @@ class PosixDirectIOWritableFile final : public PosixWritableFile {
 
       UnwrittenRemaining(&remaining_iov, written, &remaining_blocks);
       total_written += written;
+    }
+
+    if (drive_stats_) {
+      // RecordDirectWrite, not the buffered variant: this class overrides Sync() to be exactly
+      // this write and never reaches PosixWritableFile::Sync(), so nothing would ever come along
+      // to settle an unsynced-bytes debt. There is also nothing to settle - with O_DIRECT the
+      // bytes are on the device when pwritev returns.
+      //
+      // This is likewise the whole device cost on such a drive: no page cache in between and no
+      // fsync afterwards, so drive_write_time carries what drive_sync_time carries elsewhere.
+      // Bytes are block-padded, which is genuinely what reached the device.
+      drive_stats_->RecordDirectWrite(
+          static_cast<uint64_t>(total_written), MonoTime::Now() - start);
     }
 
     if (PREDICT_FALSE(total_written != bytes_to_write)) {

--- a/src/yb/util/file_system_posix.cc
+++ b/src/yb/util/file_system_posix.cc
@@ -32,6 +32,7 @@
 #include "yb/util/coding-inl.h"
 #include "yb/util/coding.h"
 #include "yb/util/debug/trace_event.h"
+#include "yb/util/drive_io_stats.h"
 #include "yb/util/errno.h"
 #include "yb/util/logging.h"
 #include "yb/util/malloc.h"
@@ -420,7 +421,10 @@ PosixWritableFile::PosixWritableFile(const std::string& fname, int fd,
       sync_on_close_(sync_on_close),
       filesize_(initial_size),
       pre_allocated_size_(0),
-      pending_sync_(false) {
+      pending_sync_(false),
+      // Files opened before their drive is registered (FsManager's own startup writes) go
+      // uncounted.
+      drive_stats_(DriveIoStatsRegistry::Instance().Find(fname)) {
 #ifdef ROCKSDB_FALLOCATE_PRESENT
   allow_fallocate_ = options.allow_fallocate;
   fallocate_with_keep_size_ = options.fallocate_with_keep_size;
@@ -430,6 +434,20 @@ PosixWritableFile::PosixWritableFile(const std::string& fname, int fd,
 PosixWritableFile::~PosixWritableFile() {
   if (fd_ >= 0) {
     WARN_NOT_OK(PosixWritableFile::Close(), "Failed to close " + filename_);
+  }
+  // Covers paths that abandon the file without a successful Close(); the exchange in
+  // ReleaseUnsyncedBytes makes the double call harmless.
+  ReleaseUnsyncedBytes();
+}
+
+void PosixWritableFile::ReleaseUnsyncedBytes() {
+  // No need to zero the per-file counter when the file is going away.
+  if (drive_stats_ == nullptr) {
+    return;
+  }
+  const auto residual = unsynced_bytes_.exchange(0, std::memory_order_relaxed);
+  if (residual != 0) {
+    drive_stats_->ReleaseUnsyncedBytes(residual);
   }
 }
 
@@ -540,6 +558,10 @@ Status PosixWritableFile::Close() {
     }
   }
   fd_ = -1;
+  // After the optional sync above, so a synced close has nothing left to release. Anything still
+  // pending here was never fsynced by us (sync_on_close_ defaults to false, and RocksDB's writer
+  // does not sync on close either) and must come off the drive gauge, or it stays there forever.
+  ReleaseUnsyncedBytes();
   return s;
 }
 
@@ -554,8 +576,14 @@ Status PosixWritableFile::Flush(FlushMode mode) {
   if (mode == FLUSH_SYNC) {
     flags |= SYNC_FILE_RANGE_WAIT_AFTER;
   }
-  if (sync_file_range(fd_, 0, 0, flags) < 0) {
+  const auto start = MonoTime::Now();
+  const auto rc = sync_file_range(fd_, 0, 0, flags);
+  if (rc < 0) {
+    // Failed operations go uncounted.
     return STATUS_IO_ERROR(filename_, errno);
+  }
+  if (drive_stats_) {
+    drive_stats_->RecordRangeSync(MonoTime::Now() - start);
   }
 #else
   if (fsync(fd_) < 0) {
@@ -568,10 +596,25 @@ Status PosixWritableFile::Flush(FlushMode mode) {
 Status PosixWritableFile::Sync() {
   TRACE_EVENT1("io", "PosixWritableFile::Sync", "path", filename_);
   ThreadRestrictions::AssertIOAllowed();
-  LOG_SLOW_EXECUTION(WARNING, 1000, strings::Substitute("sync call for $0", filename_)) {
+  // The byte count goes into the slow-sync line so that a support bundle with no metrics in it
+  // is still actionable: a slow sync of a lot of bytes is a big flush, a slow sync of a few
+  // bytes is a slow device. The path names the drive.
+  const auto pending_bytes = unsynced_bytes_.load(std::memory_order_relaxed);
+  LOG_SLOW_EXECUTION(WARNING, 1000, strings::Substitute(
+      "sync call for $0 ($1 unsynced bytes)", filename_, pending_bytes)) {
     if (pending_sync_) {
       pending_sync_ = false;
-      RETURN_NOT_OK(DoSync(fd_, filename_));
+      const auto synced_bytes = unsynced_bytes_.exchange(0, std::memory_order_relaxed);
+      const auto start = MonoTime::Now();
+      const auto sync_status = DoSync(fd_, filename_);
+      if (!sync_status.ok()) {
+        // A failed sync settles nothing: restore the unsynced debt and count nothing.
+        unsynced_bytes_.fetch_add(synced_bytes, std::memory_order_relaxed);
+        return sync_status;
+      }
+      if (drive_stats_) {
+        drive_stats_->RecordSync(synced_bytes, MonoTime::Now() - start);
+      }
     }
   }
   return Status::OK();
@@ -581,8 +624,15 @@ Status PosixWritableFile::Fsync() {
   if (FLAGS_never_fsync) {
     return Status::OK();
   }
+  const auto synced_bytes = unsynced_bytes_.exchange(0, std::memory_order_relaxed);
+  const auto start = MonoTime::Now();
   if (fsync(fd_) < 0) {
+    // A failed sync settles nothing: restore the unsynced debt and count nothing.
+    unsynced_bytes_.fetch_add(synced_bytes, std::memory_order_relaxed);
     return STATUS_IO_ERROR(filename_, errno);
+  }
+  if (drive_stats_) {
+    drive_stats_->RecordSync(synced_bytes, MonoTime::Now() - start);
   }
   pending_sync_ = false;
   return Status::OK();
@@ -624,6 +674,7 @@ Status PosixWritableFile::DoWritev(const Slice* slices, size_t n) {
   struct iovec* remaining_iov = iov;
   int remaining_count = static_cast<int>(n);
   ssize_t total_written = 0;
+  const auto start = MonoTime::Now();
 
   while (remaining_count > 0) {
     ssize_t written = writev(fd_, remaining_iov, remaining_count);
@@ -631,6 +682,8 @@ Status PosixWritableFile::DoWritev(const Slice* slices, size_t n) {
       if (errno == EINTR || errno == EAGAIN) {
         continue;
       }
+      // A failed write goes uncounted. The counters are for throughput, and IO errors already
+      // have their own reporting path.
       return STATUS_IO_ERROR(filename_, errno);
     }
 
@@ -640,6 +693,14 @@ Status PosixWritableFile::DoWritev(const Slice* slices, size_t n) {
   }
 
   filesize_ += total_written;
+  const auto bytes = static_cast<uint64_t>(total_written);
+  // Outside the drive_stats_ check on purpose: the slow-sync log line in Sync() reports this
+  // number even when the drive is not instrumented, and a hardcoded zero there would read as
+  // strong evidence for a slow device.
+  unsynced_bytes_.fetch_add(bytes, std::memory_order_relaxed);
+  if (drive_stats_) {
+    drive_stats_->RecordBufferedWrite(bytes, MonoTime::Now() - start);
+  }
 
   if (PREDICT_FALSE(total_written != nbytes)) {
     return STATUS_FORMAT(
@@ -688,12 +749,16 @@ Status PosixWritableFile::Allocate(uint64_t offset, uint64_t len) {
 Status PosixWritableFile::RangeSync(uint64_t offset, uint64_t nbytes) {
   assert(std::cmp_less_equal(offset, std::numeric_limits<off_t>::max()));
   assert(std::cmp_less_equal(nbytes, std::numeric_limits<off_t>::max()));
-  if (sync_file_range(fd_, static_cast<off_t>(offset),
-      static_cast<off_t>(nbytes), SYNC_FILE_RANGE_WRITE) == 0) {
-    return Status::OK();
-  } else {
+  const auto start = MonoTime::Now();
+  const auto rc = sync_file_range(
+      fd_, static_cast<off_t>(offset), static_cast<off_t>(nbytes), SYNC_FILE_RANGE_WRITE);
+  if (rc != 0) {
     return STATUS_IO_ERROR(filename_, errno);
   }
+  if (drive_stats_) {
+    drive_stats_->RecordRangeSync(MonoTime::Now() - start);
+  }
+  return Status::OK();
 }
 
 size_t PosixWritableFile::GetUniqueId(char* id) const {

--- a/src/yb/util/file_system_posix.h
+++ b/src/yb/util/file_system_posix.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "yb/util/drive_io_stats_fwd.h"
 #include "yb/util/file_system.h"
 
 struct iovec;
@@ -137,6 +138,32 @@ class PosixWritableFile : public WritableFile {
   uint64_t filesize_;
   uint64_t pre_allocated_size_;
   std::atomic<bool> pending_sync_;
+
+  // Per-drive IO counters for the drive this file lives on, resolved once at construction by
+  // path prefix, or null when the file is under no registered drive root. Owned by the process-
+  // global DriveIoStatsRegistry, so this pointer stays valid for the life of the file.
+  DriveIoStats* const drive_stats_;
+
+  // Bytes appended since the last sync of this file, used to walk the drive's approximate
+  // unsynced-bytes gauge back down. Atomic because Sync() is documented thread-safe with respect
+  // to Append() (see IsSyncThreadSafe()). Maintained even when drive_stats_ is null, because the
+  // slow-sync log line reports it.
+  //
+  // Deliberately approximate, and the approximation is what keeps it cheap. Sync() zeroes this
+  // and then calls fsync, so an Append() landing in between is counted as still unsynced even
+  // though that fsync almost certainly pushed it out. Making the number exact would mean holding
+  // a lock across the append and the fsync together, i.e. serializing the two operations that
+  // IsSyncThreadSafe() exists to let run concurrently, and on the WAL that is the hot path. An
+  // upper bound is all the gauge claims to be (see the drive_bytes_unsynced description).
+  //
+  // Accessed with memory_order_relaxed, like the drive counters it feeds. It publishes no other
+  // memory, and every update is a read-modify-write on this one variable, so concurrent updates
+  // still compose correctly without any barrier.
+  std::atomic<uint64_t> unsynced_bytes_{0};
+
+  // Hands whatever this file still holds unsynced back to the drive gauge without counting a
+  // sync. Closing without syncing is the normal case, so without this the gauge only climbs.
+  void ReleaseUnsyncedBytes();
 #ifdef ROCKSDB_FALLOCATE_PRESENT
   bool allow_fallocate_;
   bool fallocate_with_keep_size_;


### PR DESCRIPTION
Summary:
We report how long our fsyncs take but never how much data went to the device over the same
window, and an fsync duration with no volume beside it is not interpretable: 500 ms is a broken
device for 64 KB and unremarkable for 64 MB. log_sync_latency does not answer it either, being
table-level and so aggregated across whatever drives a table's tablets happen to sit on.

Add per-drive write-IO accounting on the existing 'drive' metric entity. New
util/drive_io_stats.{h,cc} holds the counters, a process-global registry keyed by drive root, and
the metric definitions. The design is in drive_io_stats.h's file comment: the single choke point
(yb::PosixWritableFile, behind both the Raft WAL and everything RocksDB writes through the
YugabyteDB Env), why the unit is the drive rather than the tablet or file, the separate
buffered/direct entry points and the unsynced-bytes contract, and the util/fs layering. What each
counter means is in its METRIC_DEFINE description.

Sync durations and byte settlements are recorded only on success: a failed fsync restores the
unsynced debt and counts nothing, matching the failed-write path.

Slow-sync log lines now carry the pending byte count as well, so a support bundle with no metrics
in it is still actionable.

Fixed in passing, because this change makes it reachable: FsManagerOpts::metric_registry was a
raw MetricRegistry* with no initializer, so tools and unit tests left it holding garbage. Now
defaults to nullptr, with both call sites null-checked.

Out of scope: PosixRWFile, which is on neither the WAL nor the SST path, and a WAL-versus-SST
breakdown of the byte counter.

Test Plan:
util/drive_io_stats-test, 10 tests, new: path attribution, the unsynced-bytes contract across the
buffered, direct, and closed-without-syncing paths, and the export onto the 'drive' metric entity.
Its file comment has the layout and the two traps worth knowing before adding a case.

fs/fs_manager-test, 29 tests (3 new), covering which roots SetUpDriveIoMetrics registers: both WAL
and data roots as distinct drives, nothing at all with --export_drive_io_metrics off, and never a
root that was dropped for a fault.

All passing on fastdebug/clang21. No default behavior change on the write path beyond the
accounting itself: with --export_drive_io_metrics off nothing is registered, and every instrumented
site reduces to one clock read and a null check.

Not yet exercised: a real multi-drive cluster with the metrics scraped, and a dashboard panel or
alert rule expressed in throughput terms.

Original commit: f7ece6587aff4134987e28df2f8813b103e8a2b8 / D56396

Reviewers: huapeng.yuan, esheng, #db-approvers

Reviewed By: huapeng.yuan, esheng, #db-approvers

Subscribers: svc_phabricator, ybase

Differential Revision: https://phorge.dev.yugabyte.com/D56396


## Backport notes

Clean cherry-pick, no conflicts. 1082 insertions, identical to the original commit.

Rebased onto the now-landed dependency and squashed to a single commit, replacing the earlier
hand-ported version of this PR. That version predated the backport of #31746 (unify filesystem
abstractions) and had to duplicate the per-drive accounting into both writable-file classes, since
this branch still had two. With #31746 landed there is one merged `yb::PosixWritableFile` again, so
the original commit applies as-is and none of that adaptation is needed. Reviewer comments on the
previous revision are resolved by its removal rather than by individual fixes.

### Verification

fastdebug/clang19, this branch's pinned toolchain: `util/drive_io_stats-test` 11/11 and
`fs/fs_manager-test` 13/13 pass. `build-support/lint.sh` reports 0 errors, 0 warnings.
