### PR TITLE
[#33874] DocDB: Refuse split while a replica is being remote bootstrapped

### DIFF
--- a/src/yb/integration-tests/tablet-split-itest.cc
+++ b/src/yb/integration-tests/tablet-split-itest.cc
@@ -2360,6 +2360,100 @@ TEST_F(AutomaticTabletSplitAddServerITest, DoNotSplitTabletDoingRBS) {
   ASSERT_OK(WaitForTabletSplitCompletion(2));
 }
 
+TEST_F(AutomaticTabletSplitAddServerITest, DoNotSplitFullyReplicatedTabletDoingRBS) {
+  // A tablet that already has RF running voters must not be split while a fourth replica is being
+  // remote bootstrapped as PRE_VOTER. While the copy is in progress the destination reports the
+  // peer without a consensus state, so the master records it with member type UNKNOWN_MEMBER_TYPE
+  // rather than PRE_VOTER, and the check must not depend on seeing PRE_VOTER. Unlike
+  // DoNotSplitTabletDoingRBS, no voter is removed first, so the under-replication path does not
+  // apply here.
+
+  CreateSingleTablet();
+  ASSERT_OK(WriteRows());
+
+  BuildTServerMap();
+
+  const auto catalog_mgr = ASSERT_RESULT(catalog_manager());
+  const auto tablet = ASSERT_RESULT(GetSingleTestTabletInfo(catalog_mgr));
+  const auto tablet_id = tablet->id();
+  const auto leader_idx = ASSERT_RESULT(GetLeaderIdx(tablet));
+  const auto leader_ts = cluster_->mini_tablet_server(leader_idx)->server();
+  const auto leader_id = leader_ts->permanent_uuid();
+  const auto follower_idx = (leader_idx + 1) % 3;
+  const auto follower_id = cluster_->mini_tablet_server(follower_idx)->server()->permanent_uuid();
+  LOG(INFO) << "Source tablet id " << tablet_id;
+
+  // Start RBS of a fourth replica but pause it before downloading the WAL.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_rbs_before_download_wal) = true;
+  AddTabletToNewTServer(tablet_id, leader_id, consensus::PeerMemberType::PRE_VOTER);
+
+  const auto new_ts_idx = cluster_->num_tablet_servers() - 1;
+  const auto new_ts_id = cluster_->mini_tablet_server(new_ts_idx)->server()->permanent_uuid();
+
+  // Wait for the destination's own heartbeat. From here on the replica is NOT_STARTED in the
+  // master's map and its member type is whatever the consensus-less report left there.
+  ASSERT_OK(itest::WaitUntilTabletInState(tablet, new_ts_id, tablet::NOT_STARTED));
+  {
+    const auto replicas = tablet->GetReplicaLocations();
+    const auto it = replicas->find(new_ts_id);
+    ASSERT_NE(it, replicas->end());
+    LOG(INFO) << "Bootstrapping replica as seen by the master: " << it->second.ToString();
+    ASSERT_NE(it->second.member_type, consensus::PeerMemberType::VOTER);
+  }
+
+  // The config change rebuilt the replica map, which leaves the original replicas in state UNKNOWN
+  // until each reports again. Wait for them, so that the refusal below can only be due to the
+  // bootstrapping replica and not to a voter that is momentarily "not running".
+  ASSERT_OK(WaitFor([&]() -> Result<bool> {
+    for (const auto& [ts_uuid, replica] : *tablet->GetReplicaLocations()) {
+      if (ts_uuid != new_ts_id &&
+          (replica.member_type != consensus::PeerMemberType::VOTER ||
+           replica.state != tablet::RaftGroupStatePB::RUNNING)) {
+        return false;
+      }
+    }
+    return true;
+  }, 20s * kTimeMultiplier, "Waiting for the original replicas to report RUNNING."));
+
+  // The check must refuse the split even though the tablet has exactly RF running voters. This is
+  // the regression assertion: the previous check only rejected PRE_VOTER and counted VOTERs, so it
+  // returned OK here.
+  {
+    const auto status = master::CheckLiveReplicasForSplit(
+        tablet_id, *tablet->GetReplicaLocations(), FLAGS_replication_factor);
+    ASSERT_NOK(status);
+    ASSERT_STR_CONTAINS(status.ToString(), "being bootstrapped");
+  }
+
+  // Let the split manager run a few times; nothing must be split while the RBS is paused.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_automatic_tablet_splitting) = true;
+  SleepFor(MonoDelta::FromSeconds(5 * kTimeMultiplier));
+  ASSERT_EQ(itest::GetNumTabletsOfTableOnTS(leader_ts, table_->id()), 1);
+
+  // Let the RBS finish. The new peer is promoted to VOTER, which makes the tablet over-replicated,
+  // so still no split.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_rbs_before_download_wal) = false;
+  ASSERT_OK(WaitFor([&]() -> Result<bool> {
+    const auto replicas = tablet->GetReplicaLocations();
+    const auto it = replicas->find(new_ts_id);
+    return it != replicas->end() && it->second.member_type == consensus::PeerMemberType::VOTER &&
+           it->second.state == tablet::RaftGroupStatePB::RUNNING;
+  }, 60s * kTimeMultiplier, "Waiting for the new replica to become a running voter."));
+  {
+    const auto status = master::CheckLiveReplicasForSplit(
+        tablet_id, *tablet->GetReplicaLocations(), FLAGS_replication_factor);
+    ASSERT_NOK(status);
+    ASSERT_STR_CONTAINS(status.ToString(), "over replicated");
+  }
+  ASSERT_EQ(itest::GetNumTabletsOfTableOnTS(leader_ts, table_->id()), 1);
+
+  // Remove one of the original followers to get back to RF voters; the split must now go through.
+  ASSERT_OK(itest::RemoveServer(
+      ts_map_[leader_id].get(), tablet_id, ts_map_[follower_id].get(), std::nullopt, kRpcTimeout));
+  ASSERT_OK(itest::WaitForTabletConfigChange(tablet, follower_id, consensus::REMOVE_SERVER));
+  ASSERT_OK(WaitForTabletSplitCompletion(2));
+}
+
 TEST_F(AutomaticTabletSplitAddServerITest, DoNotSplitOverReplicatedTablet) {
   // Test should not schedule automatic tablet split on over-replicated tablet.
 

--- a/src/yb/integration-tests/tablet-split-itest.cc
+++ b/src/yb/integration-tests/tablet-split-itest.cc
@@ -2310,63 +2310,12 @@ class  AutomaticTabletSplitAddServerITest: public AutomaticTabletSplitITest {
 };
 
 TEST_F(AutomaticTabletSplitAddServerITest, DoNotSplitTabletDoingRBS) {
-  // Test should not schedule automatic tablet split on tablet in progress of remote bootstrap.
-
-  CreateSingleTablet();
-  ASSERT_OK(WriteRows());
-
-  BuildTServerMap();
-
-  const auto catalog_mgr = ASSERT_RESULT(catalog_manager());
-  const auto tablet = ASSERT_RESULT(GetSingleTestTabletInfo(catalog_mgr));
-  const auto tablet_id = tablet->id();
-  const auto leader_idx = ASSERT_RESULT(GetLeaderIdx(tablet));
-  const auto leader_ts = cluster_->mini_tablet_server(leader_idx)->server();
-  const auto leader_id = leader_ts->permanent_uuid();
-  const auto follower_idx = (leader_idx + 1) % 3;
-  const auto follower_id = cluster_->mini_tablet_server(follower_idx)->server()->permanent_uuid();
-  LOG(INFO) << "Source tablet id " << tablet_id;
-
-  // Remove tablet from follower to let tablet live replicas == table replication factor
-  // after adding a new tserver.
-  ASSERT_OK(itest::RemoveServer(
-      ts_map_[leader_id].get(), tablet_id, ts_map_[follower_id].get(), std::nullopt, kRpcTimeout));
-  ASSERT_OK(itest::WaitForTabletConfigChange(tablet, follower_id, consensus::REMOVE_SERVER));
-
-  // Start rbs on it but pause before downloading wal.
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_rbs_before_download_wal) = true;
-
-  // Create a new tserver and add tablet to it. By adding it as PRE_VOTER, it will be promoted
-  // to be VOTER and will participate in raft consensus.
-  AddTabletToNewTServer(tablet_id, leader_id, consensus::PeerMemberType::PRE_VOTER);
-
-  const auto new_ts_idx = cluster_->num_tablet_servers() - 1;
-  const auto new_tserver = cluster_->mini_tablet_server(new_ts_idx);
-  const auto new_ts_id = new_tserver->server()->permanent_uuid();
-
-  // Wait for the first heartbeat from new tserver to update the replica state to NOT_STARTED.
-  ASSERT_OK(itest::WaitUntilTabletInState(tablet, new_ts_id, tablet::NOT_STARTED));
-
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_automatic_tablet_splitting) = true;
-
-  // Fail to split because tablet is doing RBS and under replication.
-  ASSERT_NOK(master::CheckLiveReplicasForSplit(
-      tablet_id, *tablet->GetReplicaLocations(), FLAGS_replication_factor));
-  ASSERT_EQ(itest::GetNumTabletsOfTableOnTS(leader_ts, table_->id()), 1);
-
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_rbs_before_download_wal) = false;
-
-  // Should succeed to split since RBS is done.
-  ASSERT_OK(WaitForTabletSplitCompletion(2));
-}
-
-TEST_F(AutomaticTabletSplitAddServerITest, DoNotSplitFullyReplicatedTabletDoingRBS) {
   // A tablet that already has RF running voters must not be split while a fourth replica is being
   // remote bootstrapped as PRE_VOTER. While the copy is in progress the destination reports the
   // peer without a consensus state, so the master records it with member type UNKNOWN_MEMBER_TYPE
-  // rather than PRE_VOTER, and the check must not depend on seeing PRE_VOTER. Unlike
-  // DoNotSplitTabletDoingRBS, no voter is removed first, so the under-replication path does not
-  // apply here.
+  // rather than PRE_VOTER, and the check must not depend on seeing PRE_VOTER. No voter is removed
+  // before the RBS starts: an earlier version of this test did that, so its refusal came from the
+  // under-replication branch and the bootstrapping replica was never what blocked the split.
 
   CreateSingleTablet();
   ASSERT_OK(WriteRows());
@@ -2431,14 +2380,23 @@ TEST_F(AutomaticTabletSplitAddServerITest, DoNotSplitFullyReplicatedTabletDoingR
   ASSERT_EQ(itest::GetNumTabletsOfTableOnTS(leader_ts, table_->id()), 1);
 
   // Let the RBS finish. The new peer is promoted to VOTER, which makes the tablet over-replicated,
-  // so still no split.
+  // so still no split. The promotion is another config change that rebuilds the replica map, so
+  // wait until all four replicas are running voters again, not just the new one; otherwise the
+  // check may refuse for "not running" rather than for over-replication.
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_rbs_before_download_wal) = false;
   ASSERT_OK(WaitFor([&]() -> Result<bool> {
     const auto replicas = tablet->GetReplicaLocations();
-    const auto it = replicas->find(new_ts_id);
-    return it != replicas->end() && it->second.member_type == consensus::PeerMemberType::VOTER &&
-           it->second.state == tablet::RaftGroupStatePB::RUNNING;
-  }, 60s * kTimeMultiplier, "Waiting for the new replica to become a running voter."));
+    if (replicas->size() != 4) {
+      return false;
+    }
+    for (const auto& [ts_uuid, replica] : *replicas) {
+      if (replica.member_type != consensus::PeerMemberType::VOTER ||
+          replica.state != tablet::RaftGroupStatePB::RUNNING) {
+        return false;
+      }
+    }
+    return true;
+  }, 60s * kTimeMultiplier, "Waiting for all four replicas to be running voters."));
   {
     const auto status = master::CheckLiveReplicasForSplit(
         tablet_id, *tablet->GetReplicaLocations(), FLAGS_replication_factor);

--- a/src/yb/integration-tests/tablet-split-itest.cc
+++ b/src/yb/integration-tests/tablet-split-itest.cc
@@ -2371,7 +2371,7 @@ TEST_F(AutomaticTabletSplitAddServerITest, DoNotSplitTabletDoingRBS) {
     const auto status = master::CheckLiveReplicasForSplit(
         tablet_id, *tablet->GetReplicaLocations(), FLAGS_replication_factor);
     ASSERT_NOK(status);
-    ASSERT_STR_CONTAINS(status.ToString(), "being bootstrapped");
+    ASSERT_STR_CONTAINS(status.ToString(), "is not running or is being bootstrapped");
   }
 
   // Let the split manager run a few times; nothing must be split while the RBS is paused.

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -3452,6 +3452,23 @@ Status CatalogManager::DoSplitTablet(
             source_tablet_info->tablet_id(),
             status);
       }
