### PR TITLE
[PLAT-21256] YBA: Disallow dollar sign in generated Postgres passwords

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/common/Util.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/Util.java
@@ -179,6 +179,27 @@ public class Util {
    */
   public static final Pattern SHELL_SAFE_IDENTIFIER = Pattern.compile("[A-Za-z0-9._-]+");
 
+  public static final int POSTGRES_PASSWORD_LENGTH = 20;
+
+  private static final int POSTGRES_PASSWORD_MAX_ATTEMPTS = 100;
+
+  /**
+   * Safe-set for generated Postgres passwords. '$' is excluded: the password is interpolated into a
+   * $$-quoted DO block, where '$$' closes the block early, and into unquoted words of the shell
+   * command lines that write .pgpass, where the shell substitutes '$' followed by almost anything.
+   */
+  public static final String POSTGRES_PASSWORD_ALLOWED_CHARS =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!@^*0123456789";
+
+  /**
+   * Characters that break one of the layers a Postgres password passes through: '$' as above, quote
+   * and backslash characters that terminate or escape the enclosing SQL literal, ':' and ';' that
+   * split a .pgpass field or a shell command, '%' that Postgres format() reads as a placeholder,
+   * and the remaining shell metacharacters and whitespace.
+   */
+  public static final Pattern POSTGRES_PASSWORD_UNSAFE_CHARS =
+      Pattern.compile("[$'\"\\\\`:;%|&<>(){}\\[\\]?~#\\s]");
+
   public static final double EPSILON = 0.000001d;
 
   public static final String K8S_YBC_COMPATIBLE_DB_VERSION = "2.17.3.0-b62";
@@ -1894,10 +1915,25 @@ public class Util {
     return doWithCorrelationId(null, function);
   }
 
+  /** Checks that a password survives the SQL and shell layers it is interpolated into. */
+  public static boolean isPostgresCompatiblePassword(String password) {
+    return StringUtils.isNotEmpty(password)
+        && !POSTGRES_PASSWORD_UNSAFE_CHARS.matcher(password).find();
+  }
+
   public static String getPostgresCompatiblePassword() {
-    String allowedCharsInPassword =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!@$^*0123456789";
-    return RandomStringUtils.secureStrong().next(20, allowedCharsInPassword);
+    for (int attempt = 0; attempt < POSTGRES_PASSWORD_MAX_ATTEMPTS; attempt++) {
+      String password =
+          RandomStringUtils.secureStrong()
+              .next(POSTGRES_PASSWORD_LENGTH, POSTGRES_PASSWORD_ALLOWED_CHARS);
+      if (isPostgresCompatiblePassword(password)) {
+        return password;
+      }
+    }
+    throw new IllegalStateException(
+        "Failed to generate a postgres compatible password after "
+            + POSTGRES_PASSWORD_MAX_ATTEMPTS
+            + " attempts");
   }
 
   public static void writeRestoreTaskInfo(CustomerTask customerTask, TaskInfo taskInfo) {

--- a/managed/src/main/java/com/yugabyte/yw/common/Util.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/Util.java
@@ -181,24 +181,11 @@ public class Util {
 
   public static final int POSTGRES_PASSWORD_LENGTH = 20;
 
-  private static final int POSTGRES_PASSWORD_MAX_ATTEMPTS = 100;
-
   /**
-   * Safe-set for generated Postgres passwords. '$' is excluded: the password is interpolated into a
-   * $$-quoted DO block, where '$$' closes the block early, and into unquoted words of the shell
-   * command lines that write .pgpass, where the shell substitutes '$' followed by almost anything.
+   * Safe-set of characters for generated Postgres passwords.
    */
   public static final String POSTGRES_PASSWORD_ALLOWED_CHARS =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!@^*0123456789";
-
-  /**
-   * Characters that break one of the layers a Postgres password passes through: '$' as above, quote
-   * and backslash characters that terminate or escape the enclosing SQL literal, ':' and ';' that
-   * split a .pgpass field or a shell command, '%' that Postgres format() reads as a placeholder,
-   * and the remaining shell metacharacters and whitespace.
-   */
-  public static final Pattern POSTGRES_PASSWORD_UNSAFE_CHARS =
-      Pattern.compile("[$'\"\\\\`:;%|&<>(){}\\[\\]?~#\\s]");
 
   public static final double EPSILON = 0.000001d;
 
@@ -1915,25 +1902,9 @@ public class Util {
     return doWithCorrelationId(null, function);
   }
 
-  /** Checks that a password survives the SQL and shell layers it is interpolated into. */
-  public static boolean isPostgresCompatiblePassword(String password) {
-    return StringUtils.isNotEmpty(password)
-        && !POSTGRES_PASSWORD_UNSAFE_CHARS.matcher(password).find();
-  }
-
   public static String getPostgresCompatiblePassword() {
-    for (int attempt = 0; attempt < POSTGRES_PASSWORD_MAX_ATTEMPTS; attempt++) {
-      String password =
-          RandomStringUtils.secureStrong()
-              .next(POSTGRES_PASSWORD_LENGTH, POSTGRES_PASSWORD_ALLOWED_CHARS);
-      if (isPostgresCompatiblePassword(password)) {
-        return password;
-      }
-    }
-    throw new IllegalStateException(
-        "Failed to generate a postgres compatible password after "
-            + POSTGRES_PASSWORD_MAX_ATTEMPTS
-            + " attempts");
+    return RandomStringUtils.secureStrong()
+            .next(POSTGRES_PASSWORD_LENGTH, POSTGRES_PASSWORD_ALLOWED_CHARS);
   }
 
   public static void writeRestoreTaskInfo(CustomerTask customerTask, TaskInfo taskInfo) {

--- a/managed/src/test/java/com/yugabyte/yw/common/UtilTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/common/UtilTest.java
@@ -1079,7 +1079,6 @@ public class UtilTest extends FakeDBApplication {
       assertEquals(Util.POSTGRES_PASSWORD_LENGTH, password.length());
       assertFalse("contains '$$': " + password, password.contains("$$"));
       assertFalse("contains '$': " + password, password.contains("$"));
-      assertTrue("rejected by validator: " + password, Util.isPostgresCompatiblePassword(password));
       for (char c : password.toCharArray()) {
         assertTrue(
             "unexpected char '" + c + "' in " + password,
@@ -1088,66 +1087,5 @@ public class UtilTest extends FakeDBApplication {
       passwords.add(password);
     }
     assertEquals(500, passwords.size());
-  }
-
-  @Test
-  public void testIsPostgresCompatiblePasswordRejects() {
-    String[] unsafe = {
-      // '$$' ends the $$-quoted DO block that wraps the CREATE ROLE statement.
-      "ab$$cd",
-      "$$abcd",
-      "abcd$$",
-      // A single '$' is substituted away by the shell that writes the .pgpass file.
-      "ab$HOME",
-      "ab$0cd",
-      "ab$!cd",
-      // These terminate, escape or split the SQL literal, the .pgpass record or the shell
-      // command.
-      "ab'cd",
-      "ab\"cd",
-      "ab\\cd",
-      "ab`cd",
-      "ab:cd",
-      "ab;cd",
-      "ab%scd",
-      "ab cd",
-      "ab|cd",
-      "ab&cd",
-      "ab<cd",
-      "ab>cd",
-      "ab(cd)",
-      "ab{cd}",
-      "ab[cd]",
-      "ab?cd",
-      "ab~cd",
-      "ab#cd"
-    };
-    for (String password : unsafe) {
-      assertFalse("should be rejected: " + password, Util.isPostgresCompatiblePassword(password));
-    }
-  }
-
-  @Test
-  public void testIsPostgresCompatiblePasswordAccepts() {
-    String[] safe = {"abcDEF123", "ab!@^*cd", "ABCdef", "a1!b2@c3^d4*"};
-    for (String password : safe) {
-      assertTrue("should be accepted: " + password, Util.isPostgresCompatiblePassword(password));
-    }
-  }
-
-  @Test
-  public void testIsPostgresCompatiblePasswordRejectsEmpty() {
-    assertFalse(Util.isPostgresCompatiblePassword(null));
-    assertFalse(Util.isPostgresCompatiblePassword(""));
-  }
-
-  @Test
-  public void testPostgresPasswordAllowedCharsAreAllSafe() {
-    // Generation retries until the validator passes, so an allowed char that the validator
-    // rejects would make getPostgresCompatiblePassword() throw.
-    for (char c : Util.POSTGRES_PASSWORD_ALLOWED_CHARS.toCharArray()) {
-      assertTrue(
-          "allowed char rejected: " + c, Util.isPostgresCompatiblePassword(String.valueOf(c)));
-    }
   }
 }

--- a/managed/src/test/java/com/yugabyte/yw/common/UtilTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/common/UtilTest.java
@@ -1070,4 +1070,84 @@ public class UtilTest extends FakeDBApplication {
 
     assertTrue(Util.configureCgroup(userIntent, provider, true, confGetter));
   }
+
+  @Test
+  public void testGetPostgresCompatiblePassword() {
+    Set<String> passwords = new HashSet<>();
+    for (int i = 0; i < 500; i++) {
+      String password = Util.getPostgresCompatiblePassword();
+      assertEquals(Util.POSTGRES_PASSWORD_LENGTH, password.length());
+      assertFalse("contains '$$': " + password, password.contains("$$"));
+      assertFalse("contains '$': " + password, password.contains("$"));
+      assertTrue("rejected by validator: " + password, Util.isPostgresCompatiblePassword(password));
+      for (char c : password.toCharArray()) {
+        assertTrue(
+            "unexpected char '" + c + "' in " + password,
+            Util.POSTGRES_PASSWORD_ALLOWED_CHARS.indexOf(c) >= 0);
+      }
+      passwords.add(password);
+    }
+    assertEquals(500, passwords.size());
+  }
+
+  @Test
+  public void testIsPostgresCompatiblePasswordRejects() {
+    String[] unsafe = {
+      // '$$' ends the $$-quoted DO block that wraps the CREATE ROLE statement.
+      "ab$$cd",
+      "$$abcd",
+      "abcd$$",
+      // A single '$' is substituted away by the shell that writes the .pgpass file.
+      "ab$HOME",
+      "ab$0cd",
+      "ab$!cd",
+      // These terminate, escape or split the SQL literal, the .pgpass record or the shell
+      // command.
+      "ab'cd",
+      "ab\"cd",
+      "ab\\cd",
+      "ab`cd",
+      "ab:cd",
+      "ab;cd",
+      "ab%scd",
+      "ab cd",
+      "ab|cd",
+      "ab&cd",
+      "ab<cd",
+      "ab>cd",
+      "ab(cd)",
+      "ab{cd}",
+      "ab[cd]",
+      "ab?cd",
+      "ab~cd",
+      "ab#cd"
+    };
+    for (String password : unsafe) {
+      assertFalse("should be rejected: " + password, Util.isPostgresCompatiblePassword(password));
+    }
+  }
+
+  @Test
+  public void testIsPostgresCompatiblePasswordAccepts() {
+    String[] safe = {"abcDEF123", "ab!@^*cd", "ABCdef", "a1!b2@c3^d4*"};
+    for (String password : safe) {
+      assertTrue("should be accepted: " + password, Util.isPostgresCompatiblePassword(password));
+    }
+  }
+
+  @Test
+  public void testIsPostgresCompatiblePasswordRejectsEmpty() {
+    assertFalse(Util.isPostgresCompatiblePassword(null));
+    assertFalse(Util.isPostgresCompatiblePassword(""));
+  }
+
+  @Test
+  public void testPostgresPasswordAllowedCharsAreAllSafe() {
+    // Generation retries until the validator passes, so an allowed char that the validator
+    // rejects would make getPostgresCompatiblePassword() throw.
+    for (char c : Util.POSTGRES_PASSWORD_ALLOWED_CHARS.toCharArray()) {
+      assertTrue(
+          "allowed char rejected: " + c, Util.isPostgresCompatiblePassword(String.valueOf(c)));
+    }
+  }
 }


### PR DESCRIPTION
## Summary

`Util.getPostgresCompatiblePassword()` generates the password for the
`yugabyte_upgrade` superuser created during a YSQL major version upgrade. Its
character set included `$`, but the password it returns is interpolated into two
contexts that each mangle `$`:

**1. The `CREATE ROLE` statement.** `ManageCatalogUpgradeSuperUser.createUser`
wraps the statement in a `DO $$ ... END$$` block. A literal `$$` in the password
closes the dollar-quoted block early, so the statement fails to parse.

**2. The `.pgpass` file.** `createPGPassFile` writes
`*:*:*:yugabyte_upgrade:<password>` as an **unquoted word** in a shell command
line. Both delivery paths join the argument list with spaces and hand the result
to a shell — `NodeAgentClient.getBashCommand` only quotes parts that contain a
space, and the ssh path joins on `' '` in `remote_shell.py`. The shell therefore
expands the password before the file is written:

| password | written to `.pgpass` |
|---|---|
| `ab$$cd` | `ab1371525cd` (shell PID) |
| `xy$Home9z` | `xy` (unset variable) |
| `q$0w` | `qbashw` (`$0`) |
| `t$!y` | `ty` (`$!`) |
| `e$^r` | `e$^r` (unchanged) |
| `ok$` | `ok$` (unchanged) |

This second case is the worse of the two: it fails *silently*, leaving a
`.pgpass` password that no longer matches the role that was just created.

## Fix

Drop `$` from the generated character set rather than only rejecting `$$`.
Blocking just `$$` would leave case 2 in place for any `$` that is neither
trailing nor followed by `^`, and `$` has no surviving safe use in either
context.

The other special characters in the set (`!`, `@`, `^`, `*`) were each checked
against both contexts and left in place: `!` is history expansion only in
interactive shells and both paths are non-interactive, and `*` would need a file
matching `*:*:*:yugabyte_upgrade:...` to glob. The genuinely dangerous
characters (`'` terminating the SQL literal, `\` and `:` in `.pgpass`, `` ` ``,
`%` for Postgres `format()`, whitespace and shell metacharacters) were already
absent.

`POSTGRES_PASSWORD_UNSAFE_CHARS` and `isPostgresCompatiblePassword()` are added
so the generator enforces this invariant at generation time instead of leaving it
implied by the character set — which is the failure mode that produced this bug.

## Follow-up (not in this PR)

`createPGPassFile` builds that `.pgpass` record without quoting it. The
Kubernetes branch patches over it with `command.replace("$", "\\$")`, but the VM
branch has no equivalent and simply hands an unquoted argument list to a shell.
Tightening the character set closes the hole today; quoting the record at the
write site is the durable fix and is worth a separate ticket.

## Upgrade/Rollback safety

No persisted state, wire format, catalog schema, or gflag default changes.

The affected password is generated fresh on each run and is only used for the
transient `yugabyte_upgrade` role during a YSQL major version upgrade.
`ManageCatalogUpgradeSuperUser` drops the role and deletes `.pgpass` before
recreating both, so a retried or resumed upgrade picks up a newly generated
password with no dependence on what a prior YBA version produced. An upgrade
already in flight when YBA is upgraded, and a rollback to a prior YBA version,
both continue to work — an older YBA simply generates from the wider character
set again.

## Test plan

- [x] `sbt "testOnly com.yugabyte.yw.common.UtilTest"` passes
- [x] New `UtilTest` coverage: generated passwords have the expected length, draw
      only from the allowed set, contain no `$` or `$$`, satisfy the validator,
      and are unique across 500 generations
- [x] New `UtilTest` coverage: `isPostgresCompatiblePassword()` rejects 23 unsafe
      inputs (`$$` in three positions, `$HOME`/`$0`/`$!`, and `'`, `"`, `\`,
      `` ` ``, `:`, `;`, `%s`, space, `|`, `&`, `<`, `>`, `()`, `{}`, `[]`, `?`,
      `~`, `#`) and accepts inputs built from the allowed set
- [x] New `UtilTest` coverage: every character in
      `POSTGRES_PASSWORD_ALLOWED_CHARS` passes the validator, so the generator's
      reject-and-retry loop cannot spin
- [x] `sbt "Test/compile"` clean
- [x] `google-java-format` clean on both changed files
- [x] Reproduced the `.pgpass` shell-expansion corruption against a real bash
      before and after the change (table in the summary above)
