### PR TITLE
[#33897] yugabyted: Pass certs dir to yb-admin from yugabyted-ui

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -168,3 +168,4 @@ This is a list of people who have contributed code to the [YugabyteDB](https://g
 * [Rylan12](https://github.com/Rylan12)
 * [SrivastavaAnubhav](https://github.com/SrivastavaAnubhav)
 * [neera-mital](https://github.com/neera-mital)
+* [ajotaops](https://github.com/ajotaops)

--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -4069,7 +4069,9 @@ class ControlScript(object):
                                 "-ysql_password={}".format(
                                 self.configs.saved_data.get("database_password")),
                                 "-ycql_password={}".format(
-                                self.configs.saved_data.get("database_password"))])
+                                self.configs.saved_data.get("database_password")),
+                                "-certs_dir_name={}".format(
+                                self.configs.saved_data.get("certs_dir"))])
 
                         if self.configs.saved_data.get("ysql_port"):
                             yugabyted_ui_cmd.append("-ysql_port={}".format(

--- a/yugabyted-ui/apiserver/cmd/server/helpers/parse_command_line_flags.go
+++ b/yugabyted-ui/apiserver/cmd/server/helpers/parse_command_line_flags.go
@@ -19,6 +19,7 @@ var (
     DbYcqlPassword string
     SslMode        string
     SslRootCert    string
+    CertsDir       string
     MasterUIPort   string
     TserverUIPort  string
     Warnings       string
@@ -52,6 +53,9 @@ func init() {
         "ssl mode for connecting to the database.")
     flag.StringVar(&SslRootCert, "ssl_root certificate", "",
         "root certificate for connecting to the database.")
+    flag.StringVar(&CertsDir, "certs_dir_name", "",
+        "directory containing the certificates yb-admin needs to reach a cluster "+
+            "with node-to-node encryption enabled.")
     flag.StringVar(&MasterUIPort, "master_ui_port", "7000",
         "Master UI port.")
     flag.StringVar(&TserverUIPort, "tserver_ui_port", "9000",

--- a/yugabyted-ui/apiserver/cmd/server/helpers/yb_admin.go
+++ b/yugabyted-ui/apiserver/cmd/server/helpers/yb_admin.go
@@ -2,8 +2,14 @@ package helpers
 
 import (
     "bytes"
+    "context"
     "os/exec"
+    "time"
 )
+
+// yb-admin blocks indefinitely when it cannot reach the masters, so bound every
+// invocation. On a TLS cluster reached without certificates it never returns.
+const ybAdminTimeout = 30 * time.Second
 
 type YBAdminFuture struct {
     Result string
@@ -29,8 +35,15 @@ func (h *HelperContainer) RunYBAdminFuture(params []string, future chan YBAdminF
         future <- ybAdminFuture
         return
     }
+    // A cluster with node-to-node encryption rejects the connection unless
+    // yb-admin is given the certificate directory.
+    if CertsDir != "" {
+        params = append([]string{"-certs_dir_name", CertsDir}, params...)
+    }
     h.logger.Infof("Executing yb-admin with params: %v", params)
-    cmd := exec.Command(path, params...)
+    ctx, cancel := context.WithTimeout(context.Background(), ybAdminTimeout)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, path, params...)
     var out bytes.Buffer
     var stderr bytes.Buffer
     cmd.Stdout = &out


### PR DESCRIPTION
## Summary

`yugabyted-ui` shells out to `yb-admin list_snapshot_schedules` to build the PITR
configuration, but never passed `-certs_dir_name`. On a cluster started with
`--use_node_to_node_encryption=true` and `--allow_insecure_connections=false`,
yb-admin cannot complete the handshake and blocks indefinitely, so `/api/pitr`
never returns and the UI's Backups tab stays empty. The feature only works on
clusters without TLS.

The call was also unbounded (`cmd.Run()` with no context), so any unreachable
master hangs the handler rather than surfacing an error.

- Add a `certs_dir_name` flag to yugabyted-ui and prepend it to the yb-admin
  argument list when set. Empty by default, so behavior on clusters without TLS
  is unchanged.
- `yugabyted` passes its configured `certs_dir` when started with `--secure`.
- Bound the yb-admin invocation with a 30s timeout via `exec.CommandContext`.

Deployments that run yugabyted-ui directly rather than through `yugabyted`
(for example the Helm chart, which starts the container itself) need to pass
`-certs_dir_name` to get the fix.

## Test plan

Reproduced and verified against a local RF=1 cluster with
`--use_node_to_node_encryption=true` and `--allow_insecure_connections=false`,
using a snapshot schedule created with `yb-admin create_snapshot_schedule`.

- [x] Before the change: `/api/pitr` never returns; the log shows
      `Executing yb-admin with params: [-master_addresses ... list_snapshot_schedules]`
      with no certs argument.
- [x] After the change, with `-certs_dir_name` set: `/api/pitr` returns HTTP 200
      with the schedule in 0.07s.
- [x] After the change, without `-certs_dir_name`: returns HTTP 500 instead of
      hanging. Log confirms two yb-admin attempts 30s apart (the handler retries
      once), each killed by the timeout.
- [x] `go vet ./cmd/server/helpers/` clean; `build-support/lint.sh` reports 0 errors.