+
+      // Re-check the replica set right before the children are registered. The same check ran when
+      // the candidate was picked, up to a background-task interval ago, and a replica add (remote
+      // bootstrap) may have started since. Children are created with the parent's committed Raft
+      // config, so splitting now would copy the bootstrapping peer into both children.
+      const auto replication_info =
+          VERIFY_RESULT(GetTableReplicationInfoNoDefault(source_tablet_info->table()));
+      status = CheckLiveReplicasForSplit(
+          source_tablet_info->tablet_id(), *source_tablet_info->GetReplicaLocations(),
+          CatalogManagerUtil::GetReplicationFactor(replication_info));
+      if (!status.ok()) {
+        return STATUS_FORMAT(
+            InvalidArgument,
+            "Tablet split candidate $0 is no longer a valid split candidate: $1",
+            source_tablet_info->tablet_id(),
+            status);
+      }
     }
     // After this point, we expect to split the tablet.
 

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -3109,6 +3109,14 @@ Status CatalogManager::ShouldSplitValidCandidate(
       tablet_info.table(), GetTablespaceManager(),
       ClusterConfig()->LockForRead()->pb.replication_info()));
 
+  // The tablet must have exactly rf running voters and no replica being remote bootstrapped, so
+  // that the split does not copy a bootstrapping peer into the children's Raft configs. Since this
+  // function runs both when a candidate is picked and again in DoSplitTablet right before the
+  // children are registered, a replica add that starts in between is caught as well.
+  RETURN_NOT_OK(CheckLiveReplicasForSplit(
+      tablet_info.id(), *tablet_info.GetReplicaLocations(),
+      CatalogManagerUtil::GetReplicationFactor(table_replication_info)));
+
   // If there is custom placement information present then
   // only count the tservers which the table has access to
   // according to the placement policy
