### PR TITLE
[#33767] DocDB: per-tablet in-memory aggregate for SST statistics

### DIFF
--- a/src/yb/docdb/docdb_fwd.h
+++ b/src/yb/docdb/docdb_fwd.h
@@ -54,6 +54,7 @@ class RedisWriteOperation;
 class ScanChoices;
 class SchemaPackingProvider;
 class SharedLockManager;
+class SstStatsAggregator;
 class StorageSet;
 class TableInfoProvider;
 class TransactionStatusCache;

--- a/src/yb/docdb/properties_collector/CMakeLists.txt
+++ b/src/yb/docdb/properties_collector/CMakeLists.txt
@@ -20,6 +20,7 @@ set(YB_PCH_PATH ../)
 set(DOCDB_PROPERTIES_COLLECTOR_SRCS
     chain_tracker.cc
     exponential_histogram.cc
+    sst_stats_aggregator.cc
     sst_stats_collector.cc
     )
 
@@ -38,4 +39,5 @@ set(YB_TEST_LINK_LIBS yb_docdb_properties_collector ${YB_MIN_TEST_LIBS})
 
 ADD_YB_TEST(chain_tracker-test)
 ADD_YB_TEST(exponential_histogram-test)
+ADD_YB_TEST(sst_stats_aggregator-test)
 ADD_YB_TEST(sst_stats_collector-test)

--- a/src/yb/docdb/properties_collector/README.md
+++ b/src/yb/docdb/properties_collector/README.md
@@ -171,11 +171,23 @@ Per row: one `DocKey::EncodedSize` walk, up to a handful of covering-write decod
 histogram increments. No allocation in steady state, no atomics, no floating point. The acceptance
 bar is end-to-end flush and compaction throughput with the flag on versus off.
 
+## The tablet aggregate
+
+`SstStatsAggregator` sums the additive scalars over one tablet's live files. It is maintained from
+the tablet's RocksDB event listener and resynced periodically from `DB::GetPropertiesOfAllTables`
+(`TableProperties::Add` drops `user_collected_properties`, so the built-in aggregation cannot be
+used). Both paths are needed: the listener because a full compaction that reclaims the garbage must
+be visible to the trigger at once rather than a resync interval later, the resync because the file
+set also changes without any event -- DB open, remote bootstrap, snapshot restore, split
+inheritance.
+
+The distributions do not aggregate this way. Bucket-wise merging is exact, but a set of files that
+shrinks needs subtraction, and five resident 145-bucket vectors cost ~5.8 KB per tablet against
+~250 bytes for the scalars, so tablet-level distributions are built on demand instead.
+
 ## Boundaries
 
-This component only produces the per-file record. Its consumers are separate: a per-tablet
-in-memory aggregate fed by the RocksDB listener (`TableProperties::Add` does not merge
-`user_collected_properties`, so aggregation goes through `SstStatsFromProperties`), the
+This component produces the per-file record and the per-tablet sum of it. The rest is separate: the
 `docdb_sst_*` Prometheus gauges for humans (additive scalars only; this metrics system exports no
 bucket vectors), and a full-compaction trigger clause that reads the aggregate directly. Every
 consumer must account for **coverage**: files that predate the collector carry no statistics, and a

--- a/src/yb/docdb/properties_collector/sst_stats_aggregator-test.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_aggregator-test.cc
@@ -1,0 +1,273 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/docdb/properties_collector/sst_stats_aggregator.h"
+
+#include "yb/docdb/properties_collector/sst_stats_collector.h"
+
+#include "yb/rocksdb/db/filename.h"
+
+#include "yb/util/test_util.h"
+
+namespace yb::docdb {
+
+namespace {
+
+constexpr auto kDbPath = "/db";
+
+std::string PathOf(uint64_t file_number) {
+  return rocksdb::MakeTableFileName(kDbPath, file_number);
+}
+
+rocksdb::LiveFileMetaData LiveFile(uint64_t file_number) {
+  return rocksdb::LiveFileMetaData(
+      "default", /* level = */ 0, file_number, kDbPath, /* total_size = */ 0, /* base_size = */ 0,
+      /* uncompressed_size = */ 0, {}, {}, /* imported = */ false, /* being_compacted = */ false);
+}
+
+// A file holding `entries` entries of which `reclaimable` are garbage, all in one age band.
+SstStats FileStats(uint64_t entries, uint64_t reclaimable) {
+  SstStats stats;
+  stats.total_entries = entries;
+  stats.chain_entries = entries;
+  stats.num_subdoc_keys = entries / 2;
+  stats.num_rows = entries / 4;
+  stats.reclaimable_entries = reclaimable;
+  stats.reclaimable_bytes = reclaimable * 10;
+  stats.droppable_age_entries[3] = reclaimable;
+  stats.droppable_age_bytes[3] = reclaimable * 10;
+  return stats;
+}
+
+// `stats == nullptr` builds a file that predates the collector: built-in properties only.
+rocksdb::TableProperties FileProperties(
+    uint64_t entries, uint64_t raw_bytes, const SstStats* stats) {
+  rocksdb::TableProperties properties;
+  properties.num_entries = entries;
+  properties.raw_key_size = raw_bytes / 2;
+  properties.raw_value_size = raw_bytes - raw_bytes / 2;
+  if (stats != nullptr) {
+    SstStatsToProperties(*stats, &properties.user_collected_properties);
+  }
+  return properties;
+}
+
+rocksdb::TableProperties CoveredFile(uint64_t entries, uint64_t reclaimable) {
+  const auto stats = FileStats(entries, reclaimable);
+  return FileProperties(entries, entries * 20, &stats);
+}
+
+rocksdb::TableProperties UncoveredFile(uint64_t entries) {
+  return FileProperties(entries, entries * 20, nullptr);
+}
+
+rocksdb::FlushJobInfo FlushOf(uint64_t file_number, rocksdb::TableProperties properties) {
+  rocksdb::FlushJobInfo info{};
+  info.file_path = PathOf(file_number);
+  info.table_properties = std::move(properties);
+  return info;
+}
+
+// A file named in an event or a live file list. Null properties stand for a file whose properties
+// the caller could not produce: an input a compaction event did not carry, or a file whose
+// properties block could not be read.
+using FileEntry = std::pair<uint64_t, const rocksdb::TableProperties*>;
+using FileEntries = std::vector<FileEntry>;
+
+void AddFiles(
+    const FileEntries& files, std::vector<std::string>* paths,
+    rocksdb::TablePropertiesCollection* properties) {
+  for (const auto& [file_number, file_properties] : files) {
+    const auto path = PathOf(file_number);
+    paths->push_back(path);
+    if (file_properties != nullptr) {
+      (*properties)[path] = std::make_shared<rocksdb::TableProperties>(*file_properties);
+    }
+  }
+}
+
+rocksdb::CompactionJobInfo CompactionOf(const FileEntries& inputs, const FileEntries& outputs) {
+  rocksdb::CompactionJobInfo info;
+  AddFiles(inputs, &info.input_files, &info.table_properties);
+  AddFiles(outputs, &info.output_files, &info.table_properties);
+  return info;
+}
+
+SstStatsAggregator::SnapshotFn SnapshotOf(FileEntries files) {
+  return [files = std::move(files)](
+      std::vector<rocksdb::LiveFileMetaData>* live_files,
+      rocksdb::TablePropertiesCollection* properties) {
+    std::vector<std::string> paths;
+    AddFiles(files, &paths, properties);
+    for (const auto& [file_number, file_properties] : files) {
+      live_files->push_back(LiveFile(file_number));
+    }
+    return Status::OK();
+  };
+}
+
+}  // namespace
+
+class SstStatsAggregatorTest : public YBTest {};
+
+TEST_F(SstStatsAggregatorTest, FileContribution) {
+  const auto covered =
+      SstFileContribution(CoveredFile(/* entries = */ 100, /* reclaimable = */ 40));
+  EXPECT_EQ(covered.total_entries, 100);
+  EXPECT_EQ(covered.reclaimable_entries, 40);
+  EXPECT_EQ(covered.reclaimable_bytes, 400);
+  EXPECT_EQ(covered.droppable_age_entries[3], 40);
+  EXPECT_EQ(covered.covered_files, 1);
+  EXPECT_EQ(covered.covered_raw_bytes, 2000);
+  EXPECT_EQ(covered.uncovered_files, 0);
+  EXPECT_EQ(covered.partial_files, 0);
+
+  // A file that predates the collector contributes no garbage, only the denominator it withholds.
+  const auto uncovered = SstFileContribution(UncoveredFile(/* entries = */ 100));
+  EXPECT_EQ(uncovered.total_entries, 0);
+  EXPECT_EQ(uncovered.covered_files, 0);
+  EXPECT_EQ(uncovered.uncovered_files, 1);
+  EXPECT_EQ(uncovered.uncovered_entries, 100);
+  EXPECT_EQ(uncovered.uncovered_raw_bytes, 2000);
+
+  auto partial_stats = FileStats(/* entries = */ 10, /* reclaimable = */ 2);
+  partial_stats.chain_valid = false;
+  const auto partial = SstFileContribution(FileProperties(10, 200, &partial_stats));
+  EXPECT_EQ(partial.covered_files, 1);
+  EXPECT_EQ(partial.partial_files, 1);
+}
+
+TEST_F(SstStatsAggregatorTest, AddAndSubtract) {
+  const auto one = SstFileContribution(CoveredFile(/* entries = */ 100, /* reclaimable = */ 40));
+  const auto two = SstFileContribution(CoveredFile(/* entries = */ 60, /* reclaimable = */ 10));
+
+  auto sum = one;
+  sum += two;
+  EXPECT_EQ(sum.total_entries, 160);
+  EXPECT_EQ(sum.reclaimable_entries, 50);
+  EXPECT_EQ(sum.droppable_age_entries[3], 50);
+  EXPECT_EQ(sum.covered_files, 2);
+
+  sum -= two;
+  EXPECT_EQ(sum, one);
+
+  // Saturating: a subtraction that was never matched by an addition must not wrap.
+  sum -= two;
+  sum -= two;
+  EXPECT_EQ(sum.total_entries, 0);
+  EXPECT_EQ(sum.covered_files, 0);
+}
+
+TEST_F(SstStatsAggregatorTest, FlushAndCompaction) {
+  SstStatsAggregator aggregator;
+  const auto first = CoveredFile(/* entries = */ 100, /* reclaimable = */ 40);
+  const auto second = CoveredFile(/* entries = */ 60, /* reclaimable = */ 10);
+  aggregator.OnFlushCompleted(FlushOf(1, first));
+  aggregator.OnFlushCompleted(FlushOf(2, second));
+  EXPECT_EQ(aggregator.Get().aggregate.total_entries, 160);
+  EXPECT_EQ(aggregator.Get().aggregate.covered_files, 2);
+  // Nothing has looked at the whole file set yet.
+  EXPECT_EQ(aggregator.Get().last_resync_micros, 0);
+
+  // A flush replayed on a file already counted must not count it twice.
+  aggregator.OnFlushCompleted(FlushOf(1, first));
+  EXPECT_EQ(aggregator.Get().aggregate.total_entries, 160);
+
+  const auto merged = CoveredFile(/* entries = */ 120, /* reclaimable = */ 5);
+  aggregator.OnCompactionCompleted(
+      CompactionOf({{1, &first}, {2, &second}}, {{3, &merged}}));
+  const auto after = aggregator.Get().aggregate;
+  EXPECT_EQ(after.total_entries, 120);
+  EXPECT_EQ(after.reclaimable_entries, 5);
+  EXPECT_EQ(after.covered_files, 1);
+  EXPECT_EQ(after.unsubtracted_files, 0);
+}
+
+TEST_F(SstStatsAggregatorTest, FailedCompactionLeavesInputsCounted) {
+  SstStatsAggregator aggregator;
+  const auto file = CoveredFile(/* entries = */ 100, /* reclaimable = */ 40);
+  aggregator.OnFlushCompleted(FlushOf(1, file));
+
+  auto info = CompactionOf({{1, &file}}, {{2, &file}});
+  info.status = STATUS(IOError, "compaction failed");
+  aggregator.OnCompactionCompleted(info);
+  EXPECT_EQ(aggregator.Get().aggregate.total_entries, 100);
+  EXPECT_EQ(aggregator.Get().aggregate.covered_files, 1);
+}
+
+TEST_F(SstStatsAggregatorTest, CompactionWithoutInputProperties) {
+  SstStatsAggregator aggregator;
+  const auto file = CoveredFile(/* entries = */ 100, /* reclaimable = */ 40);
+  const auto output = CoveredFile(/* entries = */ 90, /* reclaimable = */ 5);
+  aggregator.OnFlushCompleted(FlushOf(1, file));
+
+  aggregator.OnCompactionCompleted(CompactionOf({{1, nullptr}}, {{2, &output}}));
+  const auto after = aggregator.Get().aggregate;
+  // The consumed file's statistics stay in the sums, and the counter says so.
+  EXPECT_EQ(after.total_entries, 190);
+  EXPECT_EQ(after.unsubtracted_files, 1);
+}
+
+TEST_F(SstStatsAggregatorTest, CompactionOfUncountedFile) {
+  SstStatsAggregator aggregator;
+  const auto inherited = CoveredFile(/* entries = */ 100, /* reclaimable = */ 40);
+  const auto output = CoveredFile(/* entries = */ 90, /* reclaimable = */ 5);
+  // File 1 was never reported to the aggregator -- it was on disk before the tablet opened.
+  aggregator.OnCompactionCompleted(CompactionOf({{1, &inherited}}, {{2, &output}}));
+  const auto after = aggregator.Get().aggregate;
+  EXPECT_EQ(after.total_entries, 90);
+  EXPECT_EQ(after.covered_files, 1);
+  EXPECT_EQ(after.unsubtracted_files, 0);
+}
+
+TEST_F(SstStatsAggregatorTest, ResyncCountsUncoveredFiles) {
+  SstStatsAggregator aggregator;
+  const auto covered = CoveredFile(/* entries = */ 100, /* reclaimable = */ 40);
+  const auto uncovered = UncoveredFile(/* entries = */ 900);
+  ASSERT_OK(aggregator.Resync(SnapshotOf({{1, &covered}, {2, &uncovered}, {3, nullptr}})));
+
+  const auto snapshot = aggregator.Get();
+  EXPECT_GT(snapshot.last_resync_micros, 0);
+  EXPECT_EQ(snapshot.aggregate.total_entries, 100);
+  EXPECT_EQ(snapshot.aggregate.covered_files, 1);
+  // File 2 predates the collector; file 3's properties could not be read at all.
+  EXPECT_EQ(snapshot.aggregate.uncovered_files, 2);
+  EXPECT_EQ(snapshot.aggregate.uncovered_entries, 900);
+
+  // Resync is authoritative: it drops what the listener reported and the file set no longer has.
+  ASSERT_OK(aggregator.Resync(SnapshotOf({{1, &covered}})));
+  EXPECT_EQ(aggregator.Get().aggregate.uncovered_files, 0);
+}
+
+TEST_F(SstStatsAggregatorTest, ResyncOvertakenByFlushIsDropped) {
+  SstStatsAggregator aggregator;
+  const auto flushed = CoveredFile(/* entries = */ 100, /* reclaimable = */ 40);
+  const auto stale = CoveredFile(/* entries = */ 7, /* reclaimable = */ 7);
+
+  const auto status = aggregator.Resync(
+      [&](std::vector<rocksdb::LiveFileMetaData>* live_files,
+          rocksdb::TablePropertiesCollection* properties) {
+        // The file set the snapshot saw, before the flush that lands underneath it.
+        live_files->push_back(LiveFile(9));
+        (*properties)[PathOf(9)] = std::make_shared<rocksdb::TableProperties>(stale);
+        aggregator.OnFlushCompleted(FlushOf(1, flushed));
+        return Status::OK();
+      });
+  ASSERT_OK(status);
+
+  const auto snapshot = aggregator.Get();
+  EXPECT_EQ(snapshot.aggregate.total_entries, 100);
+  EXPECT_EQ(snapshot.last_resync_micros, 0);
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/sst_stats_aggregator.cc
+++ b/src/yb/docdb/properties_collector/sst_stats_aggregator.cc
@@ -1,0 +1,215 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/docdb/properties_collector/sst_stats_aggregator.h"
+
+#include "yb/docdb/properties_collector/sst_stats_collector.h"
+
+#include <algorithm>
+
+#include "yb/gutil/walltime.h"
+
+#include "yb/rocksdb/db/filename.h"
+
+#include "yb/util/logging.h"
+#include "yb/util/status.h"
+
+namespace yb::docdb {
+
+namespace {
+
+void AddTo(uint64_t& lhs, uint64_t rhs) { lhs += rhs; }
+
+void SubtractFrom(uint64_t& lhs, uint64_t rhs) {
+  DCHECK_GE(lhs, rhs);
+  lhs -= std::min(lhs, rhs);
+}
+
+// Applies `op` to every counter of the aggregate, pairing each with its counterpart in `other`.
+template <class Op>
+void ForEachCounter(SstStatsAggregate& lhs, const SstStatsAggregate& rhs, const Op& op) {
+  op(lhs.total_entries, rhs.total_entries);
+  op(lhs.tombstone_entries, rhs.tombstone_entries);
+  op(lhs.packed_row_entries, rhs.packed_row_entries);
+  op(lhs.meta_entries, rhs.meta_entries);
+  op(lhs.chain_entries, rhs.chain_entries);
+  op(lhs.chain_bytes, rhs.chain_bytes);
+  op(lhs.num_subdoc_keys, rhs.num_subdoc_keys);
+  op(lhs.num_rows, rhs.num_rows);
+  op(lhs.dead_rows, rhs.dead_rows);
+  op(lhs.dead_row_entries, rhs.dead_row_entries);
+  op(lhs.reclaimable_entries, rhs.reclaimable_entries);
+  op(lhs.reclaimable_bytes, rhs.reclaimable_bytes);
+  for (size_t i = 0; i < AgeBands::kNumBands; ++i) {
+    op(lhs.droppable_age_entries[i], rhs.droppable_age_entries[i]);
+    op(lhs.droppable_age_bytes[i], rhs.droppable_age_bytes[i]);
+  }
+  op(lhs.covered_files, rhs.covered_files);
+  op(lhs.covered_raw_bytes, rhs.covered_raw_bytes);
+  op(lhs.uncovered_files, rhs.uncovered_files);
+  op(lhs.uncovered_entries, rhs.uncovered_entries);
+  op(lhs.uncovered_raw_bytes, rhs.uncovered_raw_bytes);
+  op(lhs.partial_files, rhs.partial_files);
+  op(lhs.unsubtracted_files, rhs.unsubtracted_files);
+}
+
+// Zero for a path that is not an SST base file name, which no caller should produce: the events
+// and the live file list all name files through rocksdb::MakeTableFileName.
+uint64_t FileNumber(const std::string& path) { return rocksdb::TableFileNameToNumber(path); }
+
+const rocksdb::TableProperties* Lookup(
+    const rocksdb::TablePropertiesCollection& properties, const std::string& path) {
+  const auto it = properties.find(path);
+  return it == properties.end() ? nullptr : it->second.get();
+}
+
+}  // namespace
+
+SstStatsAggregate& SstStatsAggregate::operator+=(const SstStatsAggregate& other) {
+  ForEachCounter(*this, other, AddTo);
+  return *this;
+}
+
+SstStatsAggregate& SstStatsAggregate::operator-=(const SstStatsAggregate& other) {
+  ForEachCounter(*this, other, SubtractFrom);
+  return *this;
+}
+
+SstStatsAggregate SstFileContribution(const rocksdb::TableProperties& properties) {
+  SstStatsAggregate result;
+  const auto raw_bytes = properties.raw_key_size + properties.raw_value_size;
+  auto stats = SstStatsFromProperties(properties.user_collected_properties);
+  if (!stats.ok()) {
+    result.uncovered_files = 1;
+    result.uncovered_entries = properties.num_entries;
+    result.uncovered_raw_bytes = raw_bytes;
+    return result;
+  }
+  result.total_entries = stats->total_entries;
+  result.tombstone_entries = stats->tombstone_entries;
+  result.packed_row_entries = stats->packed_row_entries;
+  result.meta_entries = stats->meta_entries;
+  result.chain_entries = stats->chain_entries;
+  result.chain_bytes = stats->chain_bytes;
+  result.num_subdoc_keys = stats->num_subdoc_keys;
+  result.num_rows = stats->num_rows;
+  result.dead_rows = stats->dead_rows;
+  result.dead_row_entries = stats->dead_row_entries;
+  result.reclaimable_entries = stats->reclaimable_entries;
+  result.reclaimable_bytes = stats->reclaimable_bytes;
+  result.droppable_age_entries = stats->droppable_age_entries;
+  result.droppable_age_bytes = stats->droppable_age_bytes;
+  result.covered_files = 1;
+  result.covered_raw_bytes = raw_bytes;
+  result.partial_files = stats->chain_valid ? 0 : 1;
+  return result;
+}
+
+void SstStatsAggregator::AddFile(
+    uint64_t file_number, const rocksdb::TableProperties& properties) {
+  ++event_seqno_;
+  if (!counted_files_.insert(file_number).second) {
+    return;
+  }
+  aggregate_ += SstFileContribution(properties);
+}
+
+void SstStatsAggregator::RemoveFile(
+    uint64_t file_number, const rocksdb::TableProperties* properties) {
+  ++event_seqno_;
+  if (counted_files_.erase(file_number) == 0) {
+    return;
+  }
+  if (properties == nullptr) {
+    ++aggregate_.unsubtracted_files;
+    return;
+  }
+  aggregate_ -= SstFileContribution(*properties);
+}
+
+void SstStatsAggregator::OnFlushCompleted(const rocksdb::FlushJobInfo& info) {
+  const auto file_number = FileNumber(info.file_path);
+  if (file_number == 0) {
+    return;
+  }
+  std::lock_guard lock(mutex_);
+  AddFile(file_number, info.table_properties);
+}
+
+void SstStatsAggregator::OnCompactionCompleted(const rocksdb::CompactionJobInfo& info) {
+  if (!info.status.ok()) {
+    // The outputs were discarded and the inputs are still live.
+    return;
+  }
+  std::lock_guard lock(mutex_);
+  for (const auto& path : info.input_files) {
+    const auto file_number = FileNumber(path);
+    if (file_number != 0) {
+      RemoveFile(file_number, Lookup(info.table_properties, path));
+    }
+  }
+  for (const auto& path : info.output_files) {
+    const auto file_number = FileNumber(path);
+    const auto* properties = Lookup(info.table_properties, path);
+    // An output whose properties the event did not carry is left unknown rather than counted as
+    // uncovered: resync will pick it up, and until then a file absent from counted_files_ is one
+    // no later compaction will try to subtract.
+    if (file_number != 0 && properties != nullptr) {
+      AddFile(file_number, *properties);
+    }
+  }
+}
+
+Status SstStatsAggregator::Resync(const SnapshotFn& snapshot) {
+  uint64_t seqno_before;
+  {
+    std::lock_guard lock(mutex_);
+    seqno_before = event_seqno_;
+  }
+
+  std::vector<rocksdb::LiveFileMetaData> live_files;
+  rocksdb::TablePropertiesCollection properties;
+  RETURN_NOT_OK(snapshot(&live_files, &properties));
+
+  SstStatsAggregate aggregate;
+  std::unordered_set<uint64_t> counted_files;
+  counted_files.reserve(live_files.size());
+  for (const auto& file : live_files) {
+    counted_files.insert(file.name_id);
+    const auto* file_properties = Lookup(properties, file.BaseFilePath());
+    if (file_properties == nullptr) {
+      // Properties that could not be read at all: still count the file, so that a consumer sees
+      // the tablet is not fully measured. Its entries and bytes are simply unknown.
+      ++aggregate.uncovered_files;
+      continue;
+    }
+    aggregate += SstFileContribution(*file_properties);
+  }
+
+  std::lock_guard lock(mutex_);
+  if (event_seqno_ != seqno_before) {
+    VLOG(1) << "Dropping SST statistics resync overtaken by a flush or compaction";
+    return Status::OK();
+  }
+  aggregate_ = aggregate;
+  counted_files_ = std::move(counted_files);
+  last_resync_micros_ = GetCurrentTimeMicros();
+  return Status::OK();
+}
+
+SstStatsAggregator::Snapshot SstStatsAggregator::Get() const {
+  std::lock_guard lock(mutex_);
+  return Snapshot{.aggregate = aggregate_, .last_resync_micros = last_resync_micros_};
+}
+
+}  // namespace yb::docdb

--- a/src/yb/docdb/properties_collector/sst_stats_aggregator.h
+++ b/src/yb/docdb/properties_collector/sst_stats_aggregator.h
@@ -1,0 +1,159 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "yb/docdb/properties_collector/chain_tracker.h"
+
+#include "yb/rocksdb/listener.h"
+#include "yb/rocksdb/metadata.h"
+
+#include "yb/gutil/thread_annotations.h"
+
+#include "yb/util/status_fwd.h"
+
+namespace yb::docdb {
+
+// Sum of the per-file SST statistics over the live files of one tablet, with the counters that say
+// what the sum is a sum of. Vocabulary: properties_collector/README.md.
+//
+// Only the additive scalars are here. The histograms and max_row_chain / max_stretch are not: they
+// merge but do not subtract, so they cannot be maintained against a file set that shrinks, and
+// five resident 145-bucket vectors cost ~5.8 KB per tablet against ~250 bytes for the scalars. A
+// consumer that wants tablet-level distributions builds them on demand from the files.
+struct SstStatsAggregate {
+  // Sums of the SstStats fields of the same name.
+  uint64_t total_entries = 0;
+  uint64_t tombstone_entries = 0;
+  uint64_t packed_row_entries = 0;
+  uint64_t meta_entries = 0;
+  uint64_t chain_entries = 0;
+  uint64_t chain_bytes = 0;
+  uint64_t num_subdoc_keys = 0;
+  uint64_t num_rows = 0;
+  uint64_t dead_rows = 0;
+  uint64_t dead_row_entries = 0;
+  uint64_t reclaimable_entries = 0;
+  uint64_t reclaimable_bytes = 0;
+
+  // Bands add across files even though each file banded its garbage against its own build time.
+  // Band i of a file counts entries whose droppable-maker was [edge[i-1], edge[i]) old when that
+  // file was built, and a consumer sums the bands wholly older than the cutoff it applies: a
+  // conservative estimate per file, and a sum of conservative estimates is conservative, so
+  // summing adds no error. What summing does not do is get less conservative as files age --
+  // garbage that was younger than the cutoff when its file was built stays in a young band for the
+  // life of the file, and no consumer can recover it from the sum.
+  AgeBandCounts droppable_age_entries{};
+  AgeBandCounts droppable_age_bytes{};
+
+  // How much of the tablet the sums above actually measure. A ratio computed without these reads
+  // near zero on a tablet whose files predate the collector, because such a file contributes no
+  // garbage and no denominator either.
+  uint64_t covered_files = 0;
+  uint64_t covered_raw_bytes = 0;
+  // Live files carrying no statistics: written before the collector was enabled, or with
+  // properties that could not be read. Their num_entries and raw key+value bytes come from the
+  // built-in properties, which every file has, and are the missing part of any denominator
+  // (total_entries and covered_raw_bytes being the measured part).
+  uint64_t uncovered_files = 0;
+  uint64_t uncovered_entries = 0;
+  uint64_t uncovered_raw_bytes = 0;
+  // Covered files whose chain statistics came out partial (SstStats::chain_valid false, i.e. a key
+  // did not parse). Their chain and garbage counters are lower bounds and the identities below do
+  // not hold over the sum.
+  uint64_t partial_files = 0;
+  // Files dropped from the aggregate without their statistics, because the compaction event that
+  // consumed them did not carry their properties. The sums stay high by those files' contribution
+  // until the next resync clears the count.
+  uint64_t unsubtracted_files = 0;
+
+  // Identities over the chain-tracked population, valid only while partial_files is zero. See
+  // SstStats for what each measures.
+  uint64_t shadowed_entries() const { return chain_entries - num_subdoc_keys; }
+  uint64_t repackable_entries() const { return num_subdoc_keys - num_rows; }
+  uint64_t collapsible_entries() const { return chain_entries - num_rows; }
+
+  SstStatsAggregate& operator+=(const SstStatsAggregate& other);
+  // Saturating. The caller only ever subtracts a file it added, but an underflow here would turn a
+  // bookkeeping slip into a gauge reading near 2^64 and a compaction trigger that never stops.
+  SstStatsAggregate& operator-=(const SstStatsAggregate& other);
+
+  bool operator==(const SstStatsAggregate& other) const = default;
+};
+
+// What one live SST file contributes: its statistics if the properties carry them, otherwise the
+// uncovered-file counters alone. Never fails; properties that do not parse count as uncovered.
+SstStatsAggregate SstFileContribution(const rocksdb::TableProperties& properties);
+
+// Maintains SstStatsAggregate over the live files of one tablet's regular RocksDB.
+//
+// Updated from the RocksDB event listener, because the consumers need the post-event state at
+// once: a full compaction that reclaims the garbage must not leave the trigger re-firing until the
+// next resync. Resync over the whole live file set is the safety net for the file-set changes that
+// produce no listener event -- DB open, remote bootstrap, snapshot restore, files inherited by a
+// split -- and for a compaction whose event did not carry its input properties.
+//
+// Files are tracked by SST file number so that one is never counted twice and never subtracted
+// before it was counted; without that, the first compaction to consume a file the tablet inherited
+// at open subtracts statistics that were never added.
+class SstStatsAggregator {
+ public:
+  struct Snapshot {
+    SstStatsAggregate aggregate;
+    // Wall clock of the last resync. Zero means the aggregate has seen only the files the listener
+    // reported since open, so its coverage counters say nothing about the rest of the tablet and
+    // no consumer should read it.
+    int64_t last_resync_micros = 0;
+  };
+
+  void OnFlushCompleted(const rocksdb::FlushJobInfo& info);
+  void OnCompactionCompleted(const rocksdb::CompactionJobInfo& info);
+
+  // Replaces the aggregate with the sum over the whole live file set. `snapshot` fills the live
+  // file list and the properties collection keyed by base file path, as
+  // DB::GetLiveFilesMetaData / DB::GetPropertiesOfAllTables return them; it runs without the lock
+  // held because reading a properties block can hit disk.
+  //
+  // The snapshot is dropped rather than installed if a flush or compaction landed while it ran:
+  // it predates that event, so installing it would undo an update the incremental path already
+  // applied exactly. A tablet busy enough to skip every resync is one whose file set only ever
+  // changes through events the listener sees.
+  using SnapshotFn = std::function<Status(
+      std::vector<rocksdb::LiveFileMetaData>* live_files,
+      rocksdb::TablePropertiesCollection* properties)>;
+  Status Resync(const SnapshotFn& snapshot);
+
+  Snapshot Get() const EXCLUDES(mutex_);
+
+ private:
+  void AddFile(uint64_t file_number, const rocksdb::TableProperties& properties) REQUIRES(mutex_);
+  // `properties` is null when the event that removed the file did not carry them.
+  void RemoveFile(uint64_t file_number, const rocksdb::TableProperties* properties)
+      REQUIRES(mutex_);
+
+  mutable std::mutex mutex_;
+  SstStatsAggregate aggregate_ GUARDED_BY(mutex_);
+  std::unordered_set<uint64_t> counted_files_ GUARDED_BY(mutex_);
+  // Bumped by every file added or removed; lets Resync tell that its snapshot was overtaken.
+  uint64_t event_seqno_ GUARDED_BY(mutex_) = 0;
+  int64_t last_resync_micros_ GUARDED_BY(mutex_) = 0;
+};
+
+}  // namespace yb::docdb

--- a/src/yb/integration-tests/compaction-test.cc
+++ b/src/yb/integration-tests/compaction-test.cc
@@ -29,6 +29,7 @@
 #include "yb/consensus/consensus.h"
 
 #include "yb/docdb/consensus_frontier.h"
+#include "yb/docdb/properties_collector/sst_stats_aggregator.h"
 #include "yb/docdb/ql_rowwise_iterator_interface.h"
 
 #include "yb/dockv/doc_ttl_util.h"
@@ -83,6 +84,7 @@ DECLARE_bool(TEST_disable_adding_last_compaction_to_tablet_metadata);
 DECLARE_bool(TEST_disable_adding_user_frontier_to_sst);
 DECLARE_bool(TEST_disable_getting_user_frontier_from_mem_table);
 DECLARE_bool(TEST_pause_before_full_compaction);
+DECLARE_bool(docdb_enable_sst_stats_collector);
 DECLARE_bool(enable_ondisk_compression);
 DECLARE_bool(enable_load_balancing);
 DECLARE_bool(file_expiration_ignore_value_ttl);
@@ -97,6 +99,7 @@ DECLARE_double(auto_compact_percent_obsolete);
 
 DECLARE_int32(auto_compact_check_interval_sec);
 DECLARE_int32(cleanup_split_tablets_interval_sec);
+DECLARE_int32(docdb_sst_stats_resync_interval_sec);
 DECLARE_int32(full_compaction_pool_max_threads);
 DECLARE_int32(priority_thread_pool_size);
 DECLARE_int32(replication_factor);
@@ -538,6 +541,107 @@ TEST_F(CompactionTest, ManualCompactionProducesOneFilePerDb) {
   auto dbs = GetAllRocksDbs(cluster_.get(), false);
   for (auto* db : dbs) {
     ASSERT_EQ(1, db->GetCurrentVersionNumSSTFiles());
+  }
+}
+
+// The per-tablet SST statistics aggregate is fed by RocksDB flush and compaction events, so it is
+// exercised against a real tablet here rather than next to the collector's unit tests.
+class SstStatsAggregateTest : public CompactionTest {
+ public:
+  void SetUp() override {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_docdb_enable_sst_stats_collector) = CollectorEnabled();
+    // This test drives the resync itself; a background pass would race the assertions.
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_docdb_sst_stats_resync_interval_sec) = 0;
+    CompactionTest::SetUp();
+  }
+
+ protected:
+  virtual bool CollectorEnabled() { return true; }
+
+  TSTabletManager::TabletPtrs WorkloadTablets() {
+    TSTabletManager::TabletPtrs tablets;
+    for (const auto& peer :
+         cluster_->GetTabletManager(0)->GetTabletPeersWithTableId(workload_table_id_)) {
+      if (auto tablet = peer->shared_tablet_maybe_null()) {
+        tablets.push_back(std::move(tablet));
+      }
+    }
+    EXPECT_FALSE(tablets.empty());
+    return tablets;
+  }
+
+  // Asserts that what the listener accumulated matches what a read of the whole live file set
+  // computes, and returns the aggregate.
+  docdb::SstStatsAggregate CheckAgainstLiveFiles(const tablet::TabletPtr& tablet) {
+    auto* stats = tablet->sst_stats();
+    EXPECT_NE(stats, nullptr);
+    const auto from_events = stats->Get().aggregate;
+    EXPECT_OK(tablet->ResyncSstStats());
+    EXPECT_EQ(stats->Get().aggregate, from_events);
+    EXPECT_EQ(from_events.covered_files, tablet->GetCurrentVersionNumSSTFiles());
+    EXPECT_EQ(from_events.uncovered_files, 0);
+    EXPECT_EQ(from_events.unsubtracted_files, 0);
+    return from_events;
+  }
+};
+
+TEST_F(SstStatsAggregateTest, TracksFlushAndCompactionOutputs) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_rocksdb_level0_file_num_compaction_trigger) = -1;
+  SetupWorkload(IsolationLevel::NON_TRANSACTIONAL);
+  ASSERT_OK(WriteAtLeastFilesPerDb(5));
+
+  for (const auto& tablet : WorkloadTablets()) {
+    // Every live file was written by a flush the listener saw, so the incremental aggregate is
+    // already complete even though nothing has read the file set.
+    ASSERT_EQ(tablet->sst_stats()->Get().last_resync_micros, 0);
+    const auto flushed = CheckAgainstLiveFiles(tablet);
+    ASSERT_GT(flushed.total_entries, 0);
+    ASSERT_GT(flushed.num_rows, 0);
+  }
+
+  ASSERT_OK(ExecuteManualCompaction());
+
+  for (const auto& tablet : WorkloadTablets()) {
+    ASSERT_EQ(tablet->GetCurrentVersionNumSSTFiles(), 1);
+    const auto compacted = CheckAgainstLiveFiles(tablet);
+    ASSERT_GT(compacted.total_entries, 0);
+  }
+}
+
+class SstStatsCoverageTest : public SstStatsAggregateTest {
+ protected:
+  bool CollectorEnabled() override { return false; }
+};
+
+TEST_F(SstStatsCoverageTest, CountsFilesWrittenBeforeTheCollector) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_rocksdb_level0_file_num_compaction_trigger) = -1;
+  SetupWorkload(IsolationLevel::NON_TRANSACTIONAL);
+  ASSERT_OK(WriteAtLeastFilesPerDb(3));
+
+  // Enabling the collector takes effect on tablet open and cannot measure what is already on disk.
+  // Those files have to read as unmeasured; a garbage ratio that ignored them would read as clean.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_docdb_enable_sst_stats_collector) = true;
+  ASSERT_OK(cluster_->RestartSync());
+
+  for (const auto& tablet : WorkloadTablets()) {
+    auto* stats = tablet->sst_stats();
+    ASSERT_NE(stats, nullptr);
+    ASSERT_OK(tablet->ResyncSstStats());
+    const auto aggregate = stats->Get().aggregate;
+    ASSERT_EQ(aggregate.covered_files, 0);
+    ASSERT_EQ(aggregate.uncovered_files, tablet->GetCurrentVersionNumSSTFiles());
+    ASSERT_GT(aggregate.uncovered_files, 0);
+    ASSERT_GT(aggregate.uncovered_entries, 0);
+    ASSERT_EQ(aggregate.total_entries, 0);
+  }
+
+  // A compaction rewrites them through the collector, and coverage follows.
+  ASSERT_OK(ExecuteManualCompaction());
+  for (const auto& tablet : WorkloadTablets()) {
+    const auto aggregate = tablet->sst_stats()->Get().aggregate;
+    ASSERT_EQ(aggregate.covered_files, tablet->GetCurrentVersionNumSSTFiles());
+    ASSERT_EQ(aggregate.uncovered_files, 0);
+    ASSERT_GT(aggregate.total_entries, 0);
   }
 }
 

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -68,6 +68,7 @@
 #include "yb/docdb/docdb_rocksdb_util.h"
 #include "yb/docdb/docdb_statistics.h"
 #include "yb/docdb/docdb_util.h"
