### PR TITLE
[#33607] DocDB: Derive colocated tombstone-cache watermark from data, not SafeTime

### DIFF
--- a/src/yb/docdb/doc_read_context.cc
+++ b/src/yb/docdb/doc_read_context.cc
@@ -138,19 +138,38 @@ uint64_t DocReadContext::tombstone_cache_generation() const {
   return tombstone_cache_generation_;
 }
 
-void DocReadContext::AdvanceTombstoneCacheWatermark(HybridTime ht) const {
-  DCHECK(ht.is_valid());
-  DCHECK_NE(ht, HybridTime::kMax);
-  // kMin would make every read eligible; require a real HT so unarmed fails closed by construction.
-  DCHECK_GE(ht, HybridTime::kInitial);
+bool DocReadContext::IsTombstoneCacheArmed() const {
   std::lock_guard lock(tombstone_cache_mutex_);
-  // kMax is the unarmed sentinel, not a comparable upper bound: replace it on first advance.
-  // Only bump generation when the watermark actually moves, so arming/re-arming with an
-  // equal-or-older SafeTime does not spuriously drop a warm cache.
-  if (tombstone_cache_watermark_ == HybridTime::kMax || ht > tombstone_cache_watermark_) {
-    ++tombstone_cache_generation_;
-    tombstone_cache_watermark_ = ht;
+  return tombstone_cache_watermark_ != HybridTime::kMax;
+}
+
+bool DocReadContext::ArmTombstoneCacheFromProbe(
+    HybridTime watermark, DocHybridTime probed_tombstone, uint64_t gen_before) const {
+  DCHECK(schema_.has_colocation_id());
+  DCHECK(watermark.is_valid());
+  DCHECK_NE(watermark, HybridTime::kMax);
+  // kMin would make every read eligible; require a real HT so unarmed fails closed by construction.
+  DCHECK_GE(watermark, HybridTime::kInitial);
+  std::lock_guard lock(tombstone_cache_mutex_);
+  if (gen_before != tombstone_cache_generation_) {
+    return false;
   }
+  // kMax is the unarmed sentinel, not a comparable upper bound: replace it on first arm. Later
+  // arms only raise, so a probe that raced a notify cannot walk the watermark back below an
+  // already-applied tombstone.
+  if (tombstone_cache_watermark_ == HybridTime::kMax || watermark > tombstone_cache_watermark_) {
+    tombstone_cache_watermark_ = watermark;
+  }
+  tombstone_cache_entry_generation_ = tombstone_cache_generation_;
+  table_tombstone_time_ = probed_tombstone;
+  return true;
+}
+
+void DocReadContext::ResetTombstoneCache() const {
+  std::lock_guard lock(tombstone_cache_mutex_);
+  ++tombstone_cache_generation_;
+  tombstone_cache_watermark_ = HybridTime::kMax;
+  table_tombstone_time_ = DocHybridTime::kMax;
 }
 
 void DocReadContext::OnTableTombstoneWritten(HybridTime write_ht) const {

--- a/src/yb/docdb/doc_read_context.h
+++ b/src/yb/docdb/doc_read_context.h
@@ -110,17 +110,37 @@ struct DocReadContext {
 
   // HybridTime below which the tombstone cache must not be consumed or populated.
   // Default kMax = unarmed (cache fully disabled / fail-closed).
-  // See AdvanceTombstoneCacheWatermark.
   HybridTime tombstone_cache_watermark() const;
 
-  // Global cache epoch; bumped when Advance actually raises the watermark.
+  // Global cache epoch; bumped whenever an existing entry must stop being trusted.
   uint64_t tombstone_cache_generation() const;
 
-  // Monotone watermark advance. kMax is an "unarmed" sentinel (not a numeric max): the first
-  // advance replaces it with ht; later advances take max(current, ht). Used to arm at SafeTime
-  // and to bump on table-tombstone apply. Bumps tombstone_cache_generation_ so any previously
-  // stored cache entry is treated as a miss. Does not clear the cache slot by itself.
-  void AdvanceTombstoneCacheWatermark(HybridTime ht) const;
+  // False until a read has probed the tablet's data and armed the cache. The read path must not
+  // consume or populate before that: an unarmed context knows nothing about tombstones that
+  // predate it.
+  bool IsTombstoneCacheArmed() const;
+
+  // Arm the cache from a cold-path probe of the tablet's data, and store what the probe found,
+  // both under one lock.
+  //
+  // The watermark has to be an upper bound on every table tombstone already in the tablet's data,
+  // otherwise a read above such a tombstone can cache "no tombstone" and resurrect rows. Deriving
+  // it from the data is what makes that hold unconditionally. A clock reading does not: SafeTime
+  // bounds only tombstones written by this tablet's own raft ops, not ones applied at a producer's
+  // hybrid time on an xCluster target, nor ones that arrived inside a restored snapshot (#33607).
+  //
+  // gen_before must be the generation read before the probe started. A mismatch means a tombstone
+  // applied while the probe was in flight, so its result may already be stale: nothing is stored
+  // and the next read probes again. Deliberately does not bump the generation - it invalidates
+  // nothing, and the entry stored here must stay valid under the generation the caller checked.
+  bool ArmTombstoneCacheFromProbe(
+      HybridTime watermark, DocHybridTime probed_tombstone, uint64_t gen_before) const;
+
+  // Return to the unarmed state (watermark kMax, slot empty, generation bumped so an in-flight
+  // populate cannot land afterwards). For callers that replace the tablet's data underneath a live
+  // context, where the cached answer describes data that no longer exists and no watermark
+  // arithmetic can repair it - see TabletSnapshots::RestoreCheckpoint.
+  void ResetTombstoneCache() const;
 
   // Called when a table tombstone is applied to this replica. Always bumps the generation and
   // clears the cache slot; raises the watermark when write_ht is higher. Safe to call more than
@@ -253,12 +273,14 @@ struct DocReadContext {
   // window (watermark alone cannot reject a "no tombstone" stamp).
   mutable uint64_t tombstone_cache_entry_generation_ = 0;
 
-  // Global epoch bumped when Advance actually raises the watermark, and on every
-  // OnTableTombstoneWritten (including same-ht re-notify).
+  // Global epoch bumped on every OnTableTombstoneWritten (including a same-ht re-notify) and on
+  // ResetTombstoneCache.
   mutable uint64_t tombstone_cache_generation_ = 0;
 
   // Default kMax = unarmed: both gates reject, so an unarmed context is cache-off (correct
-  // cold-path behavior). Forgotten construction sites therefore fail closed (perf only).
+  // cold-path behavior). Every context is born here and stays here until a read probes the data
+  // and arms it, so a path that builds contexts without knowing about this cache costs the
+  // optimization and never correctness.
   mutable HybridTime tombstone_cache_watermark_ = HybridTime::kMax;
 };
 

--- a/src/yb/docdb/doc_rowwise_iterator.cc
+++ b/src/yb/docdb/doc_rowwise_iterator.cc
@@ -528,13 +528,9 @@ Result<DocHybridTime> DocRowwiseIterator::GetTableTombstoneTime(Slice root_doc_k
 // Arm the tombstone cache of a context that has never been armed, from the tablet's own data.
 //
 // Probing at an unbounded read time finds the newest table tombstone whatever hybrid time it
-// carries, which is exactly what the watermark has to bound. The alternative - arming at the
-// tablet's SafeTime - only bounds tombstones written by this tablet's raft ops, and silently
-// resurrects rows for the two ways a tombstone gets in carrying a foreign clock: applied at the
-// producer's hybrid time on an xCluster target, or restored inside a snapshot (#33607).
-//
-// The probe subsumes this read's own lookup unless the read predates the tombstone it found, so
-// the common path costs the same single seek as before.
+// carries, which is exactly what the watermark has to bound - see ArmTombstoneCacheFromProbe for
+// why no clock reading can do that. The probe subsumes this read's own lookup unless the read
+// predates the tombstone it found, so the common path costs the same single seek as before.
 Result<DocHybridTime> DocRowwiseIterator::ProbeAndArmTableTombstoneCache(
     Slice root_doc_key, HybridTime read_ht) const {
   const auto gen_before = doc_read_context_.tombstone_cache_generation();
@@ -548,11 +544,9 @@ Result<DocHybridTime> DocRowwiseIterator::ProbeAndArmTableTombstoneCache(
 
   if (!latest.is_valid()) {
     // No tombstone anywhere in this table's data, so "absent" answers every read time and any
-    // watermark would be sound. Arm at read_ht rather than at the lowest hybrid time to keep the
-    // field's meaning uniform - a time at which this replica verified it knows the whole tombstone
-    // story - which is what every other reader of the watermark assumes. The cost is that reads
-    // pinned below read_ht stay ineligible and pay a lookup. A read with no usable read time just
-    // leaves the context unarmed for the next one.
+    // watermark would be sound. Arm at read_ht anyway, so the field keeps one meaning everywhere -
+    // a time at which this replica verified it knows the whole tombstone story. The cost is that
+    // reads pinned below read_ht stay ineligible and pay a lookup.
     if (usable_watermark(read_ht)) {
       doc_read_context_.ArmTombstoneCacheFromProbe(read_ht, DocHybridTime::kInvalid, gen_before);
     }

--- a/src/yb/docdb/doc_rowwise_iterator.cc
+++ b/src/yb/docdb/doc_rowwise_iterator.cc
@@ -499,13 +499,18 @@ Result<DocHybridTime> DocRowwiseIterator::GetTableTombstoneTime(Slice root_doc_k
   }
 
   const auto read_ht = read_operation_data_.read_time.read;
-  const auto watermark_before = doc_read_context_.tombstone_cache_watermark();
-  const auto gen_before = doc_read_context_.tombstone_cache_generation();
   if (auto cached_tombstone_time =
           doc_read_context_.GetCachedTableTombstoneTime(read_ht)) {
     return *cached_tombstone_time;
   }
 
+  if (!doc_read_context_.IsTombstoneCacheArmed()) {
+    return ProbeAndArmTableTombstoneCache(root_doc_key, read_ht);
+  }
+
+  // Armed with an empty slot: a tombstone apply cleared it. Refill from a normal bounded lookup.
+  const auto watermark_before = doc_read_context_.tombstone_cache_watermark();
+  const auto gen_before = doc_read_context_.tombstone_cache_generation();
   auto doc_ht = VERIFY_RESULT(docdb::GetTableTombstoneTime(
       root_doc_key, doc_db_, txn_op_context_, read_operation_data_));
   // Cache doc_ht only if this read is still eligible and watermark/generation did not change
@@ -518,6 +523,52 @@ Result<DocHybridTime> DocRowwiseIterator::GetTableTombstoneTime(Slice root_doc_k
     doc_read_context_.set_table_tombstone_time(doc_ht, gen_before);
   }
   return doc_ht;
+}
+
+// Arm the tombstone cache of a context that has never been armed, from the tablet's own data.
+//
+// Probing at an unbounded read time finds the newest table tombstone whatever hybrid time it
+// carries, which is exactly what the watermark has to bound. The alternative - arming at the
+// tablet's SafeTime - only bounds tombstones written by this tablet's raft ops, and silently
+// resurrects rows for the two ways a tombstone gets in carrying a foreign clock: applied at the
+// producer's hybrid time on an xCluster target, or restored inside a snapshot (#33607).
+//
+// The probe subsumes this read's own lookup unless the read predates the tombstone it found, so
+// the common path costs the same single seek as before.
+Result<DocHybridTime> DocRowwiseIterator::ProbeAndArmTableTombstoneCache(
+    Slice root_doc_key, HybridTime read_ht) const {
+  const auto gen_before = doc_read_context_.tombstone_cache_generation();
+  const auto latest = VERIFY_RESULT(docdb::GetTableTombstoneTime(
+      root_doc_key, doc_db_, txn_op_context_,
+      read_operation_data_.WithAlteredReadTime(ReadHybridTime::Max())));
+
+  const auto usable_watermark = [](HybridTime ht) {
+    return ht.is_valid() && ht != HybridTime::kMax && ht >= HybridTime::kInitial;
+  };
+
+  if (!latest.is_valid()) {
+    // No tombstone anywhere in this table's data, so "absent" answers every read time and any
+    // watermark would be sound. Arm at read_ht rather than at the lowest hybrid time to keep the
+    // field's meaning uniform - a time at which this replica verified it knows the whole tombstone
+    // story - which is what every other reader of the watermark assumes. The cost is that reads
+    // pinned below read_ht stay ineligible and pay a lookup. A read with no usable read time just
+    // leaves the context unarmed for the next one.
+    if (usable_watermark(read_ht)) {
+      doc_read_context_.ArmTombstoneCacheFromProbe(read_ht, DocHybridTime::kInvalid, gen_before);
+    }
+    return DocHybridTime::kInvalid;
+  }
+
+  if (usable_watermark(latest.hybrid_time())) {
+    doc_read_context_.ArmTombstoneCacheFromProbe(latest.hybrid_time(), latest, gen_before);
+  }
+  if (read_ht.is_valid() && read_ht >= latest.hybrid_time()) {
+    return latest;
+  }
+  // This read predates the newest tombstone, so it needs the newest one at or below its own read
+  // time, and it sits below the watermark so it neither consumes nor populates.
+  return docdb::GetTableTombstoneTime(
+      root_doc_key, doc_db_, txn_op_context_, read_operation_data_);
 }
 
 Status DocRowwiseIterator::InitIterator(

--- a/src/yb/docdb/doc_rowwise_iterator.h
+++ b/src/yb/docdb/doc_rowwise_iterator.h
@@ -161,6 +161,9 @@ class DocRowwiseIterator final : public YQLRowwiseIteratorIf {
 
   Result<DocHybridTime> GetTableTombstoneTime(Slice root_doc_key) const;
 
+  Result<DocHybridTime> ProbeAndArmTableTombstoneCache(
+      Slice root_doc_key, HybridTime read_ht) const;
+
   // Increments statistics for total keys found, obsolete keys (past cutoff or no) if applicable.
   //
   // Obsolete keys include keys that are tombstoned, TTL expired, and read-time filtered.

--- a/src/yb/docdb/rocksdb_writer.cc
+++ b/src/yb/docdb/rocksdb_writer.cc
@@ -104,7 +104,7 @@ bool IsTombstoneValue(Slice value) {
 // tombstone-time cache is invalidated (watermark/generation advanced, cache cleared).
 void MaybeNotifyTableTombstoneWritten(
     SchemaPackingProvider& provider, Slice key, Slice value, HybridTime write_ht) {
-  // Guard kMax as well as invalid: AdvanceTombstoneCacheWatermark DCHECKs against kMax, and a
+  // Guard kMax as well as invalid: OnTableTombstoneWritten DCHECKs against kMax, and a
   // malformed HT must not crash debug builds from the apply path.
   if (!write_ht.is_valid() || write_ht == HybridTime::kMax || write_ht < HybridTime::kInitial ||
       !IsTableTombstoneKey(key) || !IsTombstoneValue(value)) {
@@ -932,9 +932,9 @@ Result<bool> ApplyIntentsContext::Entry(
     // Local transactional apply (YSQL legacy colocated TRUNCATE / DROP table tombstones): every
     // replica applies intents here, and followers never run ApplyTruncateColocated. Keep this
     // outside ApplyToRegularDB(): bootstrap can skip the regular-DB Put when that storage already
-    // has the write, while ADD_TABLE / change-metadata may re-arm the context at an older HT; this
-    // notify is then what raises the watermark back above the tombstone. Notifying before the
-    // RocksDB write is intentional (see OnTableTombstoneWritten).
+    // has the write, and this notify is then the only thing that tells a context warmed earlier in
+    // the same bootstrap about the tombstone. Notifying before the RocksDB write is intentional
+    // (see OnTableTombstoneWritten).
     MaybeNotifyTableTombstoneWritten(
         schema_packing_provider(), intent.doc_path, decoded_value.body, commit_ht_);
 

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -1690,9 +1690,6 @@ void Tablet::Start() {
     transaction_participant_->Start();
   }
 
-  // A read racing ahead of this still skips the cache and does not fill it.
-  ArmColocatedTombstoneCaches();
-
   // Launch vector index backfill only now, after the tablet has been published by its TabletPeer.
   // The backfill resolves transaction statuses of provisional records, which reads the tablet's
   // safe time; running it during bootstrap (before TabletPeer::tablet_ is assigned) would race with
@@ -3133,33 +3130,6 @@ Status Tablet::AddTableInMemory(const TableInfoPB& table_info, const OpId& op_id
     schedule_tablet_metadata_validation_(*metadata_);
   }
 
-  // New colocated DocReadContext is constructed unarmed (watermark kMax). Arm with the create HT.
-  //
-  // Arming here is safe against the colocation-id reuse case (DROP then CREATE with the same id),
-  // where the DROP's tombstone lands at its commit hybrid time via an APPLYING op that raft may
-  // order either side of this ADD_TABLE. Note that gives no ordering between the create HT and the
-  // tombstone HT, so the two cases are covered differently:
-  //   - tombstone applies after this: its notify resolves GetTableInfo(colocation_id) through the
-  //     colocation_to_table entry this op just repointed, so it raises *this* context's watermark.
-  //   - tombstone applied before this: its commit hybrid time was already known when this op's ht
-  //     was assigned, so hybrid-clock propagation puts ht above it.
-  // PgMiniTest.TestNoStaleDataOnColocationIdReuse covers the applies-after leg.
-  //
-  // A replayed ADD_TABLE re-arms an already-armed context and bumps the generation, dropping a warm
-  // cache. Perf only.
-  if (table_info_ptr->doc_read_context && table_info_ptr->schema().has_colocation_id()) {
-    HybridTime arm_ht = ht;
-    if (!arm_ht.is_valid() || arm_ht == HybridTime::kMax) {
-      auto safe_time = SafeTime(RequireLease::kFalse);
-      if (safe_time.ok()) {
-        arm_ht = *safe_time;
-      }
-    }
-    if (arm_ht.is_valid() && arm_ht != HybridTime::kMax) {
-      table_info_ptr->doc_read_context->AdvanceTombstoneCacheWatermark(arm_ht);
-    }
-  }
-
   return Status::OK();
 }
 
@@ -3301,16 +3271,7 @@ Status Tablet::AlterSchema(ChangeMetadataOperation* operation) {
   // Flush the updated schema metadata to disk.
   RETURN_NOT_OK(metadata_->Flush());
 
-  // SetSchema built new DocReadContexts, which start unarmed.
-  ArmColocatedTombstoneCaches();
   return Status::OK();
-}
-
-void Tablet::ArmColocatedTombstoneCaches() {
-  auto safe_time = SafeTime(RequireLease::kFalse);
-  if (safe_time.ok() && safe_time->is_valid()) {
-    metadata_->ArmColocatedTombstoneCaches(*safe_time);
-  }
 }
 
 Status Tablet::InsertPackedSchemaForXClusterTarget(
@@ -3324,10 +3285,6 @@ Status Tablet::InsertPackedSchemaForXClusterTarget(
   // Flush the updated schema metadata to disk.
   RETURN_NOT_OK(metadata_->Flush());
 
-  // This is an AlterSchema early return, so it misses the arm at the end of AlterSchema. The two
-  // TableInfos built above (version-1 and version) carry fresh unarmed DocReadContexts and
-  // colocation_to_table now points at them, so without this the cache stays off until restart.
-  ArmColocatedTombstoneCaches();
   return Status::OK();
 }
 

--- a/src/yb/tablet/tablet.h
+++ b/src/yb/tablet/tablet.h
@@ -1130,13 +1130,6 @@ class Tablet : public AbstractTablet,
 
   void DocDBDebugDump(std::vector<std::string>* lines);
 
-  // Enable the colocated table-tombstone caches of this tablet's DocReadContexts, which are
-  // constructed unarmed (watermark kMax, cache off). Call after any path that builds new contexts.
-  // Skipping it only costs the optimization for those fresh contexts - never correctness. That
-  // does not describe RestoreCheckpoint, which can leave an already-armed warm cache over swapped
-  // RocksDB data (separate follow-up: unarm/re-arm at end of restore).
-  void ArmColocatedTombstoneCaches();
-
   Status WriteTransactionalBatch(
       int64_t batch_idx,  // index of this batch in its transaction
       const docdb::LWKeyValueWriteBatchPB& put_batch, HybridTime hybrid_time,

--- a/src/yb/tablet/tablet_metadata.cc
+++ b/src/yb/tablet/tablet_metadata.cc
@@ -2287,24 +2287,15 @@ void RaftGroupMetadata::NotifyTableTombstoneWritten(const Uuid& cotable_id, Hybr
   }
 }
 
-// Turn on colocated tombstone-time caches at serve-ready SafeTime (watermark was kMax / off).
-// Walks every colocated TableInfo on this tablet, so an ALTER of one table also re-arms (and
-// bumps generation on) the others - a known cost in multi-table colocated databases.
-//
-// Fresh contexts start unarmed; skipping this only disables the cache (fail-closed). That claim
-// does not cover RestoreCheckpoint, which can swap the regular DB under an already-armed context
-// that still holds a warm value: there the gap is a content change with no invalidation (tracked
-// follow-up), not a missing arm.
-void RaftGroupMetadata::ArmColocatedTombstoneCaches(HybridTime safe_time) {
-  // kMin.is_valid() is true and would make every read eligible; require a real HT so unarmed
-  // stays fail-closed by construction (last_replicated_ defaults to kMin on an empty tablet).
-  if (!safe_time.is_valid() || safe_time == HybridTime::kMax ||
-      safe_time < HybridTime::kInitial) {
-    return;
-  }
+// Drop every colocated tombstone-time cache back to unarmed, so the next read re-derives it from
+// whatever data the tablet now holds. For callers that swap the tablet's storage underneath live
+// DocReadContexts: a cached answer then describes data that no longer exists, in both directions
+// (a cached tombstone over a pre-truncate snapshot reads the table as empty, a cached absence over
+// a post-truncate one resurrects the rows), and no watermark arithmetic can repair it.
+void RaftGroupMetadata::ResetColocatedTombstoneCaches() {
   for (const auto& table_info : GetColocatedTableInfos()) {
     if (table_info->doc_read_context && table_info->schema().has_colocation_id()) {
-      table_info->doc_read_context->AdvanceTombstoneCacheWatermark(safe_time);
+      table_info->doc_read_context->ResetTombstoneCache();
     }
   }
 }

--- a/src/yb/tablet/tablet_metadata.h
+++ b/src/yb/tablet/tablet_metadata.h
@@ -772,10 +772,9 @@ class RaftGroupMetadata : public RefCountedThreadSafe<RaftGroupMetadata>,
   void NotifyTableTombstoneWritten(ColocationId colocation_id, HybridTime write_ht) override;
   void NotifyTableTombstoneWritten(const Uuid& cotable_id, HybridTime write_ht) override;
 
-  // Arm colocated tombstone-time caches with the tablet SafeTime (serve-ready / live rebuild).
-  // Unarmed contexts default to watermark kMax (cache off). Arming enables the cache for
-  // read_ht >= safe_time; any truncate applied before serving satisfies T <= safe_time.
-  void ArmColocatedTombstoneCaches(HybridTime safe_time);
+  // Return every colocated tombstone-time cache to unarmed, for callers that replace the tablet's
+  // storage underneath live DocReadContexts.
+  void ResetColocatedTombstoneCaches();
 
   std::unordered_set<StatefulServiceKind> GetHostedServiceList() const;
 

--- a/src/yb/tablet/tablet_snapshots.cc
+++ b/src/yb/tablet/tablet_snapshots.cc
@@ -707,6 +707,14 @@ Status TabletSnapshots::RestoreCheckpoint(
 
   std::lock_guard lock(create_checkpoint_lock());
 
+  // The regular DB is about to be replaced under DocReadContexts that outlive the swap, so any
+  // colocated tombstone-time cache they hold now describes data that is going away. Reads are
+  // paused for the rest of this function, and the contexts SetSchema rebuilds below are born
+  // unarmed, so the first read after the restore re-derives every watermark from the restored
+  // data. Note the restore only rebuilds contexts for tables named in the restore metadata; the
+  // rest of the tablet's colocated tables are reachable only through this walk.
+  tablet().metadata()->ResetColocatedTombstoneCaches();
+
   const string db_dir = regular_db().GetName();
   const std::string intents_db_dir = has_intents_db() ? intents_db().GetName() : std::string();
 

--- a/src/yb/yql/pgwrapper/pg_mini-test.cc
+++ b/src/yb/yql/pgwrapper/pg_mini-test.cc
@@ -24,6 +24,7 @@
 
 #include "yb/client/client.h"
 #include "yb/client/schema.h"
+#include "yb/client/snapshot_test_util.h"
 #include "yb/client/table_creator.h"
 #include "yb/client/table_info.h"
 #include "yb/client/yb_table_name.h"
@@ -1984,8 +1985,8 @@ TEST_F_EX(PgMiniTest, TruncateColocatedInvalidatesTombstoneCache, PgMiniTestSing
     auto cached = ctx->table_tombstone_time();
     ASSERT_TRUE(cached.has_value());
     ASSERT_FALSE(cached->is_valid());
-    // Serve-ready / AddTable should have armed the watermark (not left at kMax).
-    ASSERT_NE(ctx->tombstone_cache_watermark(), HybridTime::kMax);
+    // The read above probed the data and armed the watermark (not left at kMax).
+    ASSERT_TRUE(ctx->IsTombstoneCacheArmed());
   }
 
   ASSERT_OK(conn.Execute("SET yb_enable_alter_table_rewrite = false"));
@@ -2107,15 +2108,22 @@ TEST_F_EX(PgMiniTest, TruncateColocatedAfterAlterSchema, PgMiniTestSingleNode) {
   ASSERT_EQ(
       ASSERT_RESULT(conn.FetchRow<int64_t>(Format("SELECT count(*) FROM $0", kTableName))), 0);
 
-  // Rebuild DocReadContext (copy resets watermark to kMax) then AlterSchema re-arms at SafeTime.
+  // ALTER rebuilds the DocReadContext, and nothing arms it: the watermark now comes from the
+  // first read's probe of the data, not from a clock reading taken at schema-change time.
   ASSERT_OK(conn.ExecuteFormat("ALTER TABLE $0 ADD COLUMN extra int", kTableName));
 
   auto table_id = ASSERT_RESULT(GetTableIDFromTableName(kTableName));
   auto peers = ListTableActiveTabletLeadersPeers(cluster_.get(), table_id);
   ASSERT_FALSE(peers.empty());
-  auto table_info = ASSERT_RESULT(peers.front()->tablet_metadata()->GetTableInfo(kColocationId));
-  ASSERT_NE(table_info->doc_read_context->tombstone_cache_watermark(), HybridTime::kMax);
+  auto doc_read_context = [&]() {
+    auto table_info = CHECK_RESULT(peers.front()->tablet_metadata()->GetTableInfo(kColocationId));
+    return table_info->doc_read_context;
+  };
+  ASSERT_FALSE(doc_read_context()->IsTombstoneCacheArmed());
 
+  // The pinned read predates the truncate, so it must still see the rows. It is also the read that
+  // arms the context, and the probe it runs is unbounded, so it establishes a watermark above its
+  // own read time rather than caching the "no tombstone" that is correct only at that time.
   ASSERT_OK(conn.ExecuteFormat("SET yb_read_time TO $0", pinned_us));
   ASSERT_EQ(
       ASSERT_RESULT(conn.FetchRow<int64_t>(Format("SELECT count(*) FROM $0", kTableName))), 3);
@@ -2123,6 +2131,13 @@ TEST_F_EX(PgMiniTest, TruncateColocatedAfterAlterSchema, PgMiniTestSingleNode) {
   ASSERT_OK(conn.Execute("SET yb_read_time TO 0"));
   ASSERT_EQ(
       ASSERT_RESULT(conn.FetchRow<int64_t>(Format("SELECT count(*) FROM $0", kTableName))), 0);
+
+  auto ctx = doc_read_context();
+  ASSERT_TRUE(ctx->IsTombstoneCacheArmed());
+  auto cached = ctx->table_tombstone_time();
+  ASSERT_TRUE(cached.has_value());
+  ASSERT_TRUE(cached->is_valid());
+  ASSERT_GE(ctx->tombstone_cache_watermark(), cached->hybrid_time());
 }
 
 // #32724 (d): an unarmed DocReadContext (watermark kMax) fails closed: cache ineligible.
@@ -2133,6 +2148,7 @@ TEST(DocReadContextTombstoneCacheTest, UnarmedWatermarkFailsClosed) {
   schema.set_colocation_id(42);
   auto ctx = docdb::DocReadContext::TEST_Create(schema);
   ASSERT_EQ(ctx.tombstone_cache_watermark(), HybridTime::kMax);
+  ASSERT_FALSE(ctx.IsTombstoneCacheArmed());
   ASSERT_FALSE(ctx.table_tombstone_time().has_value());
 
   // kMax is an "unarmed" sentinel, not a numeric bound, so no read_ht may be eligible, including
@@ -2151,9 +2167,17 @@ TEST(DocReadContextTombstoneCacheTest, UnarmedWatermarkFailsClosed) {
 
   // Arming makes it eligible again, which pins the assertions above to the watermark and not to
   // some unrelated reason for rejecting every read.
-  ctx.AdvanceTombstoneCacheWatermark(HybridTime::FromMicros(100));
+  ASSERT_TRUE(ctx.ArmTombstoneCacheFromProbe(
+      HybridTime::FromMicros(100), DocHybridTime::kInvalid, ctx.tombstone_cache_generation()));
+  ASSERT_TRUE(ctx.IsTombstoneCacheArmed());
   ASSERT_TRUE(ctx.IsTombstoneCacheEligible(HybridTime::FromMicros(100)));
   ASSERT_FALSE(ctx.IsTombstoneCacheEligible(HybridTime::FromMicros(99)));
+
+  // ResetTombstoneCache puts it back, which is what a data swap under a live context relies on.
+  ctx.ResetTombstoneCache();
+  ASSERT_FALSE(ctx.IsTombstoneCacheArmed());
+  ASSERT_FALSE(ctx.table_tombstone_time().has_value());
+  ASSERT_FALSE(ctx.IsTombstoneCacheEligible(HybridTime::FromMicros(100)));
 }
 
 // #32724 (e): set must stamp the caller's pre-fetch generation, not the post-truncate epoch.
@@ -2164,7 +2188,8 @@ TEST(DocReadContextTombstoneCacheTest, SetStampsCallerGeneration) {
   schema.set_colocation_id(42);
   auto ctx = docdb::DocReadContext::TEST_Create(schema);
 
-  ctx.AdvanceTombstoneCacheWatermark(HybridTime::FromMicros(100));
+  ASSERT_TRUE(ctx.ArmTombstoneCacheFromProbe(
+      HybridTime::FromMicros(100), DocHybridTime::kInvalid, ctx.tombstone_cache_generation()));
   const auto gen_before = ctx.tombstone_cache_generation();
 
   // Truncate advances generation after the fetch, before set.
@@ -2191,7 +2216,9 @@ TEST(DocReadContextTombstoneCacheTest, RejectTombstoneAboveWatermark) {
   schema.set_colocation_id(42);
   auto ctx = docdb::DocReadContext::TEST_Create(schema);
 
-  ctx.AdvanceTombstoneCacheWatermark(HybridTime::FromMicros(100));
+  ASSERT_TRUE(ctx.ArmTombstoneCacheFromProbe(
+      HybridTime::FromMicros(100), DocHybridTime::kInvalid, ctx.tombstone_cache_generation()));
+  ctx.clear_table_tombstone_time();
   const auto gen = ctx.tombstone_cache_generation();
 
   // Tombstone T > watermark: reject (would hide rows for watermark <= read_ht < T).
@@ -2210,6 +2237,112 @@ TEST(DocReadContextTombstoneCacheTest, RejectTombstoneAboveWatermark) {
   ctx.set_table_tombstone_time(DocHybridTime::kInvalid, gen);
   ASSERT_TRUE(ctx.table_tombstone_time().has_value());
   ASSERT_EQ(*ctx.table_tombstone_time(), DocHybridTime::kInvalid);
+}
+
+// #33607: a tombstone that applies while the probe is in flight must void the probe's result. The
+// notify has already set a watermark from the write itself; letting the probe store an "absent"
+// it read a moment earlier would resurrect exactly the rows that tombstone covers.
+TEST(DocReadContextTombstoneCacheTest, ArmFromProbeRejectsRacedGeneration) {
+  SchemaBuilder builder;
+  ASSERT_OK(builder.AddKeyColumn("k", DataType::INT32));
+  auto schema = builder.Build();
+  schema.set_colocation_id(42);
+  auto ctx = docdb::DocReadContext::TEST_Create(schema);
+
+  const auto gen_before = ctx.tombstone_cache_generation();
+  ctx.OnTableTombstoneWritten(HybridTime::FromMicros(200));
+
+  ASSERT_FALSE(ctx.ArmTombstoneCacheFromProbe(
+      HybridTime::FromMicros(100), DocHybridTime::kInvalid, gen_before));
+  ASSERT_FALSE(ctx.table_tombstone_time().has_value());
+  // The notify's own watermark stands, so reads below the tombstone stay ineligible.
+  ASSERT_EQ(ctx.tombstone_cache_watermark(), HybridTime::FromMicros(200));
+
+  // A probe that starts after the notify is accepted.
+  ASSERT_TRUE(ctx.ArmTombstoneCacheFromProbe(
+      HybridTime::FromMicros(200), DocHybridTime(HybridTime::FromMicros(200), /*write_id=*/0),
+      ctx.tombstone_cache_generation()));
+  ASSERT_TRUE(ctx.table_tombstone_time().has_value());
+}
+
+class PgMiniTombstoneCacheRestoreTest : public PgMiniTestSingleNode {
+ protected:
+  void SetUp() override {
+    PgMiniTestSingleNode::SetUp();
+    snapshot_util_.SetProxy(&client_->proxy_cache());
+    snapshot_util_.SetCluster(cluster_.get());
+  }
+
+  client::SnapshotTestUtil snapshot_util_;
+};
+
+// #33607 gap 1: RestoreCheckpoint replaces the regular DB under DocReadContexts that survive the
+// swap, so a warm tombstone-time cache ends up describing data that no longer exists. Here the
+// cache holds the TRUNCATE's tombstone T and the restore takes the table back to before the
+// TRUNCATE: every restored row was written before T, so filtering against the stale cached T reads
+// the table as empty. RestoreCheckpoint has to drop those caches; the restore only rebuilds
+// contexts for tables named in the restore metadata, which is not all of them.
+TEST_F_EX(PgMiniTest, TombstoneCacheResetOnSnapshotRestore, PgMiniTombstoneCacheRestoreTest) {
+  const std::string kDbName = "tombstone_restore_db";
+  const std::string kTableName = "t";
+  const int kColocationId = 20007;
+  const auto kSnapshotInterval = 5s * kTimeMultiplier;
+
+  auto conn = ASSERT_RESULT(Connect());
+  ASSERT_OK(conn.ExecuteFormat("CREATE DATABASE $0 WITH colocated=true", kDbName));
+  conn = ASSERT_RESULT(ConnectToDB(kDbName));
+  ASSERT_OK(conn.ExecuteFormat(
+      "CREATE TABLE $0 (v int PRIMARY KEY) WITH (colocation_id=$1)", kTableName, kColocationId));
+  ASSERT_OK(conn.ExecuteFormat("INSERT INTO $0 VALUES (1), (2), (3)", kTableName));
+
+  auto schedule_id = ASSERT_RESULT(snapshot_util_.CreateSchedule(
+      kDbName, client::WaitSnapshot::kTrue, kSnapshotInterval));
+
+  // Warm the cache with "no tombstone" and pin the restore target ahead of the TRUNCATE.
+  ASSERT_EQ(
+      ASSERT_RESULT(conn.FetchRow<int64_t>(Format("SELECT count(*) FROM $0", kTableName))), 3);
+  const auto restore_time = cluster_->mini_master(0)->Now();
+  ASSERT_OK(snapshot_util_.WaitScheduleSnapshot(schedule_id, restore_time));
+
+  ASSERT_OK(conn.Execute("SET yb_enable_alter_table_rewrite = false"));
+  ASSERT_OK(conn.ExecuteFormat("TRUNCATE $0", kTableName));
+
+  auto table_id = ASSERT_RESULT(GetTableIDFromTableName(kTableName));
+  auto peers = ListTableActiveTabletLeadersPeers(cluster_.get(), table_id);
+  ASSERT_FALSE(peers.empty());
+  auto tablet = ASSERT_RESULT(peers.front()->shared_tablet());
+  ASSERT_TRUE(DumpHasTableTombstone(tablet->TEST_DocDBDumpStr(), kColocationId))
+      << "TRUNCATE did not write a table-level tombstone (rewrite path taken?)";
+
+  // This read caches the tombstone, which is what the restore has to invalidate.
+  ASSERT_EQ(
+      ASSERT_RESULT(conn.FetchRow<int64_t>(Format("SELECT count(*) FROM $0", kTableName))), 0);
+
+  auto snapshot_id = ASSERT_RESULT(
+      snapshot_util_.PickSuitableSnapshot(schedule_id, restore_time));
+  ASSERT_OK(snapshot_util_.RestoreSnapshot(snapshot_id, restore_time));
+
+  conn = ASSERT_RESULT(ConnectToDB(kDbName));
+  ASSERT_EQ(
+      ASSERT_RESULT(conn.FetchRow<int64_t>(Format("SELECT count(*) FROM $0", kTableName))), 3)
+      << "restored rows were filtered against a tombstone time cached from the pre-restore data";
+}
+
+// #33607: arming is monotone. A probe whose iterator snapshot predates an applied tombstone must
+// not walk the watermark back below it.
+TEST(DocReadContextTombstoneCacheTest, ArmFromProbeNeverLowersWatermark) {
+  SchemaBuilder builder;
+  ASSERT_OK(builder.AddKeyColumn("k", DataType::INT32));
+  auto schema = builder.Build();
+  schema.set_colocation_id(42);
+  auto ctx = docdb::DocReadContext::TEST_Create(schema);
+
+  ASSERT_TRUE(ctx.ArmTombstoneCacheFromProbe(
+      HybridTime::FromMicros(300), DocHybridTime(HybridTime::FromMicros(300), /*write_id=*/0),
+      ctx.tombstone_cache_generation()));
+  ASSERT_TRUE(ctx.ArmTombstoneCacheFromProbe(
+      HybridTime::FromMicros(100), DocHybridTime::kInvalid, ctx.tombstone_cache_generation()));
+  ASSERT_EQ(ctx.tombstone_cache_watermark(), HybridTime::FromMicros(300));
 }
 
 // #32724 (f): RF3. A replica that held a warm cache while it was a follower must still see the
@@ -2241,17 +2374,15 @@ TEST_F(PgMiniTest, TruncateColocatedInvalidatesTombstoneCacheOnFollower) {
         if (peers.size() != NumTabletServers()) {
           return false;
         }
-        // Arming happens later in the same apply, so wait for it too.
         for (const auto& peer : peers) {
           auto table_info = peer->tablet_metadata()->GetTableInfo(kColocationId);
-          if (!table_info.ok() || !(*table_info)->doc_read_context ||
-              (*table_info)->doc_read_context->tombstone_cache_watermark() == HybridTime::kMax) {
+          if (!table_info.ok() || !(*table_info)->doc_read_context) {
             return false;
           }
         }
         return true;
       },
-      30s * kTimeMultiplier, "Every replica of the colocated tablet armed the table"));
+      30s * kTimeMultiplier, "Every replica of the colocated tablet has the table"));
   const auto tablet_id = peers.front()->tablet_id();
 
   auto doc_read_context = [&](const tablet::TabletPeerPtr& peer) {
@@ -2260,15 +2391,15 @@ TEST_F(PgMiniTest, TruncateColocatedInvalidatesTombstoneCacheOnFollower) {
     return table_info->doc_read_context;
   };
 
-  // Warm every replica with the pre-truncate "no tombstone" answer. The SELECT above only warmed
-  // the leader, and the replicas this test is about are the ones that are followers at apply time;
-  // stamping directly is the deterministic way to put them in that state.
+  // Warm every replica with the pre-truncate "no tombstone" answer. Only reads arm a context, and
+  // followers serve none, so the replicas this test is about would otherwise sit unarmed (cache
+  // off) and could not go stale at all. Arm them by hand at a watermark below any real hybrid time
+  // so the planted entry is eligible for every read - that is the poisoned state the apply-path
+  // notify has to clear.
   for (const auto& peer : peers) {
     auto ctx = doc_read_context(peer);
-    ASSERT_NE(ctx->tombstone_cache_watermark(), HybridTime::kMax)
-        << "replica " << peer->permanent_uuid() << " was never armed, so it cannot go stale and "
-        << "this test would not exercise anything";
-    ctx->set_table_tombstone_time(DocHybridTime::kInvalid, ctx->tombstone_cache_generation());
+    ASSERT_TRUE(ctx->ArmTombstoneCacheFromProbe(
+        HybridTime::FromMicros(1), DocHybridTime::kInvalid, ctx->tombstone_cache_generation()));
     ASSERT_TRUE(ctx->table_tombstone_time().has_value());
   }
 


### PR DESCRIPTION
## Summary

The colocated tombstone-time cache is gated on a watermark that has to be an upper bound on
every table tombstone already in the tablet's data. Reads at or above the watermark trust the
cache; a tombstone above it can be missed, and the cached "no tombstone" then resurrects every
row the truncate covered.

c9e33d90b37/D56793 armed that watermark from the tablet's SafeTime. SafeTime only bounds
tombstones this tablet wrote through its own raft ops, so the invariant breaks wherever a
tombstone arrives carrying a foreign clock:

- **xCluster target.** Tombstones apply at the producer's hybrid time, which can sit above the
  target's SafeTime. Any path that rebuilds the `DocReadContext` (restart, `ALTER`, packed-schema
  insert) re-arms below the tombstone. Once the WAL entry is GC'd there is nothing left to
  re-notify from, so the resurrection is permanent.
- **Snapshot / PITR restore.** `RestoreCheckpoint` swaps the regular DB under live contexts, and
  the restored data carries the hybrid times of whenever it was originally written.

## What changed

Arm from the data instead. The first read on an unarmed context probes for the table's newest
tombstone at an unbounded read time and takes the watermark from what it finds, which holds
regardless of which clock stamped the tombstone.

The probe is the same single bloom-filtered seek the cold read already did
(`docdb::GetTableTombstoneTime`), and it answers the read outright unless the read predates the
tombstone it found, so the common path costs no extra seek. Because contexts now arm themselves,
the explicit arm sites in `Tablet::Start`, `AlterSchema`, `InsertPackedSchemaForXClusterTarget`
and `AddTableInMemory` are gone — which also drops the stampede where an `ALTER` of one colocated
table invalidated every warm cache in the tablet.

Restore still needs an explicit reset: after the swap the cached value describes data that no
longer exists, in either direction, and no watermark arithmetic repairs that. `RestoreCheckpoint`
now unarms every colocated context (`RaftGroupMetadata::ResetColocatedTombstoneCaches`), and the
first read re-probes the restored data. The walk is needed because the restore only rebuilds
contexts for tables named in the restore metadata, not for the rest of the tablet's colocated
tables.

The DROP-then-CREATE colocation-id reuse case that `AddTableInMemory` used to reason about via
hybrid-clock propagation is now direct: the new table's context probes, finds the DROP's tombstone
under the reused prefix, and arms above it.

## Upgrade/Rollback safety

No persisted state changes: no proto/wire-format, on-disk-format, or catalog change. The tombstone
cache, its watermark and its generation counter are per-tserver in-memory state rebuilt from the
tablet's data on every process start, so a mixed-version cluster has no cross-node interaction here
— each tserver reads correctly under whichever arming rule its own binary implements.

Rollback is symmetric and needs no migration: a node reverted to the SafeTime-arming build simply
goes back to the old (buggy) arming on its next start.

`enable_colocated_table_tombstone_cache` remains the runtime kill switch on both sides; with it off
the read path bypasses the cache entirely.

## Test plan

All run on `release` (clang21), `pg_mini-test`, one test per invocation.

New coverage:

- [x] `PgMiniTest.TombstoneCacheResetOnSnapshotRestore` — warms the cache, restores a snapshot taken
      before a truncate, asserts the rows come back. Fails without the `RestoreCheckpoint` reset.
- [x] `DocReadContextTombstoneCacheTest.ArmFromProbeRejectsRacedGeneration` — a tombstone applying
      mid-probe makes the arm a no-op.
- [x] `DocReadContextTombstoneCacheTest.ArmFromProbeNeverLowersWatermark` — re-arming only raises.

Existing tombstone-cache tests, updated for the new API and re-run:

- [x] `PgMiniTest.TruncateColocatedAfterAlterSchema` (the arm-after-`ALTER` path this PR deletes)
- [x] `PgMiniTest.TruncateColocatedInvalidatesTombstoneCache`
- [x] `PgMiniTest.TruncateColocatedInvalidatesTombstoneCacheOnFollower`
- [x] `PgMiniTest.TruncateVisibleThroughTombstoneCache`
- [x] `PgMiniTest.TruncateColocatedMultipleTruncates`
- [x] `PgMiniTest.TruncateTombstoneCacheHealedByRestart`
- [x] `PgMiniTest.TruncateRewritePathControl`
- [x] `PgMiniTest.VerifyTombstoneTimeCache`
- [x] `DocReadContextTombstoneCacheTest.UnarmedWatermarkFailsClosed`
- [x] `DocReadContextTombstoneCacheTest.SetStampsCallerGeneration`
- [x] `DocReadContextTombstoneCacheTest.RejectTombstoneAboveWatermark`

Not covered by a test here: the xCluster-target leg. It needs a producer whose hybrid time runs
ahead of the target's SafeTime plus a context rebuild, which `pg_mini-test` can't stage; the fix is
the same probe the restore test exercises.
