### PR TITLE
[PLAT-22308] YBA: Fail fast with a clear error when the master leader is missing

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/UniverseTaskBase.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/UniverseTaskBase.java
@@ -2890,7 +2890,7 @@ public abstract class UniverseTaskBase extends AbstractTaskBase {
       @Nullable Predicate<DumpEntitiesResponse> moreStopCondition,
       NodeUIApiHelper nodeUIApiHelper) {
     // Wait for a maximum of 10 seconds for url to succeed.
-    NodeDetails masterLeaderNode = universe.getMasterLeaderNode();
+    NodeDetails masterLeaderNode = universe.getMasterLeaderNodeOrThrow();
     HostAndPort masterLeaderHostPort =
         HostAndPort.fromParts(
             masterLeaderNode.cloudInfo.private_ip, masterLeaderNode.masterHttpPort);

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/KubernetesCommandExecutor.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/KubernetesCommandExecutor.java
@@ -1580,7 +1580,7 @@ public class KubernetesCommandExecutor extends UniverseTaskBase {
               "PGPASSFILE",
               "value",
               Util.getDataDirectoryPath(
-                      universeFromDB, universeFromDB.getMasterLeaderNode(), this.config)
+                      universeFromDB, universeFromDB.getMasterLeaderNodeOrThrow(), this.config)
                   + "/yw-data/.pgpass"));
       masterOverrides.put("extraEnv", masterExtraEnv);
     }

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/ManageCatalogUpgradeSuperUser.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/ManageCatalogUpgradeSuperUser.java
@@ -52,11 +52,11 @@ public class ManageCatalogUpgradeSuperUser extends UniverseTaskBase {
           universe.getUniverseUUID());
       return;
     }