+#include "yb/docdb/properties_collector/sst_stats_aggregator.h"
 #include "yb/docdb/properties_collector/sst_stats_collector.h"
 #include "yb/docdb/pgsql_operation.h"
 #include "yb/docdb/ql_rocksdb_storage.h"
@@ -607,6 +608,10 @@ class Tablet::RegularRocksDbListener : public Tablet::RocksDbListener {
       : RocksDbListener(tablet, log_prefix) {}
 
   void OnCompactionCompleted(rocksdb::DB* db, const rocksdb::CompactionJobInfo& ci) override {
+    if (auto* sst_stats = tablet_.sst_stats()) {
+      sst_stats->OnCompactionCompleted(ci);
+    }
+
     auto& metadata = *CHECK_NOTNULL(tablet_.metadata());
     if (ci.is_full_compaction) {
       if (PREDICT_TRUE(!FLAGS_TEST_disable_adding_last_compaction_to_tablet_metadata)) {
@@ -631,6 +636,9 @@ class Tablet::RegularRocksDbListener : public Tablet::RocksDbListener {
 
   void OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobInfo& flush_job_info) override {
     RocksDbListener::OnFlushCompleted(db, flush_job_info);
+    if (auto* sst_stats = tablet_.sst_stats()) {
+      sst_stats->OnFlushCompleted(flush_job_info);
+    }
     auto status = tablet_.MayModifyIntentsDbFlushedOpId();
     // Best-effort; not fatal. As above, suppress ShutdownInProgress and let TryAgain warn.
     LOG_IF_WITH_PREFIX_AND_FUNC(WARNING, !status.ok() && !status.IsShutdownInProgress())
@@ -1250,6 +1258,8 @@ Status Tablet::OpenRegularDB(const rocksdb::Options& common_options) {
   if (FLAGS_docdb_enable_sst_stats_collector) {
     regular_rocksdb_options.table_properties_collector_factories.push_back(
         docdb::MakeSstStatsCollectorFactory());
+    // Before DB::Open, so that the listener installed below always sees it.
+    sst_stats_ = std::make_unique<docdb::SstStatsAggregator>();
   }
 
   // Install the history cleanup handler. Note that TabletRetentionPolicy is going to hold a raw ptr
@@ -4828,6 +4838,23 @@ uint64_t Tablet::GetCurrentVersionNumSSTFiles() const {
   return GetRegularDbStat([this] {
     return regular_db_->GetCurrentVersionNumSSTFiles();
   }, 0);
+}
+
+Status Tablet::ResyncSstStats() {
+  if (!sst_stats_) {
+    return Status::OK();
+  }
+  return sst_stats_->Resync(
+      [this](std::vector<rocksdb::LiveFileMetaData>* live_files,
+             rocksdb::TablePropertiesCollection* properties) -> Status {
+        // Reading a properties block can hit disk, so this must not hold component_lock_ or block
+        // the start of a RocksDB shutdown.
+        auto scoped_operation = CreateScopedRWOperationNotBlockingRocksDbShutdownStart();
+        RETURN_NOT_OK(scoped_operation);
+        SCHECK(regular_db_, IllegalState, "No regular DB to read SST statistics from");
+        regular_db_->GetLiveFilesMetaData(live_files);
+        return regular_db_->GetPropertiesOfAllTables(properties);
+      });
 }
 
 std::pair<int, int> Tablet::GetNumMemtables() const {

--- a/src/yb/tablet/tablet.h
+++ b/src/yb/tablet/tablet.h
@@ -745,6 +745,15 @@ class Tablet : public AbstractTablet,
   std::pair<uint64_t, uint64_t> GetCurrentVersionSstFilesAllSizes() const;
   uint64_t GetCurrentVersionNumSSTFiles() const;
 
+  // Aggregate of the regular DB's per-file SST statistics; null unless the collector that produces
+  // them is enabled (--docdb_enable_sst_stats_collector).
+  docdb::SstStatsAggregator* sst_stats() const { return sst_stats_.get(); }
+
+  // Recomputes the aggregate from the whole live file set, correcting for the file-set changes the
+  // RocksDB listener does not see. Runs on a timer from TSTabletManager; no-op when the collector
+  // is disabled.
+  Status ResyncSstStats();
+
   void ListenNumSSTFilesChanged(std::function<void()> listener);
 
   // Returns the number of memtables in intents and regular db-s.
@@ -1475,6 +1484,10 @@ class Tablet : public AbstractTablet,
   std::mutex num_sst_files_changed_listener_mutex_;
   std::function<void()> num_sst_files_changed_listener_
       GUARDED_BY(num_sst_files_changed_listener_mutex_);
+
+  // Created in OpenRegularDB when the SST statistics collector is enabled, and from then on
+  // maintained by RegularRocksDbListener. Locks internally.
+  std::unique_ptr<docdb::SstStatsAggregator> sst_stats_;
 
   AllowedHistoryCutoffProvider allowed_history_cutoff_provider_;
   std::shared_ptr<TabletRetentionPolicy> retention_policy_;

--- a/src/yb/tserver/ts_tablet_manager.cc
+++ b/src/yb/tserver/ts_tablet_manager.cc
@@ -257,6 +257,15 @@ DEFINE_NON_RUNTIME_int32(data_size_metric_updater_interval_sec, 60,
              "The interval time for the data size metric updater background task. "
              "If set to 0, it disables the background task.");
 
+DEFINE_NON_RUNTIME_int32(docdb_sst_stats_resync_interval_sec, 300,
+             "The interval at which each tablet's DocDB SST statistics aggregate is recomputed "
+             "from its whole live file set, correcting for file-set changes that produce no "
+             "RocksDB flush or compaction event (tablet open, remote bootstrap, snapshot restore, "
+             "files inherited by a split). Until the first pass, a tablet's aggregate covers only "
+             "the files written since it opened and no consumer reads it. If set to 0, it disables "
+             "the background task, which leaves the aggregate unusable. Only has an effect when "
+             "--docdb_enable_sst_stats_collector is set.");
+
 DEFINE_UNKNOWN_int32(send_wait_for_report_interval_ms, 60000,
              "The tick interval time to trigger updating all transaction coordinators with wait-for"
              " relationships.");
@@ -331,6 +340,7 @@ DEFINE_test_flag(bool, crash_before_mark_clone_attempted, false,
 DEFINE_NON_RUNTIME_uint32(vector_index_concurrent_writes, 0,
     "Number of threads used by vector index thread pool. 0 - use number of CPUs for it.");
 
+DECLARE_bool(docdb_enable_sst_stats_collector);
 DECLARE_bool(enable_wait_queues);
 DECLARE_bool(disable_deadlock_detection);
 DECLARE_bool(lazily_flush_superblock);
@@ -495,6 +505,21 @@ void TSTabletManager::VerifyTabletData() {
                        << ": " << s;
         }
       }
+    }
+  }
+}
+
+void TSTabletManager::ResyncSstStats() {
+  for (const TabletPeerPtr& peer : GetTabletPeers()) {
+    auto tablet = peer->shared_tablet_maybe_null();
+    if (!tablet) {
+      continue;
+    }
+    // Expected to fail on a tablet that starts shutting down mid-pass; the next pass covers it.
+    const auto status = tablet->ResyncSstStats();
+    if (!status.ok()) {
+      YB_LOG_EVERY_N_SECS(WARNING, 60)
+          << "Failed to resync SST statistics of " << peer->tablet_id() << ": " << status;
     }
   }
 }
@@ -926,6 +951,9 @@ Status TSTabletManager::Init() {
   data_size_metric_updater_ = std::make_unique<rpc::Poller>(
       LogPrefix(), [this]() { return ts_data_size_metrics_->Update(); });
 
+  sst_stats_resync_poller_ = std::make_unique<rpc::Poller>(
+      LogPrefix(), std::bind(&TSTabletManager::ResyncSstStats, this));
+
   metrics_emitter_ = std::make_unique<rpc::Poller>(
       LogPrefix(), std::bind(&TSTabletManager::EmitMetrics, this));
 
@@ -1014,6 +1042,9 @@ Status TSTabletManager::Start() {
   StartScheduledTask(
       data_size_metric_updater_.get(), "Data size metric updater",
       FLAGS_data_size_metric_updater_interval_sec * 1s);
+  StartScheduledTask(
+      sst_stats_resync_poller_.get(), "SST statistics resync",
+      FLAGS_docdb_enable_sst_stats_collector ? FLAGS_docdb_sst_stats_resync_interval_sec * 1s : 0s);
 
   if (waiting_txn_registry_) {
     waiting_txn_registry_poller_->Start(
@@ -2658,6 +2689,8 @@ void TSTabletManager::StartShutdown() {
   tablet_metadata_validator_->StartShutdown();
 
   data_size_metric_updater_->Shutdown();
+
+  sst_stats_resync_poller_->Shutdown();
 
   metrics_emitter_->Shutdown();
 

--- a/src/yb/tserver/ts_tablet_manager.h
+++ b/src/yb/tserver/ts_tablet_manager.h
@@ -451,6 +451,9 @@ class TSTabletManager : public tserver::TabletPeerLookupIf, public tablet::Table
   // Background task that verifies the data on each tablet for consistency.
   void VerifyTabletData();
 
+  // Background task that recomputes each tablet's DocDB SST statistics aggregate.
+  void ResyncSstStats();
+
   // Background task that emits metrics.
   void EmitMetrics();
 
@@ -861,6 +864,9 @@ class TSTabletManager : public tserver::TabletPeerLookupIf, public tablet::Table
   // on the server, accounting for hardlinks.
   std::unique_ptr<TsDataSizeMetrics> ts_data_size_metrics_;
   std::unique_ptr<rpc::Poller> data_size_metric_updater_;
+
+  // Recomputes each tablet's DocDB SST statistics aggregate from its whole live file set.
+  std::unique_ptr<rpc::Poller> sst_stats_resync_poller_;
 
   std::unique_ptr<docdb::LocalWaitingTxnRegistry> waiting_txn_registry_;
 

--- a/src/yb/tserver/tserver-path-handlers.cc
+++ b/src/yb/tserver/tserver-path-handlers.cc
@@ -50,7 +50,10 @@
 #include "yb/consensus/log_anchor_registry.h"
 #include "yb/consensus/quorum_util.h"
 
+#include "yb/docdb/properties_collector/sst_stats_aggregator.h"
+
 #include "yb/gutil/map-util.h"
+#include "yb/gutil/walltime.h"
 #include "yb/gutil/strings/human_readable.h"
 #include "yb/gutil/strings/join.h"
 #include "yb/gutil/strings/numbers.h"
@@ -80,6 +83,7 @@
 #include "yb/util/flags.h"
 #include "yb/util/html_print_helper.h"
 #include "yb/util/jsonwriter.h"
+#include "yb/util/monotime.h"
 #include "yb/util/stol_utils.h"
 #include "yb/util/url-coding.h"
 
@@ -231,6 +235,93 @@ tablet::TabletPeerPtr LoadTablet(TabletServer* tserver,
   return result;
 }
 
+string CompactDuration(int64_t micros) {
+  static constexpr std::array<std::pair<int64_t, const char*>, 4> kUnits = {{
+      {24 * 60 * 60 * MonoTime::kMicrosecondsPerSecond, "d"},
+      {60 * 60 * MonoTime::kMicrosecondsPerSecond, "h"},
+      {60 * MonoTime::kMicrosecondsPerSecond, "m"},
+      {MonoTime::kMicrosecondsPerSecond, "s"}}};
+  for (const auto& [unit_micros, suffix] : kUnits) {
+    if (micros >= unit_micros) {
+      return Format("$0$1", micros / unit_micros, suffix);
+    }
+  }
+  return Format("$0us", micros);
+}
+
+// "<5m: 3, <15m: 0, ..., >30d: 12", labelled from the band edges themselves so the page cannot
+// drift from AgeBands.
+string AgeBandsToHtml(const docdb::AgeBandCounts& counts) {
+  constexpr auto kLastBand = docdb::AgeBands::kNumBands - 1;
+  string result;
+  for (size_t i = 0; i < counts.size(); ++i) {
+    const auto label = i == kLastBand
+        ? Format("&gt;$0", CompactDuration(docdb::AgeBands::kEdgesMicros[kLastBand - 1]))
+        : Format("&lt;$0", CompactDuration(docdb::AgeBands::kEdgesMicros[i]));
+    result += Format("$0$1: $2", i == 0 ? "" : ", ", label, counts[i]);
+  }
+  return result;
+}
+
+// The per-tablet aggregate of what the SST statistics collector recorded in each file. Raw numbers
+// only: the distributions the collector also records are not in the aggregate, and rendering them
+// is tracked separately.
+void DumpSstStats(const tablet::TabletPeerPtr& peer, std::stringstream* output) {
+  *output << "<h2>SST Statistics</h2>\n";
+  auto tablet = peer->shared_tablet_maybe_null();
+  auto* sst_stats = tablet ? tablet->sst_stats() : nullptr;
+  if (sst_stats == nullptr) {
+    *output << "<p>Not collected (--docdb_enable_sst_stats_collector is not set).</p>\n";
+    return;
+  }
+
+  const auto snapshot = sst_stats->Get();
+  const auto& stats = snapshot.aggregate;
+  const auto row = [output](const string& name, const string& value) {
+    *output << Format("<tr><th>$0</th><td>$1</td></tr>\n", name, value);
+  };
+
+  *output << "<table class='table table-striped'>\n";
+  *output << "<tr><th>Statistic</th><th>Value</th></tr>\n";
+  if (snapshot.last_resync_micros == 0) {
+    // Whatever the listener has reported since this tablet opened, over an unknown share of the
+    // file set: the coverage counters below do not account for files nobody has looked at.
+    row("Last full resync", "never -- covers only files written since this tablet opened");
+  } else {
+    row("Last full resync",
+        Format("$0 ago", CompactDuration(GetCurrentTimeMicros() - snapshot.last_resync_micros)));
+  }
+  row("Files measured", Format("$0 of $1", stats.covered_files,
+                               stats.covered_files + stats.uncovered_files));
+  row("Raw bytes measured", Format("$0 of $1", stats.covered_raw_bytes,
+                                   stats.covered_raw_bytes + stats.uncovered_raw_bytes));
+  if (stats.partial_files > 0) {
+    row("Files with partial chain statistics", std::to_string(stats.partial_files));
+  }
+  if (stats.unsubtracted_files > 0) {
+    row("Compacted-away files still counted", std::to_string(stats.unsubtracted_files));
+  }
+  row("Entries", Format("$0 ($1 in unmeasured files)", stats.total_entries,
+                        stats.uncovered_entries));
+  row("Tombstone entries", std::to_string(stats.tombstone_entries));
+  row("Packed row entries", std::to_string(stats.packed_row_entries));
+  row("Meta entries", std::to_string(stats.meta_entries));
+  row("Chain-tracked entries / bytes",
+      Format("$0 / $1", stats.chain_entries, stats.chain_bytes));
+  row("Subdoc keys / rows", Format("$0 / $1", stats.num_subdoc_keys, stats.num_rows));
+  if (stats.partial_files == 0) {
+    row("Shadowed / repackable / collapsible",
+        Format("$0 / $1 / $2", stats.shadowed_entries(), stats.repackable_entries(),
+               stats.collapsible_entries()));
+  }
+  row("Dead rows / their entries", Format("$0 / $1", stats.dead_rows, stats.dead_row_entries));
+  row("Reclaimable entries / bytes",
+      Format("$0 / $1", stats.reclaimable_entries, stats.reclaimable_bytes));
+  row("Reclaimable entries by age", AgeBandsToHtml(stats.droppable_age_entries));
+  row("Reclaimable bytes by age", AgeBandsToHtml(stats.droppable_age_bytes));
+  *output << "</table>\n";
+}
+
 void HandleTabletPage(
     const std::string& tablet_id, const tablet::TabletPeerPtr& peer,
     const Webserver::WebRequest& req, Webserver::WebResponse* resp) {
@@ -243,6 +334,8 @@ void HandleTabletPage(
   *output << "<h2>Schema</h2>\n";
   const SchemaPtr schema = peer->tablet_metadata()->schema();
   server::HtmlOutputSchemaTable(*schema, output);
+
+  DumpSstStats(peer, output);
 
   *output << "<h2>Other Tablet Info Pages</h2>" << endl;
 


### PR DESCRIPTION
## Summary

Stacked on #33710 (base branch `feature-stack/sst-stats-collector/04-collector`) — review that one first; this PR's diff is the single commit on top.

The collector from #33710 stores per-file garbage statistics in each SST's properties block, but nothing aggregates them. A per-file record only answers questions about one SST; the consumers that follow — the `docdb_sst_*` Prometheus gauges and the full-compaction trigger clause — need the tablet-wide number.

`SstStatsAggregator` sums the additive scalars over one tablet's live files: entries, tombstones, chain/subdoc/row counts, dead rows, reclaimable entries and bytes, and the droppable-age bands.

It is maintained two ways, and both are needed. The tablet's `RegularRocksDbListener` adds flush and compaction outputs and subtracts compaction inputs, so a full compaction that reclaims the garbage is visible to the trigger at once rather than a resync interval later. A periodic resync from `DB::GetPropertiesOfAllTables` catches the file-set changes that arrive with no event at all: DB open, remote bootstrap, snapshot restore, split inheritance. The resync merges by hand because `TableProperties::Add` drops `user_collected_properties`, and it discards its own result if a listener event landed while it was running, so a slow resync cannot clobber newer incremental state.

The distributions are deliberately left out. Bucket-wise merging is exact, but a shrinking file set needs subtraction, and five resident 145-bucket vectors cost ~5.8 KB per tablet against ~250 bytes for the scalars. Tablet-level distributions are built on demand instead.

The aggregate also has to be honest about what it does not know, or a consumer cannot tell "no garbage" from "no data" — a ratio computed over files the collector never saw silently reads near zero. `uncovered_files` counts live files written before the collector existed (no `yb.docdb.collector_version` property), `partial_files` those with an incomplete record, and `unsubtracted_files` signals that a file left the set but its stats could not be subtracted, leaving the aggregate over-counted until the next resync.

The raw numbers are exposed on the per-tablet status page. Nothing consumes the aggregate programmatically yet; the gauges and the trigger clause follow separately.

### What to act on

- Gated on the existing `docdb_enable_sst_stats_collector`, still **default off**. With the flag off the aggregate is never constructed and the poller sits idle, so this is inert on an upgraded cluster until the flag is flipped.
- New `docdb_sst_stats_resync_interval_sec` (`NON_RUNTIME`, default 300) sets the resync cadence.

## Test plan

- [x] `sst_stats_aggregator-test` (8 cases) — aggregate arithmetic including saturating subtraction; per-file parsing of covered, uncovered and partial files; flush/compaction bookkeeping including a failed compaction and a compaction of an uncounted file; the resync-overtaken-by-flush race.
- [x] `compaction-test --gtest_filter='SstStatsAggregateTest.*:SstStatsCoverageTest.*'` (2 cases) — the incrementally maintained aggregate checked against a recount of the live files after flushes and a manual compaction; `uncovered_files` for files written before the collector was enabled, and their transition to covered after a later compaction.

Both runs are on the current `04-collector` tip. The branch was rebased onto it after it picked up review changes to `sst_stats_collector.cc` and `chain_tracker.h`; the rebase was conflict-free and both suites were re-run green on the rebased base.

