### PR TITLE
[BACKPORT 2024.2][DEVOPS-3901] build: Add selector keywords to jenkins_jobs.yml (#33555)

### DIFF
--- a/jenkins_jobs.yml
+++ b/jenkins_jobs.yml
@@ -1,33 +1,52 @@
 # This file determines the jobs that we run in this branch on Jenkins.
 # Default architecture is x86_64
+#
+# when selectors:
+#   change - run by default for DB changes
+#   full - run for full official build
+#
+
 jobs:
   - os: alma8
     compiler: clang17
     build_type: asan
     release_artifact: false
+    when:
+     - change
+     - full
 
   - os: alma8
     compiler: clang17
     build_type: tsan
     release_artifact: false
+    when:
+     - full
 
   - os: alma8
     compiler: gcc11
     build_type: fastdebug
     test_opts: YB_TEST_YB_CONTROLLER=0
     release_artifact: false
+    when:
+     - change
+     - full
 
   - os: alma8
     compiler: clang17
     build_type: release
     build_opts: YB_LINKING_TYPE=full-lto
     release_artifact: true
+    when:
+     - change
+     - full
 
   - os: alma8
     compiler: clang17
     build_type: release
     architecture: aarch64
     release_artifact: true
+    when:
+     - full
 
   - os: mac14
     compiler: clang
@@ -35,6 +54,8 @@ jobs:
     architecture: arm64
     test_opts: YB_TEST_YB_CONTROLLER=0
     release_artifact: true
+    when:
+     - full
 
   - os: mac14
     compiler: clang
@@ -42,9 +63,13 @@ jobs:
     architecture: x86_64
     test_opts: YB_COMPILE_ONLY=1
     release_artifact: true
+    when:
+     - full
 
   - os: ubuntu22.04
     compiler: clang17
     build_type: debug
     release_artifact: false
     test_opts: YB_COMPILE_ONLY=1
+    when:
+     - full


### PR DESCRIPTION
Build list can by differentiated for full official builds and change testing.
Reduces the number of builds for pre-merge / pre-landing testing.

Future use may include some build/test combinations that only apply to
changes and not full builds, such as smoke/subset testing by combining
"when" keywords with test_opts.

Original commit: 65d6873a4c288f7a6cf9abf6fe826be01fb7cc81 / #33555