-    NodeDetails masterLeaderNode = universe.getMasterLeaderNode();
+    NodeDetails masterLeaderNode = universe.getMasterLeaderNodeOrThrow();
     String pgPassFileDir =
         (Util.isKubernetesBasedUniverse(universe)
             ? Util.getDataDirectoryPath(universe, masterLeaderNode, config) + "/yw-data"
-            : Util.getNodeHomeDir(universe.getUniverseUUID(), universe.getMasterLeaderNode()));
+            : Util.getNodeHomeDir(universe.getUniverseUUID(), masterLeaderNode));
     String pgPassFilePath = pgPassFileDir + "/.pgpass";
     if (taskParams().action == Action.CREATE_USER) {
       dropUser(universe, masterLeaderNode);

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/RunYsqlUpgrade.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/RunYsqlUpgrade.java
@@ -195,7 +195,7 @@ public class RunYsqlUpgrade extends UniverseTaskBase {
    *   will try to find an alive tserver in any region.
    */
   private NodeDetails findAliveTServer(YBClientApi client, Universe universe) {
-    NodeDetails masterLeaderNode = universe.getMasterLeaderNode();
+    NodeDetails masterLeaderNode = universe.getMasterLeaderNodeOrThrow();
     String masterLeaderRegion = masterLeaderNode.getRegion();
     NodeDetails aliveTServer = null;
 

--- a/managed/src/main/java/com/yugabyte/yw/common/backuprestore/ybc/YbcManager.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/backuprestore/ybc/YbcManager.java
@@ -1067,7 +1067,7 @@ public class YbcManager {
 
   public static List<String> getPreferenceBasedYBCNodeIPsList(
       Universe universe, Set<String> excludeNodeIPs) {
-    NodeDetails leaderMasterNodeDetails = universe.getMasterLeaderNode();
+    NodeDetails leaderMasterNodeDetails = universe.getMasterLeaderNodeOrThrow();
     List<String> nodesToCheckInPreference = new ArrayList<>();
     String masterLeaderIP = leaderMasterNodeDetails.cloudInfo.private_ip;
     // Add master leader to first preference.

--- a/managed/src/main/java/com/yugabyte/yw/models/Universe.java
+++ b/managed/src/main/java/com/yugabyte/yw/models/Universe.java
@@ -1256,7 +1256,7 @@ public class Universe extends Model {
   public NodeDetails getMasterLeaderNodeOrThrow() {
     NodeDetails masterLeaderNode = getMasterLeaderNode();
     if (masterLeaderNode == null) {
-      throw new RuntimeException(
+      throw new IllegalStateException(
           "Could not find the master leader node in universe " + getUniverseUUID());
     }
     return masterLeaderNode;

--- a/managed/src/main/java/com/yugabyte/yw/models/Universe.java
+++ b/managed/src/main/java/com/yugabyte/yw/models/Universe.java
@@ -1245,6 +1245,24 @@ public class Universe extends Model {
   }
 
   /**
+   * Find the current master leader node, failing loudly when it is missing. Prefer this over {@link
+   * #getMasterLeaderNode()} on paths that cannot make progress without a master leader, so that a
+   * missing leader surfaces as an actionable error instead of a NullPointerException.
+   *
+   * @return NodeDetails of the master leader, never null
+   * @throws RuntimeException if the universe has no reachable master leader
+   */
+  @JsonIgnore
+  public NodeDetails getMasterLeaderNodeOrThrow() {
+    NodeDetails masterLeaderNode = getMasterLeaderNode();
+    if (masterLeaderNode == null) {
+      throw new RuntimeException(
+          "Could not find the master leader node in universe " + getUniverseUUID());
+    }
+    return masterLeaderNode;
+  }
+
+  /**
    * Find the current master leader in the universe
    *
    * @return a String of the private_ip of the current master leader in the universe or an empty

--- a/managed/src/test/java/com/yugabyte/yw/models/UniverseTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/models/UniverseTest.java
@@ -12,8 +12,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -24,6 +26,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.typesafe.config.Config;
 import com.yugabyte.yw.cloud.PublicCloudConstants;
@@ -1038,5 +1041,41 @@ public class UniverseTest extends FakeDBApplication {
     assertEquals(2, universeUuids.size());
     assertTrue(universeUuids.contains(universeOne.getUniverseUUID()));
     assertTrue(universeUuids.contains(universeTwo.getUniverseUUID()));
+  }
+
+  @Test
+  public void testGetMasterLeaderNodeOrThrowReturnsLeader() {
+    Universe u = createUniverse(defaultCustomer.getId());
+    final Universe universe =
+        Universe.saveDetails(u.getUniverseUUID(), ApiUtils.mockUniverseUpdater());
+    NodeDetails expectedLeader = universe.getUniverseDetails().nodeDetailsSet.iterator().next();
+
+    when(mockService.getUniverseClient(any())).thenReturn(mockYBClient);
+    when(mockYBClient.getLeaderMasterHostAndPort())
+        .thenReturn(
+            HostAndPort.fromParts(
+                expectedLeader.cloudInfo.private_ip, expectedLeader.masterRpcPort));
+
+    assertEquals(expectedLeader.nodeName, universe.getMasterLeaderNodeOrThrow().nodeName);
+  }
+
+  @Test
+  public void testGetMasterLeaderNodeOrThrowWithoutLeader() {
+    Universe u = createUniverse(defaultCustomer.getId());
+    final Universe universe =
+        Universe.saveDetails(u.getUniverseUUID(), ApiUtils.mockUniverseUpdater());
+
+    when(mockService.getUniverseClient(any())).thenReturn(mockYBClient);
+    when(mockYBClient.getLeaderMasterHostAndPort()).thenReturn(null);
+
+    // The nullable accessor keeps its contract, the strict one fails with an actionable message.
+    assertNull(universe.getMasterLeaderNode());
+    RuntimeException re =
+        assertThrows(RuntimeException.class, () -> universe.getMasterLeaderNodeOrThrow());
+    assertThat(
+        re.getMessage(),
+        allOf(
+            containsString("Could not find the master leader node"),
+            containsString(universe.getUniverseUUID().toString())));
   }
 }


### PR DESCRIPTION
## Summary

`Universe.getMasterLeaderNode()` is documented as nullable — it returns `null` whenever `getMasterLeaderHostText()` yields `""`, either because no master leader is currently elected or because the `YBClient` lookup threw and was swallowed. Five call sites dereferenced the result with no null check, so a missing leader surfaced as an opaque `NullPointerException` instead of an actionable error.

The reported path is a Kubernetes universe edit:

`EditKubernetesUniverse` → `createWaitForDataMoveTask()` → `WaitForDataMove` → `verifyNoTabletsOnBlacklistedTservers()` → `UniverseTaskBase.dumpDbEntities()`

which builds a `HostAndPort` directly off the nullable node.

This adds `Universe.getMasterLeaderNodeOrThrow()`, which raises a `RuntimeException` naming the universe, and routes the five escaping sites through it:

| Call site | Previously dereferenced |
|---|---|
| `UniverseTaskBase.dumpDbEntities()` | `.cloudInfo.private_ip` |
| `YbcManager.getPreferenceBasedYBCNodeIPsList()` | `.cloudInfo.private_ip` |
| `ManageCatalogUpgradeSuperUser.run()` | passed to `getDataDirectoryPath` / `getNodeHomeDir` |
| `RunYsqlUpgrade.findAliveTServer()` | `.getRegion()` |
| `KubernetesCommandExecutor` (ysql major upgrade `PGPASSFILE` path) | passed to `getDataDirectoryPath` |

`ManageCatalogUpgradeSuperUser` also resolved the master leader a second time for the non-Kubernetes home directory — a redundant RPC that could return `null` independently of the first call. It now reuses the local.

Call sites that already handle `null` keep the nullable accessor: `HealthChecker`, `PGUpgradeTServerCheck` and `CommonUtils.getServerToRunYsqlQuery` all null-check and fall back. `TabletReportComponent` keeps it too — its dereference sits inside a `try`/`catch` that logs and continues, so the NPE never escapes there.

### Behavior change

Every path touched here already failed when the master leader was missing; they now fail with a message naming the universe instead of an NPE. No path that previously succeeded now fails.

Two of them use the leader only as a *preference* — `RunYsqlUpgrade.findAliveTServer()` uses it as a region hint, and `YbcManager.getPreferenceBasedYBCNodeIPsList()` as a first-choice backup node — so they could in principle degrade gracefully instead of throwing. Both previously raised an NPE, so failing fast is not a regression, but they are reasonable candidates for a follow-up that falls back to another node.

## Test plan

Two cases added to `UniverseTest`:

- `testGetMasterLeaderNodeOrThrowReturnsLeader` — resolves the correct node when `getLeaderMasterHostAndPort()` returns a known node's private IP.
- `testGetMasterLeaderNodeOrThrowWithoutLeader` — asserts `getMasterLeaderNode()` still returns `null` (nullable contract preserved) and that `getMasterLeaderNodeOrThrow()` throws a `RuntimeException` whose message names the universe.

- [x] `sbt "testOnly com.yugabyte.yw.models.UniverseTest"`, run on this branch rebased onto current master — `0 failed, 0 ignored, 46 total`, both new cases included.
- [x] `google-java-format` 1.17.0 — all 7 changed files clean.
- [x] `build-support/lint.sh --rev upstream/master` — 0 errors.

The rebase onto master resolved three conflicts, all upstream movement rather than semantic overlap:

- `ManageCatalogUpgradeSuperUser` — master added an early return when YSQL is disabled. Kept it, so the new throw is reached only when YSQL is actually enabled.
- `RunYsqlUpgrade` — master renamed the parameter type `YBClient` → `YBClientApi`. Kept master's signature.
- `UniverseTest` — master appended its own `getNodePrefixesForCustomer` / `findUniverseUuidsByNodePrefix` tests at the same point in the file. Kept both sets; the suite going from 38 to 46 tests reflects that.
