### PR TITLE
[#33841] Tools: Suppress the Claude Code attribution line in PR descriptions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "attribution": {
-    "commit": ""
+    "commit": "",
+    "pr": ""
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
`.claude/settings.json` sets `attribution.commit` to `""` but leaves the sibling `attribution.pr`
unset, so that key falls back to Claude Code's default and every agent-opened PR still gets a
"Generated with Claude Code" footer. Looks like an oversight in the original commit rather than a
decision.

Adds `"pr": ""` beside it, which removes the line the same way `commit` already does. Verified by
this PR's own description, which has no footer. `attribution.sessionUrl` is left alone.
