### PR TITLE
[BACKPORT 2026.1][PLAT-21289] YBA: Stop handling events after YBA instance gets demoted

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/common/operator/AbstractReconciler.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/operator/AbstractReconciler.java
@@ -50,7 +50,7 @@ public abstract class AbstractReconciler<T extends CustomResource<?, ?>>
     this.operatorUtils = operatorUtils;
     this.workqueue = new OperatorWorkQueue(clazz.getSimpleName());
     this.namespace = namespace;
-    this.resourceInformer.addEventHandler(this);
+    this.resourceInformer.addEventHandler(HaAwareResourceEventHandler.wrap(operatorUtils, this));
   }
 
   // Abstract methods
@@ -164,6 +164,9 @@ public abstract class AbstractReconciler<T extends CustomResource<?, ?>>
    * @param resource specified resource
    */
   protected void reconcile(T resource, OperatorWorkQueue.ResourceAction action) {
+    if (HaAwareResourceEventHandler.skip(operatorUtils)) {
+      return;
+    }
     String resourceName = resource.getMetadata().getName();
     String resourceNamespace = resource.getMetadata().getNamespace();
     log.info(

--- a/managed/src/main/java/com/yugabyte/yw/common/operator/BackupReconciler.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/operator/BackupReconciler.java
@@ -329,7 +329,7 @@ public class BackupReconciler implements ResourceEventHandler<Backup>, Runnable 
 
   @Override
   public void run() {
-    informer.addEventHandler(this);
+    informer.addEventHandler(HaAwareResourceEventHandler.wrap(operatorUtils, this));
     informer.run();
   }
 }

--- a/managed/src/main/java/com/yugabyte/yw/common/operator/HaAwareResourceEventHandler.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/operator/HaAwareResourceEventHandler.java
@@ -1,0 +1,61 @@
+// Copyright (c) YugabyteDB, Inc.
+package com.yugabyte.yw.common.operator;
+
+import com.yugabyte.yw.common.operator.utils.OperatorUtils;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Single HA-follower gate for operator CR handling. Informers register {@link #wrap} so callbacks
+ * never reach reconcilers. {@link AbstractReconciler} also calls {@link #skip} for work already on
+ * the queue (backoff requeue from before demote), which does not go through the informer.
+ */
+@Slf4j
+public final class HaAwareResourceEventHandler<T> implements ResourceEventHandler<T> {
+  private final OperatorUtils operatorUtils;
+  private final ResourceEventHandler<T> delegate;
+
+  private HaAwareResourceEventHandler(
+      OperatorUtils operatorUtils, ResourceEventHandler<T> delegate) {
+    this.operatorUtils = operatorUtils;
+    this.delegate = delegate;
+  }
+
+  public static <T> ResourceEventHandler<T> wrap(
+      OperatorUtils operatorUtils, ResourceEventHandler<T> delegate) {
+    return new HaAwareResourceEventHandler<>(operatorUtils, delegate);
+  }
+
+  /** True when this YBA is an HA follower and must not apply operator CRs. */
+  public static boolean skip(OperatorUtils operatorUtils) {
+    if (!operatorUtils.isHaFollower()) {
+      return false;
+    }
+    log.debug("Skipping Kubernetes operator work on HA follower");
+    return true;
+  }
+
+  @Override
+  public void onAdd(T resource) {
+    if (skip(operatorUtils)) {
+      return;
+    }
+    delegate.onAdd(resource);
+  }
+
+  @Override
+  public void onUpdate(T oldResource, T newResource) {
+    if (skip(operatorUtils)) {
+      return;
+    }
+    delegate.onUpdate(oldResource, newResource);
+  }
+
+  @Override
+  public void onDelete(T resource, boolean deletedFinalStateUnknown) {
+    if (skip(operatorUtils)) {
+      return;
+    }
+    delegate.onDelete(resource, deletedFinalStateUnknown);
+  }
+}

--- a/managed/src/main/java/com/yugabyte/yw/common/operator/ReleaseReconciler.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/operator/ReleaseReconciler.java
@@ -250,7 +250,7 @@ public class ReleaseReconciler implements ResourceEventHandler<Release>, Runnabl
 
   @Override
   public void run() {
-    informer.addEventHandler(this);
+    informer.addEventHandler(HaAwareResourceEventHandler.wrap(operatorUtils, this));
     informer.run();
   }
 

--- a/managed/src/main/java/com/yugabyte/yw/common/operator/RestoreJobReconciler.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/operator/RestoreJobReconciler.java
@@ -214,7 +214,7 @@ public class RestoreJobReconciler implements ResourceEventHandler<RestoreJob>, R
 
   @Override
   public void run() {
-    informer.addEventHandler(this);
+    informer.addEventHandler(HaAwareResourceEventHandler.wrap(operatorUtils, this));
     informer.run();
   }
 }

--- a/managed/src/main/java/com/yugabyte/yw/common/operator/StorageConfigReconciler.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/operator/StorageConfigReconciler.java
@@ -336,7 +336,7 @@ public class StorageConfigReconciler implements ResourceEventHandler<StorageConf
 
   @Override
   public void run() {
-    informer.addEventHandler(this);
+    informer.addEventHandler(HaAwareResourceEventHandler.wrap(operatorUtils, this));
     informer.run();
   }
 }

--- a/managed/src/main/java/com/yugabyte/yw/common/operator/SupportBundleReconciler.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/operator/SupportBundleReconciler.java
@@ -73,7 +73,7 @@ public class SupportBundleReconciler
 
   @Override
   public void run() {
-    informer.addEventHandler(this);
+    informer.addEventHandler(HaAwareResourceEventHandler.wrap(operatorUtils, this));
     informer.run();
   }
 

--- a/managed/src/main/java/com/yugabyte/yw/common/operator/YBCertificateReconciler.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/operator/YBCertificateReconciler.java
@@ -465,7 +465,7 @@ public class YBCertificateReconciler implements ResourceEventHandler<YBCertifica
 
   @Override
   public void run() {
-    informer.addEventHandler(this);
+    informer.addEventHandler(HaAwareResourceEventHandler.wrap(operatorUtils, this));
     informer.run();
   }
 }

--- a/managed/src/main/java/com/yugabyte/yw/common/operator/utils/OperatorUtils.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/operator/utils/OperatorUtils.java
@@ -319,6 +319,15 @@ public class OperatorUtils {
   }
 
   /**
+   * True once HA has demoted this YBA to standby. The active instance owns the CRs, so a demoted
+   * instance that keeps reconciling fights it over the same Kubernetes cluster. Checked on every CR
+   * event rather than at startup because a role flip does not restart YBA.
+   */
+  public boolean isHaFollower() {
+    return HighAvailabilityConfig.isFollower();
+  }
+
+  /**
    * Resolves the YBA universe backing a YBUniverse custom resource, given that resource's name and
    * namespace.
    *


### PR DESCRIPTION
Summary: Both the YBA instances are listening on CRs in spite of one of the YBAs being demoted. This diff ensures that the demoted YBA doesn't listen on the CRs.

Original commit: 940fbd8ae0bfc6447ddb4c269b149562550c538f / D57794

Test Plan: Checks the logs and ensure that the demoted YBA is not listening on and processing any CRs.

Reviewers: dshubin

Reviewed By: dshubin

Subscribers: dshubin, yugaware

Differential Revision: https://phorge.dev.yugabyte.com/D57794