@@ -3445,23 +3453,6 @@ Status CatalogManager::DoSplitTablet(
       // longer be a valid candidate. This is not an unexpected error, but we should bail out of
       // splitting this tablet regardless.
       Status status = ShouldSplitValidCandidate(*source_tablet_info, drive_info);
-      if (!status.ok()) {
-        return STATUS_FORMAT(
-            InvalidArgument,
-            "Tablet split candidate $0 is no longer a valid split candidate: $1",
-            source_tablet_info->tablet_id(),
-            status);
-      }
-
-      // Re-check the replica set right before the children are registered. The same check ran when
-      // the candidate was picked, up to a background-task interval ago, and a replica add (remote
-      // bootstrap) may have started since. Children are created with the parent's committed Raft
-      // config, so splitting now would copy the bootstrapping peer into both children.
-      const auto replication_info =
-          VERIFY_RESULT(GetTableReplicationInfoNoDefault(source_tablet_info->table()));
-      status = CheckLiveReplicasForSplit(
-          source_tablet_info->tablet_id(), *source_tablet_info->GetReplicaLocations(),
-          CatalogManagerUtil::GetReplicationFactor(replication_info));
       if (!status.ok()) {
         return STATUS_FORMAT(
             InvalidArgument,

--- a/src/yb/master/tablet_split_manager.cc
+++ b/src/yb/master/tablet_split_manager.cc
@@ -554,33 +554,55 @@ std::unordered_set<TabletServerId> GetReplicasWithOutstandingCompaction(
   return tservers_with_outstanding_compaction;
 }
 
-// Check if all live replicas are in RaftGroupStatePB::RUNNING state
-// (read replicas are ignored) and tablet is not under/over replicated.
-// Tablet is over-replicated if number of live replicas > rf,
-// otherwise, if live replicas < rf, tablet is under replicated.
-// where rf is the replication factor of a table, can get it from
-// CatalogManager::GetTableReplicationFactor.
+// Check that no replica of the tablet is being bootstrapped, that every replica other than read
+// replicas (OBSERVER) is a RUNNING voter, and that the number of voters equals rf, the table's
+// replication factor.
+//
+// A replica in NOT_STARTED or BOOTSTRAPPING state blocks the split whatever its member type: that
+// is how the master sees a remote bootstrap in progress, for a new peer (PRE_VOTER or PRE_OBSERVER)
+// as well as for an existing peer being re-bootstrapped in place. The check deliberately does not
+// look for PRE_VOTER specifically: while a peer is being remote bootstrapped, the destination
+// reports it without a consensus state, and the master then records it with member type
+// UNKNOWN_MEMBER_TYPE (see MasterHeartbeatServiceImpl::CreateNewReplicaForLocalMemory), so a
+// PRE_VOTER test alone lets a tablet with rf running voters plus one bootstrapping replica
+// through. Splitting such a tablet copies the bootstrapping peer into both children's Raft
+// configs, so each child then needs its own remote bootstrap too.
+//
+// A voter whose state is not RUNNING for any other reason (e.g. UNKNOWN right after a config change
+// until the peer reports again, or a peer that is shutting down) blocks the split as well; those
+// states are transient or already unhealthy.
 Status CheckLiveReplicasForSplit(
     const TabletId& tablet_id, const TabletReplicaMap& replicas, size_t rf) {
   size_t live_replicas = 0;
   for (const auto& [ts_uuid, replica] : replicas) {
-    if (replica.member_type == consensus::PRE_VOTER) {
+    if (replica.IsStarting()) {
       return STATUS_FORMAT(NotSupported,
-                           "One tablet peer is doing RBS as PRE_VOTER, "
-                           "tablet_id: $1, peer_uuid: $2, current RAFT state: $3",
-                            tablet_id, ts_uuid,
-                            RaftGroupStatePB_Name(replica.state));
+                           "At least one tablet peer is being bootstrapped, "
+                           "tablet_id: $0, peer_uuid: $1, member type: $2, current RAFT state: $3",
+                           tablet_id, ts_uuid,
+                           consensus::PeerMemberType_Name(replica.member_type),
+                           RaftGroupStatePB_Name(replica.state));
     }
-    if (replica.member_type == consensus::VOTER) {
-      live_replicas++;
-      if (replica.state != tablet::RaftGroupStatePB::RUNNING) {
-        return STATUS_FORMAT(NotSupported,
-                             "At least one tablet peer not running, "
-                             "tablet_id: $0, peer_uuid: $1, current RAFT state: $2",
-                             tablet_id, ts_uuid,
-                             RaftGroupStatePB_Name(replica.state));
-      }
+    if (replica.member_type == consensus::OBSERVER) {
+      continue;
     }
+    if (replica.state != tablet::RaftGroupStatePB::RUNNING) {
+      return STATUS_FORMAT(NotSupported,
+                           "At least one tablet peer not running, "
+                           "tablet_id: $0, peer_uuid: $1, member type: $2, current RAFT state: $3",
+                           tablet_id, ts_uuid,
+                           consensus::PeerMemberType_Name(replica.member_type),
+                           RaftGroupStatePB_Name(replica.state));
+    }
+    if (replica.member_type != consensus::VOTER) {
+      return STATUS_FORMAT(NotSupported,
+                           "One tablet peer is not a voter (being added or remote bootstrapped), "
+                           "tablet_id: $0, peer_uuid: $1, member type: $2, current RAFT state: $3",
+                           tablet_id, ts_uuid,
+                           consensus::PeerMemberType_Name(replica.member_type),
+                           RaftGroupStatePB_Name(replica.state));
+    }
+    live_replicas++;
   }
   if (live_replicas != rf) {
     return STATUS_FORMAT(NotSupported,

--- a/src/yb/master/tablet_split_manager.cc
+++ b/src/yb/master/tablet_split_manager.cc
@@ -920,14 +920,6 @@ void TabletSplitManager::DoSplitting(
 
   for (const auto& table : valid_tables) {
     VLOG(3) << Format("Processing table $0 for split", table->id());
-    auto replication_info = catalog_manager_.GetTableReplicationInfoNoDefault(table);
-    if (!replication_info.ok()) {
-      YB_LOG_EVERY_N_SECS(WARNING, 30) << "Skipping tablet splitting for table "
-                                       << table->id() << ": "
-                                       << "as fetching replication info failed with error "
-                                       << StatusToString(replication_info.status());
-      continue;
-    }
     auto tablets_result = table->GetTablets();
     if (!tablets_result) continue;
     for (const auto& tablet : *tablets_result) {

--- a/src/yb/master/tablet_split_manager.cc
+++ b/src/yb/master/tablet_split_manager.cc
@@ -575,24 +575,20 @@ Status CheckLiveReplicasForSplit(
     const TabletId& tablet_id, const TabletReplicaMap& replicas, size_t rf) {
   size_t live_replicas = 0;
   for (const auto& [ts_uuid, replica] : replicas) {
-    if (replica.IsStarting()) {
+    // A read replica (OBSERVER) is ignored unless it is being bootstrapped right now; every other
+    // replica has to be RUNNING.
+    const bool is_read_replica = replica.member_type == consensus::OBSERVER;
+    if (replica.IsStarting() ||
+        (!is_read_replica && replica.state != tablet::RaftGroupStatePB::RUNNING)) {
       return STATUS_FORMAT(NotSupported,
-                           "At least one tablet peer is being bootstrapped, "
+                           "At least one tablet peer is not running or is being bootstrapped, "
                            "tablet_id: $0, peer_uuid: $1, member type: $2, current RAFT state: $3",
                            tablet_id, ts_uuid,
                            consensus::PeerMemberType_Name(replica.member_type),
                            RaftGroupStatePB_Name(replica.state));
     }
-    if (replica.member_type == consensus::OBSERVER) {
+    if (is_read_replica) {
       continue;
-    }
-    if (replica.state != tablet::RaftGroupStatePB::RUNNING) {
-      return STATUS_FORMAT(NotSupported,
-                           "At least one tablet peer not running, "
-                           "tablet_id: $0, peer_uuid: $1, member type: $2, current RAFT state: $3",
-                           tablet_id, ts_uuid,
-                           consensus::PeerMemberType_Name(replica.member_type),
-                           RaftGroupStatePB_Name(replica.state));
     }
     if (replica.member_type != consensus::VOTER) {
       return STATUS_FORMAT(NotSupported,
@@ -932,7 +928,6 @@ void TabletSplitManager::DoSplitting(
                                        << StatusToString(replication_info.status());
       continue;
     }
-    auto replication_factor = CatalogManagerUtil::GetReplicationFactor(*replication_info);
     auto tablets_result = table->GetTablets();
     if (!tablets_result) continue;
     for (const auto& tablet : *tablets_result) {
@@ -992,8 +987,6 @@ void TabletSplitManager::DoSplitting(
         RETURN_NOT_OK(catalog_manager_.ShouldSplitValidCandidate(*tablet, drive_info_opt.get()));
 
         const auto replicas = replica_cache.GetOrAdd(*tablet);
-        RETURN_NOT_OK(
-            CheckLiveReplicasForSplit(tablet->tablet_id(), *replicas, replication_factor));
         const auto tservers_with_outstanding_compaction =
             GetReplicasWithOutstandingCompaction(*replicas);
         if (!tservers_with_outstanding_compaction.empty()) {


### PR DESCRIPTION
## Summary

`CheckLiveReplicasForSplit` is meant to keep the master from splitting a tablet while one of its replicas is being remote bootstrapped, but it only rejected replicas whose member type is `PRE_VOTER`. While a peer is being remote bootstrapped, the destination reports it without a consensus state, and the master records it with member type `UNKNOWN_MEMBER_TYPE` and state `NOT_STARTED` or `BOOTSTRAPPING`, so a tablet with RF running voters plus one bootstrapping replica passed the check. The children of such a split are created with the parent's committed Raft config, bootstrapping peer included, so each child then needs its own remote bootstrap, and the parent cannot be deleted until that bootstrap finishes.

The check now rejects any replica in `NOT_STARTED` or `BOOTSTRAPPING` state regardless of member type and requires every remaining non-read-replica to be a `RUNNING` voter. It runs from `ShouldSplitValidCandidate`, which is evaluated both when a candidate is picked and again in `DoSplitTablet` right before the children are registered, so a replica add that starts in between is caught too. This narrows the exposure from the whole bootstrap to the heartbeat lag between a config change committing on the leader and the master hearing about it; the complete fix is a Raft-side guard that refuses a `SPLIT_OP` while the committed config contains a non-voter, tracked in #33874 as a follow-up.

Until now the default `may_have_orphaned_post_split_data` of a never-reported replica happened to block these splits on the candidate path; D57694 removes that for non-voters, so this change should land before or together with it. A tablet whose non-voter never finishes bootstrapping now stays unsplittable, visible only at VLOG(4); #33295 covers logging such rejections at INFO.

`DoNotSplitTabletDoingRBS` is rewritten rather than joined by a new test: its previous body removed a follower before starting the bootstrap, so its refusal came from the under-replication branch and the bootstrapping replica was never what blocked the split. The new body keeps RF running voters, so on the previous check it fails.

## Test Plan

```
./yb_build.sh --cxx-test tablet-split-itest --gtest_filter AutomaticTabletSplitAddServerITest.DoNotSplitTabletDoingRBS
./yb_build.sh --cxx-test tablet-split-itest --gtest_filter 'AutomaticTabletSplitAddServerITest.*'
```

The rewritten test adds a fourth replica as `PRE_VOTER` with the bootstrap paused, waits for the destination's own heartbeat and for the original replicas to report `RUNNING` again, and checks that the split is refused because of the bootstrapping peer, then refused as over-replicated after promotion, then completes once a follower is removed. Verified that it fails against master without the fix (the check returns OK with the master's entry logged as `UNKNOWN_MEMBER_TYPE`, `NOT_STARTED`).
