### PR TITLE
[BACKPORT 2025.2][#32529] DocDB: test knob to widen the external regular-write to intents-write window

### DIFF
--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -120,6 +120,7 @@
 #include "yb/util/mem_tracker.h"
 #include "yb/util/metrics.h"
 #include "yb/util/net/net_util.h"
+#include "yb/util/random_util.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/status_format.h"
 #include "yb/util/status_log.h"
@@ -323,6 +324,18 @@ DEFINE_test_flag(uint64, inject_sleep_before_applying_write_batch_ms, 0,
 
 DEFINE_test_flag(uint64, inject_sleep_before_applying_intents_ms, 0,
     "Sleep before applying intents to docdb after transaction commit");
+
+DEFINE_test_flag(double, inject_delay_before_external_intents_write_probability, 0.0,
+    "Probability of injecting a random delay between an external write batch's regular db "
+    "write and its intents db write in ApplyKeyValueRowOperations. Each firing sleeps for a "
+    "duration drawn uniformly from [0, TEST_inject_delay_before_external_intents_write_max_ms]. "
+    "Widens the otherwise sub-millisecond window in which a regular db flush can force-advance "
+    "the intents db flushed frontier past not-yet-written external intents (see "
+    "advance_intents_flushed_op_id_to_match_regular).");
+
+DEFINE_test_flag(uint64, inject_delay_before_external_intents_write_max_ms, 100,
+    "Upper bound in milliseconds of the random delay injected when "
+    "TEST_inject_delay_before_external_intents_write_probability fires.");
 
 DEFINE_test_flag(bool, skip_remove_intent, false,
     "If true, remove intent will be skipped");
@@ -2054,6 +2067,15 @@ Status Tablet::ApplyKeyValueRowOperations(
     WriteToRocksDB(frontiers, &regular_write_batch, StorageDbType::kRegular);
 
     if (intents_write_batch.Count() != 0) {
+      TEST_SYNC_POINT("Tablet::ApplyKeyValueRowOperations:BeforeIntentsWrite");
+      if (PREDICT_FALSE(RandomActWithProbability(
+              FLAGS_TEST_inject_delay_before_external_intents_write_probability))) {
+        const auto delay_ms = RandomUniformInt<uint64>(
+            0, FLAGS_TEST_inject_delay_before_external_intents_write_max_ms);
+        LOG_WITH_PREFIX(INFO) << "TEST: injecting " << delay_ms
+                              << " ms delay before external intents write";
+        SleepFor(MonoDelta::FromMilliseconds(delay_ms));
+      }
       if (!metadata_->IsUnderXClusterReplication()) {
         RETURN_NOT_OK(metadata_->SetIsUnderXClusterReplicationAndFlush(true));
       }


### PR DESCRIPTION
Summary:
On an xCluster target, an external write carrying replicated intents from a distributed
source transaction is applied as one Raft op written to two RocksDBs in sequence: the
regular DB first, then the intents DB (Tablet::ApplyKeyValueRowOperations). The gap
between the two writes is normally sub-millisecond, which makes timing bugs at this seam
(most recently GH #32694, the intents-flushed-frontier force-advance TOCTOU) essentially
impossible to hit in an end-to-end stress test: E2E reproduction attempts for #32694
could not land a regular-DB flush inside the window, while the deterministic unit-level
repro (D55769) has to force it with a sync point.

Following the GH #32529 design principles (test fault injection that is randomized by
construction), add both flavors of test control at this seam:

- TEST_inject_delay_before_external_intents_write_probability (double, default 0.0) and
  TEST_inject_delay_before_external_intents_write_max_ms (uint64, default 100): when the
  probability fires for an external write that has a pending intents-DB write, sleep
  between the two RocksDB writes for a duration drawn uniformly from [0, max_ms]. A
  probabilistic, randomized delay (never a fixed sleep) lets a stress test widen the
  window on a small fraction of ops without collapsing replication throughput, and
  sweeps the window boundaries across firings instead of sampling one fixed point. Each
  firing logs the drawn duration so a stress failure can be correlated with an injected
  window.

- TEST_SYNC_POINT("Tablet::ApplyKeyValueRowOperations:BeforeIntentsWrite"): a dormant
  sync point at the same seam for pinning mechanisms deterministically in unit tests;
  the #32694 repro (D55769) rendezvouses on exactly this point, so it rebases onto this
  change as a pure test addition.

No production behavior change: with the probability at its default 0.0 the injection
reduces to one double load per external-intent write, and the sync point is a no-op
unless a test enables sync-point processing.

Authored and uploaded by Claude Code (Fable 5).

Original commit: 71d88ab21f90b3bed24fe50cb97260956e24e728 / D55823

Test Plan:
- Compiles clean on fastdebug (clang21); build-support/lint.sh clean.
- No default-behavior change: the probability flag defaults to 0.0 and the sync point is
  inert without a test-side callback.
- Local verification runs (fastdebug, results to follow as a comment):
  - existing XClusterExternalApplyBootstrapTest.ExternalApplyReplayedAfterRestartShadowsPackedRow
    with default flags: the fused external apply leaves the intents write batch empty, so
    the knob must not fire and the test must pass unchanged;
  - the D55769 unfused external-intent tests with
    --TEST_inject_delay_before_external_intents_write_probability=1.0
    --TEST_inject_delay_before_external_intents_write_max_ms=300
    to observe the injected-delay log line firing on the external-intent path with the
    flag-off control test still green.
- Jenkins full CI.

Reviewers: schandra

Reviewed By: schandra

Subscribers: ybase

Differential Revision: https://phorge.dev.yugabyte.com/D55823
