### PR TITLE
[#33916] DocDB: Collect thin client stack traces through libunwind

### DIFF
--- a/src/yb/thin_client/yb_thin_client-itest.cc
+++ b/src/yb/thin_client/yb_thin_client-itest.cc
@@ -51,6 +51,7 @@
 #include "yb/yql/pgwrapper/pg_wrapper_test_base.h"
 
 DECLARE_bool(TEST_asyncrpc_finished_set_timedout);
+DECLARE_bool(use_libunwind_for_stack_trace_collection);
 DECLARE_bool(use_node_to_node_encryption);
 DECLARE_bool(use_client_to_server_encryption);
 DECLARE_bool(allow_insecure_connections);
@@ -1281,6 +1282,35 @@ TEST_F(PgThinClientTest, AlreadyReplicatedWriteReportsSuccess) {
 
   ybthin_columns_free(info.columns, info.n_columns);
   ybthin_table_close(table);
+  ybthin_client_destroy(client);
+}
+
+// ybthin_client_create must switch stack trace collection to libunwind.
+//
+// The default is glibc backtrace(), which unwinds through the host process's libgcc. This .so
+// registers ~1.3 MB of .eh_frame with that libgcc, and libgcc sorts a registered object's FDEs
+// lazily inside a malloc made while holding its object_mutex -- so a host whose allocator unwinds
+// from inside malloc (jemalloc heap profiling, a leak checker) deadlocks against itself and
+// ybthin_client_create never returns (#33916). libunwind keeps its own FDE cache and never takes
+// that lock.
+//
+// The deadlock itself needs such a host to reproduce, so this asserts the condition that prevents
+// it rather than the absence of the hang.
+TEST_F(PgThinClientTest, ClientCreateSelectsLibunwindForStackTraces) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_use_libunwind_for_stack_trace_collection) = false;
+
+  const auto addr = TServerAddr();
+  const char* addrs[] = {addr.c_str()};
+  ybthin_client* client = nullptr;
+  auto st = ybthin_client_create(
+      addrs, 1, /* tls= */ nullptr, /* pool= */ nullptr, /* rpc_timeout_ms= */ 60000,
+      /* num_reactors= */ 0, &client);
+  ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+
+  ASSERT_TRUE(FLAGS_use_libunwind_for_stack_trace_collection)
+      << "ybthin_client_create must force libunwind before any thread is created; leaving glibc "
+      << "backtrace() in place deadlocks a host that unwinds from inside malloc (#33916)";
+
   ybthin_client_destroy(client);
 }
 

--- a/src/yb/thin_client/yb_thin_client.cc
+++ b/src/yb/thin_client/yb_thin_client.cc
@@ -79,6 +79,22 @@
 #include "yb/util/status.h"
 #include "yb/util/status_format.h"
 
+// Collect stack traces through (llvm-)libunwind rather than glibc backtrace().
+//
+// The default is false outside TSAN builds (see use_libunwind_for_stack_trace_collection in
+// util/stack_trace.cc), which routes collection through the system libgcc unwinder. That is not
+// safe for a shared library embedded in a foreign process: our ~1.3 MB .eh_frame is registered
+// with the HOST's libgcc via __register_frame_info, and libgcc sorts a registered object's FDEs
+// lazily on first lookup -- a ~260 KiB malloc made while holding its object_mutex. If the host's
+// allocator unwinds from inside malloc (jemalloc with heap profiling, a leak checker), that
+// nested unwind re-enters _Unwind_Find_FDE and blocks on the mutex the same thread already holds.
+// The thread deadlocks and ybthin_client_create never returns (#33916).
+//
+// libunwind keeps its own FDE cache and never takes libgcc's lock, and it is statically linked
+// into this .so. The BOLT concern that motivates the false default applies to YB's release
+// binaries, not to this client library.
+DECLARE_bool(use_libunwind_for_stack_trace_collection);
+
 using yb::DataType;
 using yb::faststring;
 using yb::HostPort;
@@ -753,6 +769,13 @@ ybthin_status ybthin_client_create(
     const char* const* tserver_addrs, size_t n_addrs, const ybthin_tls_opts* tls,
     const ybthin_pool_opts* pool, uint32_t rpc_timeout_ms, uint32_t num_reactors,
     ybthin_client** out) {
+  // Must happen before anything creates a thread: Thread::Create warms up the stack trace library
+  // on first use, and that warm-up is what trips the libgcc deadlock described above.
+  static std::once_flag unwinder_once;
+  std::call_once(unwinder_once, [] {
+    FLAGS_use_libunwind_for_stack_trace_collection = true;
+  });
+
   if (!tserver_addrs || n_addrs == 0 || !out) {
     return MakeStatus(YBTHIN_INVALID, "tserver_addrs and out are required");
   }


### PR DESCRIPTION
## Summary

Fixes #33916. `ybthin_client_create` switches stack trace collection to libunwind before anything in
the client creates a thread. Sanitizer builds keep their default.

With the default glibc `backtrace()`, `ybthin_client_create` can deadlock and never return on a host
whose allocator unwinds from inside `malloc` — jemalloc with heap profiling, a leak checker —
reported at roughly 1 in 8 process starts. `Thread::Create` warms up the stack trace library on
first use; that warm-up unwinds through the host's libgcc, which sorts this `.so`'s registered
`.eh_frame` lazily inside a `malloc` held under `object_mutex`. A host allocator that unwinds from
inside that `malloc` re-enters `_Unwind_Find_FDE` and blocks on the mutex its own thread holds.

libunwind keeps its own FDE cache and is already statically linked into the `.so` — verified against
the shipped 2026.1.2.0 tarball: no `unw_*` undefined symbols, no `libunwind.so` dependency. No new
dependency, no packaging change.

Skipping the warm-up instead would not fix it; that defers the same FDE sort to the first real
`StackTrace::Collect`.

## Trade-off

libunwind can SIGSEGV collecting a trace in a BOLT-ed binary, which is why the non-sanitizer
default is `false`. This gives up BOLT for this `.so`.
`src/yb/thin_client/yb_release` does not pass `--bolt`, so nothing regresses today.

## Test Plan

`yb_thin_client-itest`.

`ClientCreateSelectsLibunwindForStackTraces` creates a client twice in one process and asserts the
flag after each, so a once-per-process write cannot pass. Reproducing the deadlock needs a
jemalloc-profiling host, so the test asserts the condition that prevents it rather than the absence
of the hang.

## Follow-ups

Backport to 2026.1.2 is on `yb_thin_client_2026.1.2`; the thin client tarballs already on
`s3://downloads.yugabyte.com/yb_thin_client/` predate this fix.

## Upgrade/Rollback safety

No wire, storage, or catalog change.
